### PR TITLE
ENH: adding the `per_step` kwarg to the `count` plan

### DIFF
--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -900,6 +900,28 @@ def caching_repeater(n, plan):
         yield from (m for m in lst_plan)
 
 
+def count_step(detectors, step, pos_cache):
+    """Inner loop of a count scan
+
+    This is the default function for ``per_step`` in count plans.
+
+    Parameters
+    ----------
+    detectors : iterable
+        devices to read
+    step : dict
+        maps motors to positions in this step. Not used, included for API
+        compatibility with ``bluesky.plan_stubs.one_nd_step``, and similar
+        custom ``per_step`` functions only.
+    pos_cache : dict
+        maps motors to their last-set positions. Not used, included for API
+        compatibility with ``bluesky.plan_stubs.one_nd_step``, and similar
+        custom ``per_step`` functions only.
+    """
+
+    yield from trigger_and_read(list(detectors))
+
+
 def one_1d_step(detectors, motor, step):
     """
     Inner loop of a 1D step scan

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -928,8 +928,13 @@ def one_1d_step(detectors, motor, step, take_reading=trigger_and_read):
         The motor to move
     step : Any
         Where to move the motor to
-    take_reading : Callable[List[OphydObj]] -> Generator[Msg], optional
-        function to do the actual acquisition.
+    take_reading : plan, optional
+        function to do the actual acquisition ::
+
+           def take_reading(dets, name='primary'):
+                yield from ...
+
+        Callable[List[OphydObj], Optional[str]] -> Generator[Msg], optional
 
         Defaults to `trigger_and_read`
     """
@@ -981,8 +986,15 @@ def one_nd_step(detectors, step, pos_cache, take_reading=trigger_and_read):
         mapping motors to positions in this step
     pos_cache : dict
         mapping motors to their last-set positions
-    take_reading : Callable[List[OphydObj]] -> Generator[Msg], optional
-        function to
+    take_reading : plan, optional
+        function to do the actual acquisition ::
+
+           def take_reading(dets, name='primary'):
+                yield from ...
+
+        Callable[List[OphydObj], Optional[str]] -> Generator[Msg], optional
+
+        Defaults to `trigger_and_read`
     """
     motors = step.keys()
     yield from move_per_step(step, pos_cache)

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -900,10 +900,10 @@ def caching_repeater(n, plan):
         yield from (m for m in lst_plan)
 
 
-def count_step(detectors, take_reading=trigger_and_read):
-    """Inner loop of a count scan.
+def one_shot(detectors, take_reading=trigger_and_read):
+    """Inner loop of a count.
 
-    This is the default function for ``per_step`` in count plans.
+    This is the default function for ``per_shot`` in count plans.
 
     Parameters
     ----------

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -900,7 +900,7 @@ def caching_repeater(n, plan):
         yield from (m for m in lst_plan)
 
 
-def count_step(detectors):
+def count_step(detectors, take_reading=trigger_and_read):
     """Inner loop of a count scan.
 
     This is the default function for ``per_step`` in count plans.
@@ -909,9 +909,19 @@ def count_step(detectors):
     ----------
     detectors : Iterable[OphydObj]
         devices to read
+
+    take_reading : plan, optional
+        function to do the actual acquisition ::
+
+           def take_reading(dets, name='primary'):
+                yield from ...
+
+        Callable[List[OphydObj], Optional[str]] -> Generator[Msg], optional
+
+        Defaults to `trigger_and_read`
     """
     yield Msg('checkpoint')
-    yield from trigger_and_read(list(detectors))
+    yield from take_reading(list(detectors))
 
 
 def one_1d_step(detectors, motor, step, take_reading=trigger_and_read):

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -914,7 +914,7 @@ def count_step(detectors):
     yield from trigger_and_read(list(detectors))
 
 
-def one_1d_step(detectors, motor, step, per_step=trigger_and_read):
+def one_1d_step(detectors, motor, step, take_reading=trigger_and_read):
     """
     Inner loop of a 1D step scan
 
@@ -928,7 +928,7 @@ def one_1d_step(detectors, motor, step, per_step=trigger_and_read):
         The motor to move
     step : Any
         Where to move the motor to
-    per_step : Callable[List[OphydObj]] -> Generator[Msg], optional
+    take_reading : Callable[List[OphydObj]] -> Generator[Msg], optional
         function to do the actual acquisition.
 
         Defaults to `trigger_and_read`
@@ -940,7 +940,7 @@ def one_1d_step(detectors, motor, step, per_step=trigger_and_read):
         yield Msg('wait', None, group=grp)
 
     yield from move()
-    return (yield from per_step(list(detectors) + [motor]))
+    return (yield from take_reading(list(detectors) + [motor]))
 
 
 def move_per_step(step, pos_cache):
@@ -967,7 +967,7 @@ def move_per_step(step, pos_cache):
     yield Msg('wait', None, group=grp)
 
 
-def one_nd_step(detectors, step, pos_cache, per_step=trigger_and_read):
+def one_nd_step(detectors, step, pos_cache, take_reading=trigger_and_read):
     """
     Inner loop of an N-dimensional step scan
 
@@ -981,12 +981,12 @@ def one_nd_step(detectors, step, pos_cache, per_step=trigger_and_read):
         mapping motors to positions in this step
     pos_cache : dict
         mapping motors to their last-set positions
-    per_step : Callable[List[OphydObj]] -> Generator[Msg], optional
+    take_reading : Callable[List[OphydObj]] -> Generator[Msg], optional
         function to
     """
     motors = step.keys()
     yield from move_per_step(step, pos_cache)
