### PR TITLE
TST: fix tests with no hints or empty hints

### DIFF
--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -310,7 +310,7 @@ class BestEffortCallback(CallbackBase):
                         MAR = 2
                         if (1/MAR < data_aspect_ratio < MAR):
                             aspect = 'equal'
-                            ax.set_aspect(aspect, adjustable='box-forced')
+                            ax.set_aspect(aspect, adjustable='box')
                         else:
                             aspect = 'auto'
                             ax.set_aspect(aspect, adjustable='datalim')

--- a/bluesky/tests/test_simple_api.py
+++ b/bluesky/tests/test_simple_api.py
@@ -57,7 +57,6 @@ def test_plans(RE, pln, args, kwargs, hw):
     (bp.rel_spiral_fermat,
      ('motor_no_hints1', 'motor_no_hints2', 0.3, 0.3, 0.05, 3), {}),
     ])
-@pytest.mark.xfail
 def test_plans_motors_no_hints(RE, pln, args, kwargs, hw):
     args = tuple(getattr(hw, v, v) if isinstance(v, str) else v
                  for v in args)
@@ -71,22 +70,20 @@ def test_plans_motors_no_hints(RE, pln, args, kwargs, hw):
 
 @pytest.mark.parametrize('pln,args,kwargs', [
     # repeat with motor objects that have empty hints
-    (bp.scan, ('motor1', 1, 2, 2), {}),
-    (bp.inner_product_scan, (2, 'motor1', 1, 2), {}),
-    (bp.relative_inner_product_scan, (2, 'motor1', 1, 2), {}),
-    (bp.grid_scan, ('motor1', 1, 2, 2, 'motor2', 1, 2, 3, False), {}),
-    (bp.spiral, ('motor1', 'motor2', 0.0, 0.0, 0.3, 0.3, 0.05, 3), {}),
-    (bp.rel_spiral, ('motor1', 'motor2', 0.3, 0.3, 0.05, 3), {}),
-    (bp.spiral_fermat, ('motor1', 'motor2', 0.0, 0.0, 0.3, 0.3, 0.05, 3), {}),
-    (bp.rel_spiral_fermat, ('motor1', 'motor2', 0.3, 0.3, 0.05, 3), {}),
+    (bp.scan, ('motor_empty_hints1', 1, 2, 2), {}),
+    (bp.inner_product_scan, (2, 'motor_empty_hints1', 1, 2), {}),
+    (bp.relative_inner_product_scan, (2, 'motor_empty_hints1', 1, 2), {}),
+    (bp.grid_scan, ('motor_empty_hints1', 1, 2, 2, 'motor_empty_hints2', 1, 2, 3, False), {}),
+    (bp.spiral, ('motor_empty_hints1', 'motor_empty_hints2', 0.0, 0.0, 0.3, 0.3, 0.05, 3), {}),
+    (bp.rel_spiral, ('motor_empty_hints1', 'motor_empty_hints2', 0.3, 0.3, 0.05, 3), {}),
+    (bp.spiral_fermat, ('motor_empty_hints1', 'motor_empty_hints2', 0.0, 0.0, 0.3, 0.3, 0.05, 3), {}),
+    (bp.rel_spiral_fermat, ('motor_empty_hints1', 'motor_empty_hints2', 0.3, 0.3, 0.05, 3), {}),
     ])
-@pytest.mark.xfail
 def test_plans_motor_empty_hints(RE, pln, args, kwargs, hw):
     args = tuple(getattr(hw, v, v) if isinstance(v, str) else v
                  for v in args)
     for v in args:
         if hasattr(v, 'hints'):
-            v.hints = {}
             assert v.hints == {}
     det = hw.det
     bec = BestEffortCallback()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is to resolve xfail-ing tests introduced in https://github.com/bluesky/bluesky/commit/32bd8f5c2bf3c599415355f23b3d592dfc5bb2ef. Depends on https://github.com/bluesky/ophyd/pull/725.

Another update: fix a deprecated `box-forced` in bec.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Failing tests are annoying.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally successfully.

<!--
## Screenshots (if appropriate):
-->
