### PR TITLE
ENH: RunEngine as a service

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -2995,3 +2995,31 @@ class RelativeSpiralFermatScan(Plan):
                                       self.y_motor, self.x_range, self.y_range,
                                       self.dr, self.factor, tilt=self.tilt,
                                       md=self.md)
+
+
+def jsonify(plan):
+    """
+    Convert a plan's messages to JSON for use with server/client.
+
+    See bluesky.service_server and bluesky.service_client.
+
+    Parameters
+    ----------
+    plan : iterable or iterator
+        a generator, list, or similar containing `Msg` objects
+
+    Yields
+    ------
+    msg : dict
+        {'msg': input_msg_as_dict}
+    """
+    def convert(msg):
+        "Msg(...) -> {'msg': Msg_as_dict}"
+        d = dict(msg._asdict())  # _asdict() returns OrderedDict
+        obj = d['obj']
+        if not (obj is None or isinstance(obj, str)):
+            # heuristic:
+            # convert any Device/Signal objects to their string names
+            d['obj'] = obj.name
+        return {'msg': d}
+    yield from msg_mutator(plan, convert)

--- a/bluesky/service_client.py
+++ b/bluesky/service_client.py
@@ -1,0 +1,22 @@
+import json
+import zmq
+
+
+def execute_on_remote(plan, host='localhost', port=5554):
+
+    ctx = zmq.Context()
+    sock = ctx.socket(zmq.PAIR)
+    sock.connect("tcp://{host}:{port}".format(host=host, port=port))
+
+    try:
+        for msg in plan:
+            response = sock.recv()
+            print('RECEIVED:', response.decode())
+            json_msg = json.dumps(msg)
+            print('SENDING:', json_msg)
+            sock.send_string(json_msg)
+    except:
+        pass
+    finally:
+        sock.close()
+        ctx.term()

--- a/bluesky/service_server.py
+++ b/bluesky/service_server.py
@@ -1,0 +1,65 @@
+import json
+import zmq
+from multiprocessing import Process, Queue
+
+
+def start_run_engine(RE, host='127.0.0.1', port=5554):
+    msg_queue = Queue()
+    response_queue = Queue()
+    server_process = Process(target=start_server,
+                             args=(msg_queue, response_queue, host, port))
+    server_process.start()
+    exception = None
+
+    def plan():
+        while True:
+            raw_msg = msg_queue.get()
+            msg = raw_msg['msg']
+            response = yield msg
+            response_queue.put({'response': repr(response)})
+
+    while True:
+        if RE.state == 'idle':
+            response = {'state': RE.state}
+            if exception is not None:
+                response['exception'] = repr(exception)
+                exception = None
+            response_queue.put(json.dumps(response))
+            try:
+                RE(plan())
+            except Exception as exc:
+                print('EXCEPTION RAISED:', exc)
+                print('The RunEngine will be re-started....')
+                exception = exc
+                continue
+        # The RunEngine is paused or idle.
+        response_queue.put(json.dumps({'state': RE.state}))
+        raw_msg = msg_queue.get()
+        if 'change_state' in raw_msg:
+            getattr(RE, raw_msg['change_state'])()
+        
+    server_process.join()
+
+
+def start_server(msg_queue, response_queue, host='127.0.0.1', port=5554):
+
+    ctx = zmq.Context()
+    sock = ctx.socket(zmq.PAIR)
+    sock.bind("tcp://{host}:{port}".format(host=host, port=port))
+
+    try:
+        print('Server is ready to receive messages.')
+        while True:
+            response = response_queue.get()
+            print('SENDING:', response)
+            sock.send_string(json.dumps(response))
+
+            payload = sock.recv()  # bytes
+            msg = json.loads(payload.decode())
+            print('RECEIVED:', msg)
+            msg_queue.put(msg)
+    except:
+        pass
+    finally:
+        sock.close()
+        ctx.term()

