### PR TITLE
ENH: improve peak stats output on bec-plots

### DIFF
--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -519,7 +519,7 @@ class LivePlotPlusPeaks(LivePlot):
             if self.ax in self.__labeled:
                 label = '_no_legend_'
             else:
-                label = f'{attr}={val:.2f}'
+                label = '{}={:.2f}'.format(attr, val)
             vlines.append(self.ax.axvline(val, label=label, **style))
 
         # Horizontal lines:
@@ -531,7 +531,7 @@ class LivePlotPlusPeaks(LivePlot):
             if self.ax in self.__labeled:
                 label = '_no_legend_'
             else:
-                label = f'{attr}={val[1]:.2f}'
+                label = '{}={:.2f}'.format(attr, val[1])
             hlines.append(self.ax.axhline(val[1], label=label, **style))
 
         # Horizontal arrows (e.g., FWHM):
@@ -545,7 +545,7 @@ class LivePlotPlusPeaks(LivePlot):
             fwhm = val['fwhm']
             fwhm_x = val['cen_list']
             fwhm_y = (max_crds[1] + min_crds[1]) / 2
-            label = f'{attr}={fwhm:.2f}'
+            label = '{}={:.2f}'.format(attr, fwhm)
             # Fake line for the legend:
             hlines += self.ax.plot([], [], label=label, **style)
             harrows.append(self.ax.annotate(

--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -432,7 +432,7 @@ class BestEffortCallback(CallbackBase):
 
 
 class PeakResults:
-    ATTRS = ('com', 'cen', 'max', 'min', 'fwhm', 'nlls')
+    ATTRS = ('com', 'cen', 'max', 'min', 'fwhm', 'nlls', 'crossings')
 
     def __init__(self):
         for attr in self.ATTRS:
@@ -538,16 +538,15 @@ class LivePlotPlusPeaks(LivePlot):
         if val:
             max_crds = self.peak_results['max'][self.y]
             min_crds = self.peak_results['min'][self.y]
+            crossings = self.peak_results['crossings'][self.y]
             style = {'color': 'g'}
-            fwhm = val['fwhm']
-            fwhm_x = val['cen_list']
-            fwhm_y = (max_crds[1] + min_crds[1]) / 2
-            label = self.label_format.format(attr=attr, val=fwhm)
+            arrow_y_pos = (max_crds[1] + min_crds[1]) / 2
+            label = self.label_format.format(attr=attr, val=val)
             # Fake line for the legend:
             lines += self.ax.plot([], [], label=label, **style)
             arrows.append(self.ax.annotate(
-                '', xytext=(fwhm_x[0], fwhm_y),
-                xy=(fwhm_x[1], fwhm_y),
+                '', xytext=(crossings[0], arrow_y_pos),
+                xy=(crossings[-1], arrow_y_pos),
                 arrowprops=dict(arrowstyle="<->", **style)))
 
         self.__labeled[self.ax] = None

--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -547,7 +547,7 @@ class LivePlotPlusPeaks(LivePlot):
             fwhm_y = (max_crds[1] + min_crds[1]) / 2
             label = f'{attr}={fwhm:.2f}'
             # Fake line for the legend:
-            hlines = self.ax.plot([], [], label=label, **style)
+            hlines += self.ax.plot([], [], label=label, **style)
             harrows.append(self.ax.annotate(
                 '', xytext=(fwhm_x[0], fwhm_y),
                 xy=(fwhm_x[1], fwhm_y),

--- a/bluesky/callbacks/fitting.py
+++ b/bluesky/callbacks/fitting.py
@@ -289,7 +289,7 @@ class PeakStats(CollectThenCompute):
 
         if _cen_list:
             self.cen = np.mean(_cen_list)
-            self.crossings = np.array(_cen_list)
+            self.crossings = list(_cen_list)
             if len(_cen_list) >= 2:
                 self.fwhm = np.abs(self.crossings[-1] - self.crossings[0],
                                    dtype=float)

--- a/bluesky/tests/test_bec.py
+++ b/bluesky/tests/test_bec.py
@@ -4,6 +4,7 @@ import bluesky.preprocessors as bpp
 import bluesky.plan_stubs as bps
 from bluesky.preprocessors import SupplementalData
 from bluesky.callbacks.best_effort import BestEffortCallback
+import pytest
 
 
 def test_hints(RE, hw):
@@ -86,3 +87,21 @@ def test_live_grid(RE, hw):
     bec = BestEffortCallback()
     RE.subscribe(bec)
     RE(grid_scan([hw.det4], hw.motor1, 0, 1, 1, hw.motor2, 0, 1, 2, True))
+
+
+def test_format_labels(RE, hw):
+    bec = BestEffortCallback()
+    RE.subscribe(bec)
+
+    bec.format_labels('{attr}: {val:.3f}')
+    RE(scan([hw.ab_det], hw.motor, 1, 5, 5))
+
+    bec.format_labels('{attr}: {val:.2e}')
+    RE(scan([hw.ab_det], hw.motor, 1, 5, 5))
+
+    bec.format_labels(None)
+    RE(scan([hw.ab_det], hw.motor, 1, 5, 5))
+
+    with pytest.raises(AssertionError):
+        bec.format_labels('{} {}')
+        RE(scan([hw.ab_det], hw.motor, 1, 5, 5))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add more peak stats information on bec-plots.

## Description
<!--- Describe your changes in detail -->
The PR covers more verbose output of the peak stats on the best effort callback plots.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #934.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All existing tests have passed.

## Reproduce it with:
```py
%matplotlib qt
from bluesky.utils import install_qt_kicker
install_qt_kicker()

from bluesky.run_engine import RunEngine
from bluesky.callbacks.best_effort import BestEffortCallback
from bluesky.plans import count, scan, rel_scan
from ophyd.sim import motor, det

RE = RunEngine({})
bec = BestEffortCallback()
RE.subscribe(bec)

RE(rel_scan([det], motor, -1.5, 2, 15))
```

<!--
## Screenshots (if appropriate):
-->
![det_vs_motor](https://user-images.githubusercontent.com/13209176/37130564-fce5473c-2251-11e8-9203-658843915495.png)
