### PR TITLE
ENH/TST: Support RE(plain_list_of_messages) w/o breaking .send().

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1,6 +1,7 @@
 import os
 import asyncio
 import itertools
+import types
 import time as ttime
 import sys
 from itertools import count
@@ -441,6 +442,9 @@ class RunEngine:
 
         self.state = 'running'
         self._gen = iter(plan)  # no-op on generators; needed for classes
+        if not isinstance(self._gen, types.GeneratorType):
+            # If plan does not support .send, we must wrap it in a generator.
+            self._gen = (msg for msg in self._gen)
         with SignalHandler(signal.SIGINT) as self._sigint_handler:  # ^C
             self._task = loop.create_task(self._run(self._gen))
             loop.run_forever()

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -245,3 +245,8 @@ def test_simple_fly():
 
     mm = MockFlyer(det, motor)
     RE(fly_gen(mm, -1, 1, 15))
+
+
+def test_list_of_msgs():
+    # smoke tests checking that RunEngine accepts a plain list of Messages
+    RE([Msg('open_run'), Msg('set', motor, 5), Msg('close_run')])


### PR DESCRIPTION
See included test. Note:

```
In [10]: isinstance(Ascan([det], motor, [1]), types.GeneratorType)
Out[10]: False

In [11]: isinstance(iter(Ascan([det], motor, [1])), types.GeneratorType)
Out[11]: True
```
