### PR TITLE
BLD: Add python_requires.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     package_data={'bluesky': ['schema/*.json']},
     scripts=glob.glob('scripts/*'),
+    python_requires='>=3.6',
     install_requires=requirements,
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
This field in `setup(...)`, now part of our standard cookiecutter for
new projects, was never added to bluesky.