--- a/examples/client.py
+++ b/examples/client.py
@@ -1,0 +1,31 @@
+from bluesky.service_client import execute_on_remote
+
+plan = [{'msg': {'command': 'null', 'obj': None, 'args': [], 'kwargs': {}}},
+
+        # a pause message pauses the RunEngine
+        {'msg': {'command': 'pause', 'obj': None, 'args': [], 'kwargs': {}}},
+        # and it can be resumed
+        {'change_state': 'resume'},
+
+        # objects like motor are mapped with string idenfiers
+        {'msg': {'command': 'set', 'obj': 'motor', 'args': [5], 'kwargs': {}}},
+
+        # pause again, and this time abort
+        {'msg': {'command': 'pause', 'obj': None, 'args': [], 'kwargs': {}}},
+        {'change_state': 'abort'},
+        # the RunEngine is idle, but the server is ready to send it new
+        # messages and put it back into a running state
+        {'msg': {'command': 'null', 'obj': None, 'args': [], 'kwargs': {}}},
+
+        # this raises a TypeError, but the server recovers
+        {'msg': {'command': 'set', 'obj': 'motor', 'args': [], 'kwargs': {}}},
+        # ... and this is processed
+        {'msg': {'command': 'null', 'obj': None, 'args': [], 'kwargs': {}}}]
+
+
+def main():
+    execute_on_remote(plan)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/client2.py
+++ b/examples/client2.py
@@ -1,0 +1,12 @@
+from bluesky.service_client import execute_on_remote
+from bluesky.plans import jsonify
+from bluesky.plans import scan
+from bluesky.examples import motor
+
+def main():
+    plan = scan([], motor, 1, 3, 3)
+    execute_on_remote(jsonify(plan))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/server.py
+++ b/examples/server.py
@@ -1,0 +1,13 @@
+from bluesky.run_engine import RunEngineNamedLookup
+from bluesky.examples import motor
+from bluesky.service_server import start_run_engine
+
+
+def main():
+    RE = RunEngineNamedLookup({'motor': motor})
+    RE.msg_hook = print
+    start_run_engine(RE)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
If anyone thinks that "bluesky as a service" will solve a problem that they currently have, here is a workable approach.

This is alpha code, developed in three hours on a whim. I'm putting this out there as is, merely to demonstrate that the bluesky model is amenable to server/client interaction. Use at your own risk.
## Model
1. The server runs a only-slightly-customized RunEngine, configured with a dictionary that maps JSON-friendly tokens like `'motor'` to Python Device objects like `motor`.
2. The client sends "messages" as JSON objects.
3. The server decodes these "messages" into actual `Msg`'s and sends them to the RunEngine. It sends the RunEngine's response back to the client (as JSON).

The server/client communication is implemented using the zmq PAIR model: a server in two-way communication with exactly one client.
## Capabilities

This server implementation already supports:
- adaptive plans
- pause/resume/abort
- reporting and automatically recovering from arbitrary exceptions in the RunEngine

It does not yet support:
- pausing from a suspended state
- probably other stuff I haven't thought of

This client is just a quick sketch. Any tcp client that can send JSON is workable.
## Demo

The plan (from bluesky/examples/client.py)

``` python
plan = [
        # start simple :- )
        {'msg': {'command': 'null', 'obj': None, 'args': [], 'kwargs': {}}},

        # a pause message pauses the RunEngine
        {'msg': {'command': 'pause', 'obj': None, 'args': [], 'kwargs': {}}},
        # and it can be resumed
        {'change_state': 'resume'},

        # objects like motor are mapped with string idenfiers
        {'msg': {'command': 'set', 'obj': 'motor', 'args': [5], 'kwargs': {}}},

        # pause again, and this time abort
        {'msg': {'command': 'pause', 'obj': None, 'args': [], 'kwargs': {}}},
        {'change_state': 'abort'},
        # the RunEngine is idle, but the server is ready to send it new
        # messages and put it back into a running state
        {'msg': {'command': 'null', 'obj': None, 'args': [], 'kwargs': {}}},

        # this raises a TypeError, but the server recovers...
        {'msg': {'command': 'set', 'obj': 'motor', 'args': [], 'kwargs': {}}},
        # ... and this is processed
        {'msg': {'command': 'null', 'obj': None, 'args': [], 'kwargs': {}}}]
```

