### PR TITLE
ENH: put curated namespaces at the top level

### DIFF
--- a/bluesky/__init__.py
+++ b/bluesky/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from types import SimpleNamespace
 logger = logging.getLogger(__name__)
 
 from .utils import Msg
@@ -28,5 +29,33 @@ from .plans import OuterProductDeltaScanPlan
 from .plans import Tweak
 
 from ._version import get_versions
+from . import plans
+
+plns = SimpleNamespace(
+    count=plans.count,
+    scan=plans.scan,
+    inner_product_scan=plans.inner_product_scan,
+    grid_scan=plans.grid_scan,
+    scan_nd=plans.scan_nd,
+    list_scan=plans.list_scan,
+    log_scan=plans.log_scan,
+    adaptive_scan=plans.adaptive_scan,
+    tune_centroid=plans.tune_centroid,
+    spiral=plans.spiral,
+    spiral_fermat=plans.spiral_fermat,
+    ramp_plan=plans.ramp_plan)
+
+rplns = SimpleNamespace(
+    rel_scan=plans.rel_scan,
+    relative_inner_product_scan=plans.relative_inner_product_scan,
+    rel_grid_scan=plans.rel_grid_scan,
+    rel_list_scan=plans.rel_list_scan,
+    rel_log_scan=plans.rel_log_scan,
+    rel_adaptive_scan=plans.rel_adaptive_scan,
+    rel_spiral=plans.rel_spiral,
+    rel_spiral_fermat=plans.rel_spiral_fermat)
+
 __version__ = get_versions()['version']
 del get_versions
+del SimpleNamespace
+del logging


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The selling point of these namespace is that you can do

```python
from bluesky import plns as bp
from bluesky import rplns as rbp
```

and then bp.<tab> or rbp.<tab> gives you reasonable (<15 entry) lists of options to make them discover-able.

The only downside is that 

```python
frob bluesky.plns import count
```

will not work is `plns` is not a module