### PR TITLE
ENH: first draft at qt plan builder

### DIFF
--- a/bluesky/plan_tools.py
+++ b/bluesky/plan_tools.py
@@ -62,3 +62,22 @@ def plot_raster_path(plan, x_motor, y_motor, ax=None, probe_size=None, lw=2):
          "bluesky.simulators instead.")
     return _bs.plot_raster_path(plan, x_motor, y_motor, ax=ax,
                                 probe_size=probe_size, lw=lw)
+
+
+def to_nested(plan):
+    ret = []
+    container_stack = [ret]
+
+    for msg in plan:
+        if msg.command in {'open_run', 'create'}:
+            new_ret = []
+            container_stack[-1].append({msg.command: new_ret})
+
+            container_stack.append(new_ret)
+            container_stack[-1].append(msg)
+        elif msg.command in {'close_run', 'save'}:
+            container_stack.pop()
+        else:
+            container_stack[-1].append(msg)
+
+    return ret

--- a/bluesky/qt_tools.py
+++ b/bluesky/qt_tools.py
@@ -1,0 +1,80 @@
+from PyQt5.QtWidgets import QTreeWidgetItem, QMainWindow, QTreeWidget
+from PyQt5 import QtWidgets
+from bluesky import Msg
+import pprint
+from bluesky.plan_tools import to_nested
+
+
+def make_row(msg):
+    kwarg_str = '{!r}'.format(msg.kwargs)
+    if len(kwarg_str) > 50:
+        kwarg_str = '{...}'
+    child = QTreeWidgetItem([msg.command,
+                             msg.obj.name if msg.obj is not None else '',
+                             '{}'.format(msg.args),
+                             kwarg_str])
+    child.setToolTip(3, pprint.pformat(msg.kwargs))
+    return child
+
+
+def fill_item(item, value):
+    item.setExpanded(True)
+    if isinstance(value, dict):
+        for key, val in sorted(value.items()):
+            child = make_row(val[0])
+            item.addChild(child)
+            fill_item(child, val[1:])
+    elif isinstance(value, list):
+        for val in value:
+            fill_item(item, val)
+    else:
+        child = make_row(value)
+
+        item.addChild(child)
+
+
+def fill_widget(widget, value):
+    widget.clear()
+    fill_item(widget.invisibleRootItem(), value)
+
+
+def plan_writer():
+    window = QMainWindow()
+    mw = QtWidgets.QWidget()
+    ed_pannel = QtWidgets.QWidget()
+    ed_layout = QtWidgets.QVBoxLayout()
+    ed_pannel.setLayout(ed_layout)
+
+    w = QTreeWidget()
+    w.setColumnCount(4)
+    w.setHeaderLabels(Msg._fields)
+    w.setAlternatingRowColors(True)
+
+    ed = QtWidgets.QPlainTextEdit()
+    ed_layout.addWidget(ed)
+    # go_button = QtWidgets.QPushButton('display `target`')
+    # ed_layout.addWidget(go_button)
+
+    layout = QtWidgets.QHBoxLayout()
+    layout.addWidget(w)
+    layout.addWidget(ed_pannel)
+    mw.setLayout(layout)
+
+    window.setCentralWidget(mw)
+
+    def update_tree():
+        lcls = {}
+        try:
+            exec(ed.toPlainText(), globals(), lcls)
+            ret = to_nested(lcls['target'])
+        except Exception as e:
+            pass
+        else:
+            fill_widget(w, ret)
+            w.resizeColumnToContents(0)
+            w.resizeColumnToContents(1)
+
+    ed.textChanged.connect(update_tree)
+    # go_button.pressed.connect(update_tree)
+    window.show()
+    return window

--- a/bluesky/qt_tools.py
+++ b/bluesky/qt_tools.py
@@ -1,5 +1,5 @@
-from PyQt5.QtWidgets import QTreeWidgetItem, QMainWindow, QTreeWidget
-from PyQt5 import QtWidgets
+from matplotlib.backends.qt_compat import QtWidgets
+from matplotlib.backends.qt_compat.QtWidgets import QTreeWidgetItem, QMainWindow, QTreeWidget
 from bluesky import Msg
 import pprint
 from bluesky.plan_tools import to_nested

--- a/bluesky/qt_tools.py
+++ b/bluesky/qt_tools.py
@@ -1,5 +1,5 @@
 from matplotlib.backends.qt_compat import QtWidgets
-from matplotlib.backends.qt_compat.QtWidgets import QTreeWidgetItem, QMainWindow, QTreeWidget
+
 from bluesky import Msg
 import pprint
 from bluesky.plan_tools import to_nested
@@ -9,10 +9,10 @@ def make_row(msg):
     kwarg_str = '{!r}'.format(msg.kwargs)
     if len(kwarg_str) > 50:
         kwarg_str = '{...}'
-    child = QTreeWidgetItem([msg.command,
-                             msg.obj.name if msg.obj is not None else '',
-                             '{}'.format(msg.args),
-                             kwarg_str])
+    child = QtWidgets.QTreeWidgetItem([msg.command,
+                                       msg.obj.name if msg.obj is not None else '',
+                                       '{}'.format(msg.args),
+                                       kwarg_str])
     child.setToolTip(3, pprint.pformat(msg.kwargs))
     return child
 
@@ -39,13 +39,13 @@ def fill_widget(widget, value):
 
 
 def plan_writer():
-    window = QMainWindow()
+    window = QtWidgets.QMainWindow()
     mw = QtWidgets.QWidget()
     ed_pannel = QtWidgets.QWidget()
     ed_layout = QtWidgets.QVBoxLayout()
     ed_pannel.setLayout(ed_layout)
 
-    w = QTreeWidget()
+    w = QtWidgets.QTreeWidget()
     w.setColumnCount(4)
     w.setHeaderLabels(Msg._fields)
     w.setAlternatingRowColors(True)
@@ -68,7 +68,7 @@ def plan_writer():
             exec(ed.toPlainText(), globals(), lcls)
             ret = to_nested(lcls['target'])
         except Exception as e:
-            pass
+            print(e)
         else:
             fill_widget(w, ret)
             w.resizeColumnToContents(0)


### PR DESCRIPTION
Type on the right, nested messages show up on the left

Still hacky.

To test, in IPython

```python
%matplotlib qt
import matplotlib.pyplot as plt
plt.plot(range(5))
```
to make sure qApp and everything is setup, then run

```python
plan_writer()
```

type a plan and set the iterable equal to `target`, ex

```python
import bluesky.plans as bp
from bluesky.examples import det

target = bp.count([det])
```

The code is evaluated against the current globals, but the result is shoved into a local dict.