### PR TITLE
use tmpdir for ophyd sim path so pytest cleans up properly

### DIFF
--- a/bluesky/tests/conftest.py
+++ b/bluesky/tests/conftest.py
@@ -25,7 +25,7 @@ def RE(request):
 @pytest.fixture(scope='function')
 def hw(tmpdir):
     from ophyd.sim import hw
-    return hw(tmpdir)
+    return hw(str(tmpdir))
 
 
 # vendored from ophyd.sim

--- a/bluesky/tests/conftest.py
+++ b/bluesky/tests/conftest.py
@@ -23,9 +23,9 @@ def RE(request):
 
 
 @pytest.fixture(scope='function')
-def hw(request):
+def hw(tmpdir):
     from ophyd.sim import hw
-    return hw()
+    return hw(tmpdir)
 
 
 # vendored from ophyd.sim


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
-->