### PR TITLE
add test_state_is_readonly

### DIFF
--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -31,6 +31,11 @@ def test_states():
                                                      'paused']
 
 
+def test_state_is_readonly(RE):
+    with pytest.raises(AttributeError):
+        RE.state = 'running'
+
+
 def test_verbose(RE, hw):
     RE.verbose = True
     assert RE.verbose


### PR DESCRIPTION
A unit test verifying RunEngine.state is not assignable.

## Description
def test_state_is_readonly(RE):
    with pytest.raises(AttributeError):
        RE.state = 'running'

## Motivation and Context
This is in support of #1188.
 