### PR TITLE
ENH: This adds a check of the meta-data for json compatibility to sumarize_plan

### DIFF
--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -9,6 +9,7 @@ from .utils import (normalize_subs_input, root_ancestor,
                     RunEngineControlException, merge_axis)
 from functools import wraps
 from .plan_stubs import (open_run, close_run, mv, pause, trigger_and_read)
+import json
 
 
 def plan_mutator(plan, msg_proc):
@@ -289,6 +290,24 @@ def print_summary_wrapper(plan):
         cmd = msg.command
         if cmd == 'open_run':
             print('{:=^80}'.format(' Open Run '))
+            # This next bit checks the metadata for json compatibility
+            try:
+                json.dumps(msg.kwargs)
+            except TypeError:
+                error_keys=[]
+                for key, value in msg.kwargs.items():
+                    try:
+                        json.dumps(value)
+                    except TypeError:
+                        error_keys.append(key)
+                if error_keys:
+                    raise TypeError(
+                        f'The values for the keys in "{error_keys}" '
+                        f'from the start document are not valid')
+                else:
+                    raise TypeError(
+                        f'the msg.kwarg dictionary is not valid, '
+                        f'however all of the values appear fine')
         elif cmd == 'close_run':
             print('{:=^80}'.format(' Close Run '))
         elif cmd == 'set':


### PR DESCRIPTION

## Description
The changes are made to `print_summary_wrapper`, when an `open_run` message is received it adds a check of the message.kwargs for json compatibility. If an issue is found it further attempts to isolate the cause. Finally it raises an exception with as much information about the issue as it can find.

## Motivation and Context
This resolves issue #1016 

## How Has This Been Tested?
This was tested using the file attached to issue #1016 