-    yield from per_step(list(detectors) + list(motors))
+    yield from take_reading(list(detectors) + list(motors))
 
 
 def repeat(plan, num=1, delay=None):

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -900,23 +900,15 @@ def caching_repeater(n, plan):
         yield from (m for m in lst_plan)
 
 
-def count_step(detectors, step, pos_cache):
+def count_step(detectors):
     """Inner loop of a count scan.
 
     This is the default function for ``per_step`` in count plans.
 
     Parameters
     ----------
-    detectors : iterable
+    detectors : Iterable[OphydObj]
         devices to read
-    step : dict
-        maps motors to positions in this step. Not used, included for API
-        compatibility with ``bluesky.plan_stubs.one_nd_step``, and similar
-        custom ``per_step`` functions only.
-    pos_cache : dict
-        maps motors to their last-set positions. Not used, included for API
-        compatibility with ``bluesky.plan_stubs.one_nd_step``, and similar
-        custom ``per_step`` functions only.
     """
 
     yield from trigger_and_read(list(detectors))

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -910,7 +910,7 @@ def count_step(detectors):
     detectors : Iterable[OphydObj]
         devices to read
     """
-
+    yield Msg('checkpoint')
     yield from trigger_and_read(list(detectors))
 
 

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -901,7 +901,7 @@ def caching_repeater(n, plan):
 
 
 def count_step(detectors, step, pos_cache):
-    """Inner loop of a count scan
+    """Inner loop of a count scan.
 
     This is the default function for ``per_step`` in count plans.
 

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -22,7 +22,7 @@ from . import preprocessors as bpp
 from . import plan_stubs as bps
 
 
-def count(detectors, num=1, delay=None, *, per_step=None, md=None):
+def count(detectors, num=1, delay=None, *, per_shot=None, md=None):
     """
     Take one or more readings from detectors.
 
@@ -36,7 +36,7 @@ def count(detectors, num=1, delay=None, *, per_step=None, md=None):
         If None, capture data until canceled
     delay : iterable or scalar, optional
         Time delay in seconds between successive readings; default is 0.
-    per_step : callable, optional
+    per_shot : callable, optional
         hook for customizing action of inner loop (messages per step)
         Expected signature ::
 
@@ -65,13 +65,13 @@ def count(detectors, num=1, delay=None, *, per_step=None, md=None):
     _md.update(md or {})
     _md['hints'].setdefault('dimensions', [(('time',), 'primary')])
 
-    if per_step is None:
-        per_step = bps.count_step
+    if per_shot is None:
+        per_shot = bps.one_shot
 
     @bpp.stage_decorator(detectors)
     @bpp.run_decorator(md=_md)
     def inner_count():
-        return (yield from bps.repeat(partial(per_step, detectors),
+        return (yield from bps.repeat(partial(per_shot, detectors),
                                       num=num, delay=delay))
 
     return (yield from inner_count())

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -38,14 +38,10 @@ def count(detectors, num=1, delay=None, *, per_step=None, md=None):
         Time delay in seconds between successive readings; default is 0.
     per_step : callable, optional
         hook for customizing action of inner loop (messages per step)
-        Expected signature:
-        ``f(detectors, step, pos_cache) -> plan (a generator)``
+        Expected signature ::
 
-        ..note ::
-
-            In this case ``step`` and ``pos_cache`` are provided purely for API
-            compatibility with ``bluesky.plan_stubs.one_nd_step`` and similar
-            custom ``per_step`` functions, hey will be passed empty dicts.
+           def f(detectors: Iterable[OphydObj]) -> Generator[Msg]:
+               ...
 
     md : dict, optional
         metadata
@@ -75,7 +71,7 @@ def count(detectors, num=1, delay=None, *, per_step=None, md=None):
     @bpp.stage_decorator(detectors)
     @bpp.run_decorator(md=_md)
     def inner_count():
-        return (yield from bps.repeat(partial(per_step, detectors, {}, {}),
+        return (yield from bps.repeat(partial(per_step, detectors),
                                       num=num, delay=delay))
 
     return (yield from inner_count())

--- a/doc/source/plans.rst
+++ b/doc/source/plans.rst
@@ -534,7 +534,7 @@ Combinations of the above that are often convenient:
     trigger_and_read
     one_1d_step
     one_nd_step
-    count_step
+    one_shot
     move_per_step
 
 Special utilities:

--- a/doc/source/plans.rst
+++ b/doc/source/plans.rst
@@ -534,6 +534,7 @@ Combinations of the above that are often convenient:
     trigger_and_read
     one_1d_step
     one_nd_step
+    count_step
     move_per_step
 
 Special utilities:


### PR DESCRIPTION
Adds the `per_step` kwarg to count

## Description
I have added the `per_step` kwarg to the plan `count` mirroring the way it is done for other built-in plans like `scan`. To do this I also had to add the new default `per_step` function `coutn_step` to `plan_stubs`.

## Motivation and Context
At one of the beamlines at NSLS-II they are interested in taking one, or more, 'spectra' at each step in a plan, which can be defined as a scan over a single axis. To do this for  the plan `scan` I created a `per_step` function that collects the `spectra` at each point. To be able to use the same `per_step` function with 'count' plans it required this change.

## How Has This Been Tested?
It has been manually tested, as well as getting the existing pytests to pass locally. I will ensure that the tests also pass on Travis prior to merging.
