### PR TITLE
New jsonschema types api #1197

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - python: 3.5
     - python: 3.6
       env: PUBLISH_DOCS=1
     - python: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
 
 install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`
+  - pip install --upgrade pip
   - pip install --upgrade cython
   - pip install --quiet --upgrade --global-option='--without-libyaml' pyyaml
   - pip install -r requirements.txt

--- a/bluesky/callbacks/stream.py
+++ b/bluesky/callbacks/stream.py
@@ -2,31 +2,12 @@ import logging
 import time as ttime
 from collections import Iterable, ChainMap
 
-import jsonschema
 import numpy as np
-from event_model import DocumentNames, schemas
+from event_model import DocumentNames, schema_validators
 
 from .core import CallbackBase
 from ..run_engine import Dispatcher
 from ..utils import new_uid
-
-
-def is_array(checker, instance):
-    return (
-        jsonschema.validators.Draft7Validator.TYPE_CHECKER.is_type(instance, 'array') or
-        isinstance(instance, tuple)
-    )
-
-
-array_type_checker = jsonschema.validators.Draft7Validator.TYPE_CHECKER.redefine('array', is_array)
-
-
-_Validator = jsonschema.validators.extend(
-    jsonschema.validators.Draft7Validator,
-    type_checker=array_type_checker)
-
-
-schema_validators = {name: _Validator(schema=schema) for name, schema in schemas.items()}
 
 
 class LiveDispatcher(CallbackBase):

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -12,8 +12,7 @@ import functools
 import inspect
 from contextlib import ExitStack
 
-import jsonschema
-from event_model import DocumentNames, schemas
+from event_model import DocumentNames, schema_validators
 from super_state_machine.machines import StateMachine
 from super_state_machine.extras import PropertyMachine
 from super_state_machine.errors import TransitionError
@@ -24,24 +23,6 @@ from .utils import (CallbackRegistry, SigintHandler, normalize_subs_input,
                     IllegalMessageSequence, FailedPause, FailedStatus,
                     InvalidCommand, PlanHalt, Msg, ensure_generator,
                     single_gen, short_uid)
-
-
-def is_array(checker, instance):
-    return (
-        jsonschema.validators.Draft7Validator.TYPE_CHECKER.is_type(instance, 'array') or
-        isinstance(instance, tuple)
-    )
-
-
-array_type_checker = jsonschema.validators.Draft7Validator.TYPE_CHECKER.redefine('array', is_array)
-
-
-_Validator = jsonschema.validators.extend(
-    jsonschema.validators.Draft7Validator,
-    type_checker=array_type_checker)
-
-
-schema_validators = {name: _Validator(schema=schema) for name, schema in schemas.items()}
 
 
 class RunEngineStateMachine(StateMachine):

--- a/bluesky/tests/test_documents.py
+++ b/bluesky/tests/test_documents.py
@@ -1,7 +1,6 @@
 import pytest
 import jsonschema
-from bluesky.run_engine import RunEngine
-from event_model import DocumentNames, schemas
+from event_model import DocumentNames, schema_validators
 from bluesky.utils import new_uid
 from bluesky.examples import simple_scan
 
@@ -19,14 +18,14 @@ def test_custom_metadata(RE, hw):
 def test_dots_not_allowed_in_keys():
     doc = {'time': 0,
            'uid': new_uid()}
-    jsonschema.validate(doc, schemas[DocumentNames.start])
+    schema_validators[DocumentNames.start].validate(doc)
     # Add a legal key.
     doc.update({'b': 'c'})
-    jsonschema.validate(doc, schemas[DocumentNames.start])
+    schema_validators[DocumentNames.start].validate(doc)
     # Now add illegal key.
     doc.update({'b.': 'c'})
     with pytest.raises(jsonschema.ValidationError):
-        jsonschema.validate(doc, schemas[DocumentNames.start])
+        schema_validators[DocumentNames.start].validate(doc)
 
     doc = {'time': 0,
            'uid': new_uid(),
@@ -34,25 +33,25 @@ def test_dots_not_allowed_in_keys():
                                'dtype': 'number',
                                'shape': []}},
            'run_start': new_uid()}
-    jsonschema.validate(doc, schemas[DocumentNames.descriptor])
+    schema_validators[DocumentNames.descriptor].validate(doc)
     # Add a legal key.
     doc.update({'b': 'c'})
-    jsonschema.validate(doc, schemas[DocumentNames.descriptor])
+    schema_validators[DocumentNames.descriptor].validate(doc)
     # Now add illegal key.
     doc.update({'b.c': 'd'})
     with pytest.raises(jsonschema.ValidationError):
-        jsonschema.validate(doc, schemas[DocumentNames.descriptor])
+        schema_validators[DocumentNames.descriptor].validate(doc)
 
     doc = {'time': 0,
            'uid': new_uid(),
            'exit_status': 'success',
            'reason': '',
            'run_start': new_uid()}
-    jsonschema.validate(doc, schemas[DocumentNames.stop])
+    schema_validators[DocumentNames.stop].validate(doc)
     # Add a legal key.
     doc.update({'b': 'c'})
-    jsonschema.validate(doc, schemas[DocumentNames.stop])
+    schema_validators[DocumentNames.stop].validate(doc)
     # Now add illegal key.
     doc.update({'.b': 'c'})
     with pytest.raises(jsonschema.ValidationError):
-        jsonschema.validate(doc, schemas[DocumentNames.stop])
+        schema_validators[DocumentNames.stop].validate(doc)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 cycler
 event-model>=1.5.0,!=1.8.0
 historydict
-jsonschema
 numpy
 super_state_machine
 toolz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cycler
-event-model>=1.5.0,!=1.8.0
+event-model==1.10.0rc1
 historydict
 numpy
 super_state_machine

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cycler
-event-model>=1.10.0rc1
+event-model>=1.10.0
 historydict
 numpy
 super_state_machine

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cycler
 event-model>=1.5.0,!=1.8.0
 historydict
-jsonschema<3
+jsonschema
 numpy
 super_state_machine
 toolz


### PR DESCRIPTION
This PR depends on https://github.com/bluesky/event-model/pull/79.
Replace calls to deprecated jsonschema.validate() with sanctioned jsonschema.Validator.validate().

## Description
Use a dict of jsonschema.Validator imported from event-model.
Remove jsonschema<3 pin from requirements.txt.

## Motivation and Context
This change is simply to get away from the deprecated jsonschema.validate().

## How Has This Been Tested?
Existing tests pass.