### PR TITLE
MNT: turn everything into strings before pyolog

### DIFF
--- a/bluesky/standard_config.py
+++ b/bluesky/standard_config.py
@@ -97,6 +97,7 @@ def olog_wrapper(logbook, logbooks, prop):
     """
     def _logbook_log(msg, d):
         msg = msg.format(**d)
+        d = {k: repr(v) for k, v in d.items()}
         logbook.log(msg,
                     properties={prop: d},
                     ensure=True,


### PR DESCRIPTION
So we don't try to json-ify Ophyd objects
