### PR TITLE
modifying list_scan to accept multiple motors

### DIFF
--- a/bluesky/plan_patterns.py
+++ b/bluesky/plan_patterns.py
@@ -279,7 +279,7 @@ def inner_list_product(args):
         patterned like (``motor1, position_list1,``
                         ``...,``
                         ``motorN, position_listN``)
-        Motors can be any 'setable' object (motor, temp controller, etc.)
+        Motors can be any 'settable' object (motor, temp controller, etc.)
         ``position_list``'s are a list of postiions, all lists must have the
         same length.
     Returns
@@ -309,11 +309,11 @@ def outer_list_product(args, snake_axes):
                         ``motorN, position_listN``)
 
         The first motor is the "slowest", the outer loop. ``position_list``'s
-        are a list of positions, all lists must have the same length.
+        are lists of positions, all lists must have the same length.
 .
     snake_axes
         which axes should be snaked, either None (do not snake any axes),
-        True (snake all axes) or a list of axes to snake. 'snaking an axis'
+        ``True`` (snake all axes) or a list of axes to snake. 'snaking an axis'
         is defined as following snake-like, winding trajectory instead of a
         simple left-to-right trajectory.
 
@@ -342,7 +342,7 @@ def outer_list_product(args, snake_axes):
             else:
                 snaking.append(True)
         else:
-            raise ValueError('The snake_axes arg to ``outer_list_pattern`` '
+            raise ValueError('The snake_axes arg to ``outer_list_product`` '
                              'must be either False (do not snake any axes), '
                              'True (snake all axes) or a list of axes to '
                              'snake. Instead it is {}.'.format(snake_axes))

--- a/bluesky/plan_patterns.py
+++ b/bluesky/plan_patterns.py
@@ -280,7 +280,7 @@ def inner_list_product(args):
                         ``...,``
                         ``motorN, position_listN``)
         Motors can be any 'settable' object (motor, temp controller, etc.)
-        ``position_list``'s are a list of postiions, all lists must have the
+        ``position_list``'s are lists of positions, all lists must have the
         same length.
     Returns
     -------
@@ -321,7 +321,7 @@ def outer_list_product(args, snake_axes):
 
     See Also
     --------
-    `bluesky.plan_patterns.inner_list_product`
+    :func:`bluesky.plan_patterns.inner_list_product`
 
     Returns
     -------
@@ -344,8 +344,8 @@ def outer_list_product(args, snake_axes):
                 snaking.append(True)
         else:
             raise ValueError('The snake_axes arg to ``outer_list_product`` '
-                             'must be either False (do not snake any axes), '
-                             'True (snake all axes) or a list of axes to '
+                             'must be either "False" (do not snake any axes), '
+                             '"True" (snake all axes) or a list of axes to '
                              'snake. Instead it is {}.'.format(snake_axes))
 
         c = cycler(motor, pos_list)

--- a/bluesky/plan_patterns.py
+++ b/bluesky/plan_patterns.py
@@ -1,5 +1,6 @@
 import functools
 import operator
+import collections
 
 import numpy as np
 from cycler import cycler