This is the stdout from the server. The lines beginning with all-caps are from the server itself; the rest is from a RunEngine.msg_hook.

```
$ python bluesky/examples/server.py
Server is ready to receive messages.
SENDING: {"state": "idle"}
RECEIVED: {'msg': {'obj': None, 'kwargs': {}, 'args': [], 'command': 'null'}}
null: (None), (), {}
SENDING: {'response': 'None'}
RECEIVED: {'msg': {'obj': None, 'kwargs': {}, 'args': [], 'command': 'pause'}}
pause: (None), (), {}
Pausing...
SENDING: {"state": "paused"}
RECEIVED: {'change_state': 'resume'}
null: (None), (), {}
SENDING: {'response': 'None'}
RECEIVED: {'msg': {'obj': 'motor', 'kwargs': {}, 'args': [5], 'command': 'set'}}
set: (mover: motor), (5,), {}
SENDING: {'response': 'mover: motor'}
RECEIVED: {'msg': {'obj': None, 'kwargs': {}, 'args': [], 'command': 'pause'}}
pause: (None), (), {}
Pausing...
SENDING: {"state": "paused"}
RECEIVED: {'change_state': 'abort'}
Aborting....
SENDING: {"state": "idle"}
RECEIVED: {'msg': {'obj': None, 'kwargs': {}, 'args': [], 'command': 'null'}}
null: (None), (), {}
SENDING: {'response': 'None'}
RECEIVED: {'msg': {'obj': 'motor', 'kwargs': {}, 'args': [], 'command': 'set'}}
set: (mover: motor), (), {}
EXCEPTION RAISED: set() missing 1 required positional argument: 'val'
The RunEngine will be re-started....
SENDING: {"exception": "TypeError(\"set() missing 1 required positional argument: 'val'\",)", "state": "idle"}
RECEIVED: {'msg': {'obj': None, 'kwargs': {}, 'args': [], 'command': 'null'}}
null: (None), (), {}
SENDING: {'response': 'None'}
```

This is the stdout from the client:

```
$ python bluesky/examples/client.py
RECEIVED: "{\"state\": \"idle\"}"
SENDING: {"msg": {"args": [], "command": "null", "kwargs": {}, "obj": null}}
RECEIVED: {"response": "None"}
SENDING: {"msg": {"args": [], "command": "pause", "kwargs": {}, "obj": null}}
RECEIVED: "{\"state\": \"paused\"}"
SENDING: {"change_state": "resume"}
RECEIVED: {"response": "None"}
SENDING: {"msg": {"args": [5], "command": "set", "kwargs": {}, "obj": "motor"}}
RECEIVED: {"response": "mover: motor"}
SENDING: {"msg": {"args": [], "command": "pause", "kwargs": {}, "obj": null}}
RECEIVED: "{\"state\": \"paused\"}"
SENDING: {"change_state": "abort"}
RECEIVED: "{\"state\": \"idle\"}"
SENDING: {"msg": {"args": [], "command": "null", "kwargs": {}, "obj": null}}
RECEIVED: {"response": "None"}
SENDING: {"msg": {"args": [], "command": "set", "kwargs": {}, "obj": "motor"}}
RECEIVED: "{\"exception\": \"TypeError(\\\"set() missing 1 required positional argument: 'val'\\\",)\", \"state\": \"idle\"}"
SENDING: {"msg": {"args": [], "command": "null", "kwargs": {}, "obj": null}}
```
