### PR TITLE
Rewind seq_num after resuming.

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -568,7 +568,7 @@ class RunEngine:
                     else:
                         raise
                 if (self._msg_cache is not None and
-                        msg.command is not in self.UNCACHEABLE_COMMANDS):
+                        msg.command not in self._UNCACHEABLE_COMMANDS):
                     # We have a checkpoint.
                     self._msg_cache.append(msg)
 

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -367,11 +367,7 @@ def test_seqnum_nonrepeated():
         yield Msg('set', motor, 2)
         yield Msg('read', motor)
         yield Msg('save')
-        if first_pass:
-            first_pass = False
-            yield Msg('pause')
-        else:
-            print('not pausing this time')
+        yield Msg('pause')
         yield Msg('create')
         yield Msg('set', motor, 3)
         yield Msg('read', motor)


### PR DESCRIPTION
See test. If we take a data point twice, reuse the sequence number so it is easy to identify what the repeats were. There are probably some cases where users do not want this. We can make it configurable later.