@@ -267,6 +268,89 @@ def spiral_fermat(x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
     cyc = cycler(x_motor, x_points)
     cyc += cycler(y_motor, y_points)
     return cyc
+
+
+def inner_list_product(args):
+    '''Scan over one multi-motor trajectory.
+
+    Parameters
+    ----------
+    args : list
+        patterned like (``motor1, position_list1,``
+                        ``...,``
+                        ``motorN, position_listN``)
+        Motors can be any 'setable' object (motor, temp controller, etc.)
+        ``position_list``'s are a list of postiions, all lists must have the
+        same length.
+    Returns
+    -------
+    cyc : cycler
+    '''
+    if len(args) % 2 != 0:
+        raise ValueError("wrong number of positional arguments")
+
+    cyclers = []
+    for motor, pos_list, in partition(2, args):
+        c = cycler(motor, pos_list)
+        cyclers.append(c)
+    return functools.reduce(operator.add, cyclers)
+
+
+def outer_list_product(args, snake_axes):
+    '''Scan over a mesh; each motor is on an independent trajectory.
+
+    Parameters
+    ----------
+    args
+        patterned like (``motor1, position_list1,``
+                        ``motor2, position_list2,``
+                        ``motor3, position_list3,``
+                        ``...,``
+                        ``motorN, position_listN``)
+
+        The first motor is the "slowest", the outer loop. ``position_list``'s
+        are a list of positions, all lists must have the same length.
+.
+    snake_axes
+        which axes should be snaked, either None (do not snake any axes),
+        True (snake all axes) or a list of axes to snake. 'snaking an axis'
+        is defined as following snake-like, winding trajectory instead of a
+        simple left-to-right trajectory.
+
+
+    See Also
+    --------
+    `bluesky.plan_patterns.inner_list_product`
+
+    Returns
+    -------
+    cyc : cycler
+    '''
+    snaking = []
+    cyclers = []
+    for motor, pos_list in partition(2, args):
+        if not snake_axes:
+            snaking.append(False)
+        elif isinstance(snake_axes, collections.abc.Iterable):
+            if motor in snake_axes:
+                snaking.append(True)
+            else:
+                snaking.append(False)
+        elif snake_axes:
+            if not snaking:
+                snaking.append(False)
+            else:
+                snaking.append(True)
+        else:
+            raise ValueError('The snake_axes arg to ``outer_list_pattern`` '
+                             'must be either False (do not snake any axes), '
+                             'True (snake all axes) or a list of axes to '
+                             'snake. Instead it is {}.'.format(snake_axes))
+
+        c = cycler(motor, pos_list)
+        cyclers.append(c)
+
+    return snake_cyclers(cyclers, snaking)
 
 
 def inner_product(num, args):

--- a/bluesky/plan_patterns.py
+++ b/bluesky/plan_patterns.py
@@ -287,7 +287,8 @@ def inner_list_product(args):
     cyc : cycler
     '''
     if len(args) % 2 != 0:
-        raise ValueError("wrong number of positional arguments")
+        raise ValueError("Wrong number of positional arguments for "
+                         "'inner_list_product'")
 
     cyclers = []
     for motor, pos_list, in partition(2, args):
@@ -312,8 +313,8 @@ def outer_list_product(args, snake_axes):
         are lists of positions, all lists must have the same length.
 .
     snake_axes
-        which axes should be snaked, either None (do not snake any axes),
-        ``True`` (snake all axes) or a list of axes to snake. 'snaking an axis'
+        which axes should be snaked, either ``False`` (do not snake any axes),
+        ``True`` (snake all axes) or a list of axes to snake. "Snaking" an axis
         is defined as following snake-like, winding trajectory instead of a
         simple left-to-right trajectory.
 
@@ -369,7 +370,8 @@ def inner_product(num, args):
     cyc : cycler
     '''
     if len(args) % 3 != 0:
-        raise ValueError("wrong number of positional arguments")
+        raise ValueError("Wrong number of positional arguments for "
+                         "'inner_product'")
 
     cyclers = []
     for motor, start, stop, in partition(3, args):
@@ -408,7 +410,8 @@ def chunk_outer_product_args(args):
     # make it easy to iterate over the chunks or args..
     args.insert(4, False)
     if len(args) % 5 != 0:
-        raise ValueError("wrong number of positional arguments")
+        raise ValueError("Wrong number of positional arguments "
+                         "for 'chunk_outer_product_args'")
 
     yield from partition(5, args)
 

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -67,18 +67,27 @@ def count(detectors, num=1, delay=None, *, md=None):
     return (yield from inner_count())
 
 
-def list_scan(detectors, motor, steps, *, per_step=None, md=None):
+def list_scan(detectors, *args, per_step=None, md=None):
     """
-    Scan over one variable in steps.
+    Scan over one or more variables in steps simultaneously (inner product).
 
     Parameters
     ----------
     detectors : list
         list of 'readable' objects
-    motor : object
-        any 'settable' object (motor, temp controller, etc.)
-    steps : list
-        list of positions
+    *args :
+        For one dimension, ``motor, [point1, point2, ....]``.
+        In general:
+
+        .. code-block:: python
+
+            motor1, [point1, point2, ...],
+            motor2, [point1, point2, ...],
+            ...,
+            motorN, [point1, point2, ...]
+
+        Motors can be any 'settable' object (motor, temp controller, etc.)
+
     per_step : callable, optional
         hook for customizing action of inner loop (messages per step)
         Expected signature:
@@ -90,39 +99,73 @@ def list_scan(detectors, motor, steps, *, per_step=None, md=None):
     --------
     :func:`bluesky.plans.rel_list_scan`
     """
+    if len(args) % 2 != 0:
+            raise ValueError("The list of arguments must contain a list of "
+                             "points for each defined motor")
+
+    md = md or {}  # reset md if it is None.
+
+    # set some variables and check that all lists are the same length
+    lengths = {}
+    motors = []
+    pos_lists = []
+    length = None
+    for motor, pos_list in partition(2,args):
+        pos_list = list(pos_list)  # Ensure list (accepts any finite iterable).
+        lengths[motor.name] = len(pos_list)
+        if not length:
+            length = len(pos_list)
+        motors.append(motor)
+        pos_lists.append(pos_list)
+    length_check = all(elem == list(lengths.values())[0] for elem in
+                       list(lengths.values()))
+
+    if not length_check:
+        raise ValueError("The lengths of all lists in *args must be the same"
+                         "However the lengths in args are : "
+                         "{}".format(lengths))
+
+    md_args = list(chain(*((repr(motor), pos_list)
+                           for motor, pos_list in partition(2, args))))
+    motor_names = list(lengths.keys())
+
     _md = {'detectors': [det.name for det in detectors],
-           'motors': [motor.name],
-           'num_points': len(steps),
-           'num_intervals': len(steps) - 1,
+           'motors': motor_names,
+           'num_points': length,
+           'num_intervals': length - 1,
            'plan_args': {'detectors': list(map(repr, detectors)),
-                         'motor': repr(motor), 'steps': steps,
+                         'args': md_args,
                          'per_step': repr(per_step)},
            'plan_name': 'list_scan',
-           'plan_pattern': 'array',
-           'plan_pattern_module': 'numpy',
-           'plan_pattern_args': dict(object=steps),
+           'plan_pattern': 'inner_list_product',
+           'plan_pattern_module': plan_patterns.__name__,
+           'plan_pattern_args': dict(args=md_args),
            'hints': {},
            }
     _md.update(md or {})
-    try:
-        dimensions = [(motor.hints['fields'], 'primary')]
-    except (AttributeError, KeyError):
-        pass
-    else:
-        _md['hints'].setdefault('dimensions', dimensions)
-    if per_step is None:
-        per_step = bps.one_1d_step
 
-    @bpp.stage_decorator(list(detectors) + [motor])
-    @bpp.run_decorator(md=_md)
-    def inner_list_scan():
-        for step in steps:
-            yield from per_step(detectors, motor, step)
+    x_fields = []
+    for motor in motors:
+        x_fields.extend(getattr(motor, 'hints', {}).get('fields', []))
 
-    return (yield from inner_list_scan())
+    default_dimensions = [(x_fields, 'primary')]
+
+    default_hints = {}
+    if len(x_fields) > 0:
+        default_hints.update(dimensions=default_dimensions)
+
+    # now add default_hints and override any hints from the original md (if
+    # exists)
+    _md['hints'] = default_hints
+    _md['hints'].update(md.get('hints', {}) or {})
+
+    full_cycler = plan_patterns.inner_list_product(args)
+
+    return (yield from scan_nd(detectors, full_cycler, per_step=per_step,
+                               md=_md))
 
 
-def rel_list_scan(detectors, motor, steps, *, per_step=None, md=None):
+def rel_list_scan(detectors, *args, per_step=None, md=None):
     """
     Scan over one variable in steps relative to current position.
 
@@ -130,6 +173,20 @@ def rel_list_scan(detectors, motor, steps, *, per_step=None, md=None):
     ----------
     detectors : list
         list of 'readable' objects
+    *args :
+        For one dimension, ``motor, [point1, point2, ....]``.
+        In general:
+
+        .. code-block:: python
+
+            motor1, [point1, point2, ...],
+            motor2, [point1, point2, ...],
+            ...,
+            motorN, [point1, point2, ...]
+
+        Motors can be any 'settable' object (motor, temp controller, etc.)
+        point1, point2 etc are relative to the current location.
+
     motor : object
         any 'settable' object (motor, temp controller, etc.)
     steps : list
@@ -148,12 +205,148 @@ def rel_list_scan(detectors, motor, steps, *, per_step=None, md=None):
     _md = {'plan_name': 'rel_list_scan'}
     _md.update(md or {})
 
-    @bpp.reset_positions_decorator([motor])
-    @bpp.relative_set_decorator([motor])
+    motors= [motor for motor, pos_list in partition(2, args)]
+
+    @bpp.reset_positions_decorator(motors)
+    @bpp.relative_set_decorator(motors)
     def inner_relative_list_scan():
-        return (yield from list_scan(detectors, motor, steps,
-                                     per_step=per_step, md=_md))
+        return (yield from list_scan(detectors, *args, per_step=per_step,
+                                     md=_md))
     return (yield from inner_relative_list_scan())
+
+
+def list_grid_scan(detectors, *args, snake_axes=False, per_step=None, md=None):
+    """
+    Scan over a mesh; each motor is on an independent trajectory.
+
+    Parameters
+    ----------
+    detectors : list
+        list of 'readable' objects
+
+    args
+        patterned like (``motor1, position_list1,``
+                        ``motor2, position_list2,``
+                        ``motor3, position_list3,``
+                        ``...,``
+                        ``motorN, position_listN``)
+
+        The first motor is the "slowest", the outer loop. ``position_list``'s
+        are a list of positions, all lists must have the same length. Motors
+        can be any 'settable' object (motor, temp controller, etc.).
+
+    snake_axes : boolean or iterable, optional
+        which axes should be snaked, either False (do not snake any axes),
+        True (snake all axes) or a list of axes to snake. 'snaking an axis'
+        is defined as following snake-like, winding trajectory instead of a
+        simple left-to-right trajectory.
+
+    per_step : callable, optional
+        hook for customizing action of inner loop (messages per step)
+        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
+        details.
+    md : dict, optional
+        metadata
+
+    See Also
+    --------
+    :func:`bluesky.plans.rel_list_grid_scan`
+    :func:`bluesky.plans.list_scan`
+    :func:`bluesky.plans.rel_list_scan`
+    """
+
+    full_cycler = plan_patterns.outer_list_product(args, snake_axes)
+
+    md_args = []
+    motor_names = []
+    motors = []
+    for i, (motor, pos_list) in enumerate(partition(2, args)):
+        md_args.extend([repr(motor), pos_list])
+        motor_names.append(motor.name)
+        motors.append(motor)
+    _md = {'shape': tuple(len(pos_list)
+                          for motor, pos_list in partition(2, args)),
+           'snake_axes': snake_axes,
+           'plan_args': {'detectors': list(map(repr, detectors)),
+                         'args': md_args,
+                         'per_step': repr(per_step)},
+           'plan_name': 'list_grid_scan',
+           'plan_pattern': 'outer_list_product',
+           'plan_pattern_args': dict(args=md_args).update(
+                {'snake_axes':snake_axes}),
+           'plan_pattern_module': plan_patterns.__name__,
+           'motors': tuple(motor_names),
+           'hints': {},
+           }
+    _md.update(md or {})
+    _md['hints'].setdefault('gridding', 'rectilinear')
+    try:
+        _md['hints'].setdefault('dimensions', [(m.hints['fields'], 'primary')
+                                               for m in motors])
+    except (AttributeError, KeyError):
+        ...
+
+    return (yield from scan_nd(detectors, full_cycler,
+                               per_step=per_step, md=_md))
+
+
+def rel_list_grid_scan(detectors, *args, snake_axes=False, per_step=None,
+                       md=None):
+    """
+    Scan over a mesh; each motor is on an independent trajectory.Each point is
+    relative to the current postion.
+
+    Parameters
+    ----------
+    detectors : list
+        list of 'readable' objects
+
+    args
+        patterned like (``motor1, position_list1,``
+                        ``motor2, position_list2,``
+                        ``motor3, position_list3,``
+                        ``...,``
+                        ``motorN, position_listN``)
+
+        The first motor is the "slowest", the outer loop. ``position_list``'s
+        are a list of positions, all lists must have the same length. Motors
+        can be any 'settable' object (motor, temp controller, etc.).
+
+    snake_axes : boolean or Iterable, optional
+        which axes should be snaked, either False (do not snake any axes),
+        True (snake all axes) or a list of axes to snake. 'snaking an axis'
+        is defined as following snake-like, winding trajectory instead of a
+        simple left-to-right trajectory.
+
+    per_step : callable, optional
+        hook for customizing action of inner loop (messages per step)
+        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
+        details.
+    md : dict, optional
+        metadata
+
+    See Also
+    --------
+    :func:`bluesky.plans.rel_list_grid_scan`
+    :func:`bluesky.plans.list_scan`
+    :func:`bluesky.plans.rel_list_scan`
+     See Also
+    --------
+    :func:`bluesky.plans.list_scan`
+    """
+    _md = {'plan_name': 'rel_list_grid_scan'}
+    _md.update(md or {})
+
+    motors= [motor for motor, pos_list in partition(2, args)]
+
+
+    @bpp.reset_positions_decorator(motors)
+    @bpp.relative_set_decorator(motors)
+    def inner_relative_list_grid_scan():
+        return (yield from list_grid_scan(detectors, *args,
+                                          snake_axes=snake_axes,
+                                          per_step=per_step, md=_md))
+    return (yield from inner_relative_list_grid_scan())
 
 
 def _scan_1d(detectors, motor, start, stop, num, *, per_step=None, md=None):

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -98,6 +98,8 @@ def list_scan(detectors, *args, per_step=None, md=None):
     See Also
     --------
     :func:`bluesky.plans.rel_list_scan`
+    :func:`bluesky.plans.list_grid_scan`
+    :func:`bluesky.plans.rel_list_grid_scan`
     """
     if len(args) % 2 != 0:
             raise ValueError("The list of arguments must contain a list of "
@@ -200,6 +202,8 @@ def rel_list_scan(detectors, *args, per_step=None, md=None):
     See Also
     --------
     :func:`bluesky.plans.list_scan`
+    :func:`bluesky.plans.list_grid_scan`
+    :func:`bluesky.plans.rel_list_grid_scan`
     """
     # TODO read initial positions (redundantly) so they can be put in md here
     _md = {'plan_name': 'rel_list_scan'}
@@ -232,19 +236,19 @@ def list_grid_scan(detectors, *args, snake_axes=False, per_step=None, md=None):
                         ``motorN, position_listN``)
 
         The first motor is the "slowest", the outer loop. ``position_list``'s
-        are a list of positions, all lists must have the same length. Motors
+        are lists of positions, all lists must have the same length. Motors
         can be any 'settable' object (motor, temp controller, etc.).
 
     snake_axes : boolean or iterable, optional
-        which axes should be snaked, either False (do not snake any axes),
-        True (snake all axes) or a list of axes to snake. 'snaking an axis'
+        which axes should be snaked, either ``False`` (do not snake any axes),
+        ``True`` (snake all axes) or a list of axes to snake. "Snaking" an axis
         is defined as following snake-like, winding trajectory instead of a
         simple left-to-right trajectory.
 
     per_step : callable, optional
         hook for customizing action of inner loop (messages per step)
-        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
-        details.
+        See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
+        for details.
     md : dict, optional
         metadata
 
@@ -309,36 +313,32 @@ def rel_list_grid_scan(detectors, *args, snake_axes=False, per_step=None,
                         ``motorN, position_listN``)
 
         The first motor is the "slowest", the outer loop. ``position_list``'s
-        are a list of positions, all lists must have the same length. Motors
+        are lists of positions, all lists must have the same length. Motors
         can be any 'settable' object (motor, temp controller, etc.).
 
     snake_axes : boolean or Iterable, optional
-        which axes should be snaked, either False (do not snake any axes),
-        True (snake all axes) or a list of axes to snake. 'snaking an axis'
+        which axes should be snaked, either ``False`` (do not snake any axes),
+        ``True`` (snake all axes) or a list of axes to snake. "Snaking" an axis
         is defined as following snake-like, winding trajectory instead of a
         simple left-to-right trajectory.
 
     per_step : callable, optional
         hook for customizing action of inner loop (messages per step)
-        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
-        details.
+        See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
+        for details.
     md : dict, optional
         metadata
 
     See Also
     --------
-    :func:`bluesky.plans.rel_list_grid_scan`
+    :func:`bluesky.plans.list_grid_scan`
     :func:`bluesky.plans.list_scan`
     :func:`bluesky.plans.rel_list_scan`
-     See Also
-    --------
-    :func:`bluesky.plans.list_scan`
     """
     _md = {'plan_name': 'rel_list_grid_scan'}
     _md.update(md or {})
 
-    motors= [motor for motor, pos_list in partition(2, args)]
-
+    motors = [motor for motor, pos_list in partition(2, args)]
 
     @bpp.reset_positions_decorator(motors)
     @bpp.relative_set_decorator(motors)
@@ -869,8 +869,8 @@ def scan_nd(detectors, cycler, *, per_step=None, md=None):
         list of dictionaries mapping motors to positions
     per_step : callable, optional
         hook for customizing action of inner loop (messages per step)
-        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
-        details.
+        See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
+        for details.
     md : dict, optional
         metadata
 
@@ -975,8 +975,8 @@ def scan(detectors, *args, num=None, per_step=None, md=None):
         number of points
     per_step : callable, optional
         hook for customizing action of inner loop (messages per step)
-        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
-        details.
+        See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
+        for details.
     md : dict, optional
         metadata
 
@@ -1062,8 +1062,8 @@ def grid_scan(detectors, *args, per_step=None, md=None):
         simple left-to-right trajectory.
     per_step : callable, optional
         hook for customizing action of inner loop (messages per step)
-        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
-        details.
+        See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
+        for details.
     md : dict, optional
         metadata
 
@@ -1134,8 +1134,8 @@ def rel_grid_scan(detectors, *args, per_step=None, md=None):
         trajectory or a simple left-to-right trajectory.
     per_step : callable, optional
         hook for customizing action of inner loop (messages per step)
-        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
-        details.
+        See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
+        for details.
     md : dict, optional
         metadata
 
@@ -1191,8 +1191,8 @@ def rel_scan(detectors, *args, num=None, per_step=None, md=None):
         number of points
     per_step : callable, optional
         hook for customizing action of inner loop (messages per step)
-        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
-        details.
+        See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
+        for details.
     md : dict, optional
         metadata
 
@@ -1321,8 +1321,8 @@ def spiral_fermat(detectors, x_motor, y_motor, x_start, y_start, x_range,
         Tilt angle in radians, default 0.0
     per_step : callable, optional
         hook for customizing action of inner loop (messages per step)
-        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
-        details.
+        See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
+        for details.
     md : dict, optional
         metadata
 
@@ -1390,8 +1390,8 @@ def rel_spiral_fermat(detectors, x_motor, y_motor, x_range, y_range, dr,
         Tilt angle in radians, default 0.0
     per_step : callable, optional
         hook for customizing action of inner loop (messages per step)
-        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
-        details.
+        See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
+        for details.
     md : dict, optional
         metadata
 
@@ -1445,8 +1445,8 @@ def spiral(detectors, x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
         Tilt angle in radians, default 0.0
     per_step : callable, optional
         hook for customizing action of inner loop (messages per step)
-        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
-        details.
+        See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
+        for details.
     md : dict, optional
         metadata
 
@@ -1520,8 +1520,8 @@ def rel_spiral(detectors, x_motor, y_motor, x_range, y_range, dr, nth,
         Tilt angle in radians, default 0.0
     per_step : callable, optional
         hook for customizing action of inner loop (messages per step)
-        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
-        details.
+        See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
+        for details.
     md : dict, optional
         metadata
 
@@ -1554,9 +1554,9 @@ def spiral_square(detectors, x_motor, y_motor, x_center, y_center, x_range,
     detectors : list
         list of 'readable' objects
     x_motor : object
-        any 'setable' object (motor, temp controller, etc.)
+        any 'settable' object (motor, temp controller, etc.)
     y_motor : object
-        any 'setable' object (motor, temp controller, etc.)
+        any 'settable' object (motor, temp controller, etc.)
     x_center : float
         x center
     y_center : float
@@ -1571,7 +1571,7 @@ def spiral_square(detectors, x_motor, y_motor, x_center, y_center, x_range,
         Number of y axis points.
     per_step : callable, optional
         hook for cutomizing action of inner loop (messages per step)
-        See docstring of bluesky.plans.one_nd_step (the default) for
+        See docstring of :func:`bluesky.plans.one_nd_step` (the default) for
         details.
     md : dict, optional
         metadata
@@ -1625,9 +1625,9 @@ def rel_spiral_square(detectors, x_motor, y_motor, x_range, y_range,
     detectors : list
         list of 'readable' objects
     x_motor : object
-        any 'setable' object (motor, temp controller, etc.)
+        any 'settable' object (motor, temp controller, etc.)
     y_motor : object
-        any 'setable' object (motor, temp controller, etc.)
+        any 'settable' object (motor, temp controller, etc.)
     x_range : float
         x width of spiral
     y_range : float
@@ -1638,7 +1638,7 @@ def rel_spiral_square(detectors, x_motor, y_motor, x_range, y_range,
         Number of y axis points.
     per_step : callable, optional
         hook for cutomizing action of inner loop (messages per step)
-        See docstring of bluesky.plans.one_nd_step (the default) for
+        See docstring of :func:`bluesky.plans.one_nd_step` (the default) for
         details.
     md : dict, optional
         metadata
@@ -1802,8 +1802,8 @@ def x2x_scan(detectors, motor1, motor2, start, stop, num, *,
 
     per_step : callable, optional
         hook for cutomizing action of inner loop (messages per step)
-        See docstring of bluesky.plan_stubs.one_nd_step (the default) for
-        details.
+        See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
+        for details.
 
     md : dict, optional
         metadata

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -112,7 +112,7 @@ def list_scan(detectors, *args, per_step=None, md=None):
     motors = []
     pos_lists = []
     length = None
-    for motor, pos_list in partition(2,args):
+    for motor, pos_list in partition(2, args):
         pos_list = list(pos_list)  # Ensure list (accepts any finite iterable).
         lengths[motor.name] = len(pos_list)
         if not length:
@@ -123,7 +123,7 @@ def list_scan(detectors, *args, per_step=None, md=None):
                        list(lengths.values()))
 
     if not length_check:
-        raise ValueError("The lengths of all lists in *args must be the same"
+        raise ValueError("The lengths of all lists in *args must be the same. "
                          "However the lengths in args are : "
                          "{}".format(lengths))
 
@@ -246,7 +246,7 @@ def list_grid_scan(detectors, *args, snake_axes=False, per_step=None, md=None):
         simple left-to-right trajectory.
 
     per_step : callable, optional
-        hook for customizing action of inner loop (messages per step)
+        hook for customizing action of inner loop (messages per step).
         See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
         for details.
     md : dict, optional
@@ -277,7 +277,7 @@ def list_grid_scan(detectors, *args, snake_axes=False, per_step=None, md=None):
            'plan_name': 'list_grid_scan',
            'plan_pattern': 'outer_list_product',
            'plan_pattern_args': dict(args=md_args).update(
-                {'snake_axes':snake_axes}),
+                {'snake_axes': snake_axes}),
            'plan_pattern_module': plan_patterns.__name__,
            'motors': tuple(motor_names),
            'hints': {},
@@ -297,8 +297,8 @@ def list_grid_scan(detectors, *args, snake_axes=False, per_step=None, md=None):
 def rel_list_grid_scan(detectors, *args, snake_axes=False, per_step=None,
                        md=None):
     """
-    Scan over a mesh; each motor is on an independent trajectory.Each point is
-    relative to the current postion.
+    Scan over a mesh; each motor is on an independent trajectory. Each point is
+    relative to the current position.
 
     Parameters
     ----------
@@ -323,7 +323,7 @@ def rel_list_grid_scan(detectors, *args, snake_axes=False, per_step=None,
         simple left-to-right trajectory.
 
     per_step : callable, optional
-        hook for customizing action of inner loop (messages per step)
+        hook for customizing action of inner loop (messages per step).
         See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
         for details.
     md : dict, optional
@@ -868,7 +868,7 @@ def scan_nd(detectors, cycler, *, per_step=None, md=None):
     cycler : Cycler
         list of dictionaries mapping motors to positions
     per_step : callable, optional
-        hook for customizing action of inner loop (messages per step)
+        hook for customizing action of inner loop (messages per step).
         See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
         for details.
     md : dict, optional
@@ -974,7 +974,7 @@ def scan(detectors, *args, num=None, per_step=None, md=None):
     num : integer
         number of points
     per_step : callable, optional
-        hook for customizing action of inner loop (messages per step)
+        hook for customizing action of inner loop (messages per step).
         See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
         for details.
     md : dict, optional
@@ -1061,7 +1061,7 @@ def grid_scan(detectors, *args, per_step=None, md=None):
         indicating whether to following snake-like, winding trajectory or a
         simple left-to-right trajectory.
     per_step : callable, optional
-        hook for customizing action of inner loop (messages per step)
+        hook for customizing action of inner loop (messages per step).
         See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
         for details.
     md : dict, optional
@@ -1133,7 +1133,7 @@ def rel_grid_scan(detectors, *args, per_step=None, md=None):
         is a boolean indicating whether to following snake-like, winding
         trajectory or a simple left-to-right trajectory.
     per_step : callable, optional
-        hook for customizing action of inner loop (messages per step)
+        hook for customizing action of inner loop (messages per step).
         See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
         for details.
     md : dict, optional
@@ -1190,7 +1190,7 @@ def rel_scan(detectors, *args, num=None, per_step=None, md=None):
     num : integer
         number of points
     per_step : callable, optional
-        hook for customizing action of inner loop (messages per step)
+        hook for customizing action of inner loop (messages per step).
         See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
         for details.
     md : dict, optional
@@ -1320,7 +1320,7 @@ def spiral_fermat(detectors, x_motor, y_motor, x_start, y_start, x_range,
     tilt : float, optional
         Tilt angle in radians, default 0.0
     per_step : callable, optional
-        hook for customizing action of inner loop (messages per step)
+        hook for customizing action of inner loop (messages per step).
         See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
         for details.
     md : dict, optional
@@ -1389,7 +1389,7 @@ def rel_spiral_fermat(detectors, x_motor, y_motor, x_range, y_range, dr,
     tilt : float, optional
         Tilt angle in radians, default 0.0
     per_step : callable, optional
-        hook for customizing action of inner loop (messages per step)
+        hook for customizing action of inner loop (messages per step).
         See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
         for details.
     md : dict, optional
@@ -1444,7 +1444,7 @@ def spiral(detectors, x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
     tilt : float, optional
         Tilt angle in radians, default 0.0
     per_step : callable, optional
-        hook for customizing action of inner loop (messages per step)
+        hook for customizing action of inner loop (messages per step).
         See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
         for details.
     md : dict, optional
@@ -1519,7 +1519,7 @@ def rel_spiral(detectors, x_motor, y_motor, x_range, y_range, dr, nth,
     tilt : float, optional
         Tilt angle in radians, default 0.0
     per_step : callable, optional
-        hook for customizing action of inner loop (messages per step)
+        hook for customizing action of inner loop (messages per step).
         See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
         for details.
     md : dict, optional
@@ -1570,7 +1570,7 @@ def spiral_square(detectors, x_motor, y_motor, x_center, y_center, x_range,
     y_num : float
         Number of y axis points.
     per_step : callable, optional
-        hook for cutomizing action of inner loop (messages per step)
+        hook for cutomizing action of inner loop (messages per step).
         See docstring of :func:`bluesky.plans.one_nd_step` (the default) for
         details.
     md : dict, optional
@@ -1637,7 +1637,7 @@ def rel_spiral_square(detectors, x_motor, y_motor, x_range, y_range,
     y_num : float
         Number of y axis points.
     per_step : callable, optional
-        hook for cutomizing action of inner loop (messages per step)
+        hook for cutomizing action of inner loop (messages per step).
         See docstring of :func:`bluesky.plans.one_nd_step` (the default) for
         details.
     md : dict, optional
@@ -1801,7 +1801,7 @@ def x2x_scan(detectors, motor1, motor2, start, stop, num, *,
         will move between ``start / 2`` and ``stop / 2``
 
     per_step : callable, optional
-        hook for cutomizing action of inner loop (messages per step)
+        hook for cutomizing action of inner loop (messages per step).
         See docstring of :func:`bluesky.plan_stubs.one_nd_step` (the default)
         for details.
 

--- a/bluesky/tests/test_scans.py
+++ b/bluesky/tests/test_scans.py
@@ -166,11 +166,41 @@ def test_ascan(RE, hw):
     traj_checker(RE, scan, traj)
 
 
+def test_multi_motor_list_scan(RE, hw):
+    expected_data = [
+        {'motor2': 18, 'motor2_setpoint': 18, 'det': 1,
+         'motor1': 6, 'motor1_setpoint': 6},
+        {'motor2': 28, 'motor2_setpoint': 28, 'det': 1,
+         'motor1': 7, 'motor1_setpoint': 7},
+        {'motor2': 38, 'motor2_setpoint': 38, 'det': 1,
+         'motor1': 8, 'motor1_setpoint': 8}]
+
+    scan = bp.list_scan([hw.det], hw.motor1, [6, 7, 8],
+                        hw.motor2, [18, 28, 38])
+    multi_traj_checker(RE, scan, expected_data)
+
+
 def test_dscan(RE, hw):
     traj = np.array([1, 2, 3])
     hw.motor.set(-4)
     scan = bp.rel_list_scan([hw.det], hw.motor, traj)
     traj_checker(RE, scan, traj - 4)
+
+
+def test_multi_motor_rel_list_scan(RE, hw):
+    expected_data = [
+        {'motor2': 18, 'motor2_setpoint': 18, 'det': 1,
+         'motor1': 6, 'motor1_setpoint': 6},
+        {'motor2': 28, 'motor2_setpoint': 28, 'det': 1,
+         'motor1': 7, 'motor1_setpoint': 7},
+        {'motor2': 38, 'motor2_setpoint': 38, 'det': 1,
+         'motor1': 8, 'motor1_setpoint': 8}]
+
+    hw.motor1.set(5)
+    hw.motor2.set(8)
+    scan = bp.rel_list_scan([hw.det], hw.motor1, np.array([1, 2, 3]),
+                            hw.motor2, np.array([10, 20, 30]))
+    multi_traj_checker(RE, scan, expected_data)
 
 
 def test_dscan_list_input(RE, hw):
@@ -179,6 +209,134 @@ def test_dscan_list_input(RE, hw):
     hw.motor.set(-4)
     scan = bp.rel_list_scan([hw.det], hw.motor, traj)
     traj_checker(RE, scan, np.array(traj) - 4)
+
+
+def test_multi_motor_rel_list_scan_list_input(RE, hw):
+    expected_data = [
+        {'motor2': 18, 'motor2_setpoint': 18, 'det': 1,
+         'motor1': 6, 'motor1_setpoint': 6},
+        {'motor2': 28, 'motor2_setpoint': 28, 'det': 1,
+         'motor1': 7, 'motor1_setpoint': 7},
+        {'motor2': 38, 'motor2_setpoint': 38, 'det': 1,
+         'motor1': 8, 'motor1_setpoint': 8}]
+
+    hw.motor1.set(5)
+    hw.motor2.set(8)
+    scan = bp.rel_list_scan([hw.det], hw.motor1, [1, 2, 3],
+                            hw.motor2, [10, 20, 30])
+    multi_traj_checker(RE, scan, expected_data)
+
+
+def test_list_grid_scan(RE, hw):
+    expected_data = []
+    for motor1_pos in [6, 7, 8]:
+        for motor2_pos in [18, 28, 38]:
+            expected_data.append({'motor2': motor2_pos,
+                                  'motor2_setpoint': motor2_pos,
+                                  'det': 1.0,
+                                  'motor1': motor1_pos,
+                                  'motor1_setpoint': motor1_pos})
+    scan = bp.list_grid_scan([hw.det], hw.motor1, [6, 7, 8],
+                             hw.motor2, [18, 28, 38])
+    multi_traj_checker(RE, scan, expected_data)
+
+
+def test_list_grid_scan_snake(RE, hw):
+    expected_data = []
+    for motor1_pos in [6, 7, 8]:
+        if motor1_pos == 7:
+            motor2_list = [38, 28, 18]
+        else:
+            motor2_list = [18, 28, 38]
+        for motor2_pos in motor2_list:
+            expected_data.append({'motor2': motor2_pos,
+                                  'motor2_setpoint': motor2_pos,
+                                  'det': 1.0,
+                                  'motor1': motor1_pos,
+                                  'motor1_setpoint': motor1_pos})
+
+    scan = bp.list_grid_scan([hw.det], hw.motor1, [6, 7, 8],
+                             hw.motor2, [18, 28, 38], snake_axes=True)
+    multi_traj_checker(RE, scan, expected_data)
+
+
+def test_list_grid_scan_snake_list(RE, hw):
+    expected_data = []
+    for motor1_pos in [6, 7, 8]:
+        if motor1_pos == 7:
+            motor2_list = [38, 28, 18]
+        else:
+            motor2_list = [18, 28, 38]
+        for motor2_pos in motor2_list:
+            expected_data.append({'motor2': motor2_pos,
+                                  'motor2_setpoint': motor2_pos,
+                                  'det': 1.0,
+                                  'motor1': motor1_pos,
+                                  'motor1_setpoint': motor1_pos})
+
+    scan = bp.list_grid_scan([hw.det], hw.motor1, [6, 7, 8],
+                             hw.motor2, [18, 28, 38], snake_axes=[hw.motor2])
+    multi_traj_checker(RE, scan, expected_data)
+
+
+def test_rel_list_grid_scan(RE, hw):
+    expected_data = []
+    for motor1_pos in [6, 7, 8]:
+        for motor2_pos in [18, 28, 38]:
+            expected_data.append({'motor2': motor2_pos,
+                                  'motor2_setpoint': motor2_pos,
+                                  'det': 1.0,
+                                  'motor1': motor1_pos,
+                                  'motor1_setpoint': motor1_pos})
+
+    hw.motor1.set(5)
+    hw.motor2.set(8)
+    scan = bp.rel_list_grid_scan([hw.det], hw.motor1, [1, 2, 3],
+                                 hw.motor2, [10, 20, 30])
+    multi_traj_checker(RE, scan, expected_data)
+
+
+def test_rel_list_grid_scan_snake(RE, hw):
+    expected_data = []
+    for motor1_pos in [6, 7, 8]:
+        if motor1_pos == 7:
+            motor2_list = [38, 28, 18]
+        else:
+            motor2_list = [18, 28, 38]
+        for motor2_pos in motor2_list:
+            expected_data.append({'motor2': motor2_pos,
+                                  'motor2_setpoint': motor2_pos,
+                                  'det': 1.0,
+                                  'motor1': motor1_pos,
+                                  'motor1_setpoint': motor1_pos})
+
+    hw.motor1.set(5)
+    hw.motor2.set(8)
+    scan = bp.rel_list_grid_scan([hw.det], hw.motor1, [1, 2, 3],
+                                 hw.motor2, [10, 20, 30], snake_axes=True)
+    multi_traj_checker(RE, scan, expected_data)
+
+
+def test_rel_list_grid_scan_snake_list(RE, hw):
+    expected_data = []
+    for motor1_pos in [6, 7, 8]:
+        if motor1_pos == 7:
+            motor2_list = [38, 28, 18]
+        else:
+            motor2_list = [18, 28, 38]
+        for motor2_pos in motor2_list:
+            expected_data.append({'motor2': motor2_pos,
+                                  'motor2_setpoint': motor2_pos,
+                                  'det': 1.0,
+                                  'motor1': motor1_pos,
+                                  'motor1_setpoint': motor1_pos})
+
+    hw.motor1.set(5)
+    hw.motor2.set(8)
+    scan = bp.rel_list_grid_scan([hw.det], hw.motor1, [1, 2, 3],
+                                 hw.motor2, [10, 20, 30],
+                                 snake_axes=[hw.motor2])
+    multi_traj_checker(RE, scan, expected_data)
 
 
 def test_lin_ascan(RE, hw):

--- a/doc/source/plans.rst
+++ b/doc/source/plans.rst
@@ -218,14 +218,15 @@ incorporating these trajectories, use our general N-dimensional scan plan,
    :toctree: generated
    :nosignatures:
 
+   scan
+   rel_scan
    grid_scan
    rel_grid_scan
-   scan_nd
    list_scan
    rel_list_scan
    list_grid_scan
    rel_list_grid_scan
-
+   scan_nd
 
 Spiral trajectories
 -------------------

--- a/doc/source/plans.rst
+++ b/doc/source/plans.rst
@@ -168,15 +168,35 @@ Multi-dimensional scans
 
 See :ref:`tutorial_multiple_motors` in the tutorial for an introduction to the
 common cases of moving multiple motors in coordination (i.e. moving X and Y
-along a diagonal) with :func:`~bluesky.plans.scan` or in a grid with
-:func:`~bluesky.plans.grid_scan` with equal spacing.
+along a diagonal) or in a grid. The key examples are reproduced here. Again,
+see the section linked for further explanation.
 
-Both :func:`~bluesky.plan.scan` and :func:`~bluesky.plans.grid_scan` are built
-on a more general-purpose plan, :func:`~bluesky.plan.scan_nd`, which we can use
-for more specialized cases, such as:
+.. code-block:: python
 
-* grids or trajectories with unequally-spaced steps
-* moving some motors together
+    from ophyd.sim import det, motor1, motor2, motor3
+    from bluesky.plans import scan, grid_scan, list_scan, list_grid_scan
+
+    RE(scan(dets,
+            motor1, -1.5, 1.5,  # scan motor1 from -1.5 to 1.5
+            motor2, -0.1, 0.1,  # ...while scanning motor2 from -0.1 to 0.1
+            11))  # ...both in 11 steps
+
+    # Scan motor1 and motor2 jointly through a 5-point trajectory.
+    RE(list_scan(dets, motor1, [1, 1, 3, 5, 8], motor2, [25, 16, 9, 4, 1]))
+
+    # Scan a 3 x 5 x 2 grid.
+    RE(grid_scan([det],
+                 motor1, -1.5, 1.5, 3,  # no snake parameter for first motor
+                 motor2, -0.1, 0.1, 5, False))
+                 motor3, -200, 200, 5, False))
+
+    # Scan a grid with abitrary spacings given as specific positions.
+    RE(list_grid_scan([det],
+                      motor1, [1, 1, 2, 3, 5],
+                      motor2, [25, 16, 9]))
+
+All of these plans are built on a more general-purpose plan,
+:func:`~bluesky.plan.scan_nd`, which we can use for more specialized cases.
 
 Some jargon: we speak of :func:`~bluesky.plans.scan`-like joint movement as an
 "inner product" of trajectories and :func:`~bluesky.plans.grid_scan`-like

--- a/doc/source/plans.rst
+++ b/doc/source/plans.rst
@@ -44,6 +44,8 @@ documentation.
    rel_scan
    list_scan
    rel_list_scan
+   list_grid_scan
+   rel_list_grid_scan
    log_scan
    rel_log_scan
    grid_scan
@@ -219,6 +221,11 @@ incorporating these trajectories, use our general N-dimensional scan plan,
    grid_scan
    rel_grid_scan
    scan_nd
+   list_scan
+   rel_list_scan
+   list_grid_scan
+   rel_list_grid_scan
+
 
 Spiral trajectories
 -------------------

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -453,6 +453,38 @@ Demo:
 This works for any number of motors, not just two. Try importing ``motor3``
 from ``ophyd.sim`` and running a 3-motor scan.
 
+To move motors along arbitrary trajectories instead of equally-spaced points,
+use :func:`~bluesky.plans.list_scan` and :func:`~bluesky.plans.rel_list_scan`.
+
+.. code-block:: python
+
+    from bluesky.plans import list_scan
+
+    # Scan motor1 and motor2 jointly through a 5-point trajectory.
+    RE(list_scan(dets, motor1, [1, 1, 3, 5, 8], motor2, [25, 16, 9, 4, 1]))
+
+Demo:
+
+.. ipython:: python
+   :suppress:
+
+   from bluesky.plans import list_scan
+
+.. ipython:: python
+
+    RE(list_scan(dets,
+                 motor1, [1, 1, 3, 5, 8],
+                 motor2, [25, 16, 9, 4, 1]))
+
+.. plot::
+
+    from bluesky.plans import list_scan
+    from ophyd.sim import det4, motor1, motor2
+    dets = [det4]
+    RE(list_scan(dets,
+                 motor1, [1, 1, 3, 5, 8],
+                 motor2, [25, 16, 9, 4, 1]))
+
 Scan Multiple Motors in a Grid
 ------------------------------
 
@@ -540,8 +572,42 @@ axes do. Example:
                  motor2, -0.1, 0.1, 5, False))
                  motor3, -200, 200, 5, False))
 
+To move motors along arbitrary trajectories instead of equally-spaced points,
+use :func:`~bluesky.plans.list_grid_scan` and
+:func:`~bluesky.plans.rel_list_grid_scan`.
+
+.. code-block:: python
+
+    from bluesky.plans import list_grid_scan
+
+    RE(list_grid_scan(dets,
+                      motor1, [1, 1, 2, 3, 5],
+                      motor2, [25, 16, 9]))
+
+Demo:
+
+.. ipython:: python
+   :suppress:
+
+   from bluesky.plans import list_grid_scan
+
+.. ipython:: python
+
+    RE(list_grid_scan(dets,
+                      motor1, [1, 1, 2, 3, 5],
+                      motor2, [25, 16, 9]))
+
+.. plot::
+
+    from bluesky.plans import list_grid_scan
+    from ophyd.sim import det4, motor1, motor2
+    dets = [det4]
+    RE(list_grid_scan(dets,
+                      motor1, [1, 1, 2, 3, 5],
+                      motor2, [25, 16, 9]))
+
 See :ref:`multi-dimensional_scans` to handle more specialized cases, including
-unequal step spacing and combinations of :func:`~bluesky.plans.scan`-like and
+combinations of :func:`~bluesky.plans.scan`-like and
 :func:`~bluesky.plans.grid_scan`-like movement.
 
 More generally, the :doc:`plans` documentation includes more exotic


### PR DESCRIPTION
modifying list_scan to accept multiple motor/list pairs

## Description
Current API:
```
list_scan(dets,` motor, [...])  # supports one motor only
scan(dets, motor, start, stop, motor2, start2, stop2, num_steps)  # "inner product" over motors
```
Proposed API:
```
list_scan(dets, motor, [...], motor2, [...])  # If list lengths are unequal, blow up.
list_grid_scan(dets, motor, [...], motor2, [...], motor3, [...], snaking=True|False|tuple)
```
## Motivation and Context
fixes #1144 

## How Has This Been Tested?
has not yet been tested

