### PR TITLE
validate num argument in scan() (fixes issue #1198)

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -805,6 +805,12 @@ def scan(detectors, *args, num=None, per_step=None, md=None):
                              "argument 'num'.")
         num = args[-1]
         args = args[:-1]
+
+    if not (float(num).is_integer() and num > 0.0):
+        raise ValueError(f"The parameter `num` is expected to be a number of steps (not step size!) "
+                         f"It must therefore be a whole number. The given value was {num}.")
+    num = int(num)
+
     md_args = list(chain(*((repr(motor), start, stop)
                            for motor, start, stop in partition(3, args))))
     motor_names = tuple(motor.name for motor, start, stop

--- a/bluesky/tests/test_scans.py
+++ b/bluesky/tests/test_scans.py
@@ -8,6 +8,20 @@ import numpy.testing
 import pytest
 
 
+def test_scan_num(RE, hw):
+    RE(bp.scan([hw.det], hw.motor1, -1, 1, num=1))
+    RE(bp.scan([hw.det], hw.motor1, -1, 1, num=1.0))
+
+    with pytest.raises(ValueError):
+        RE(bp.scan([hw.det], hw.motor1, -1, 1, num=0))
+
+    with pytest.raises(ValueError):
+        RE(bp.scan([hw.det], hw.motor1, -1, 1, num=0.5))
+
+    with pytest.raises(ValueError):
+        RE(bp.scan([hw.det], hw.motor1, -1, 1, num=float('nan')))
+
+
 def traj_checker(RE, scan, expected_traj):
     actual_traj = []
     callback = collector('motor', actual_traj)


### PR DESCRIPTION
Add some validation for argument `num` in `bluesky.plans.scan()` and a unit test.

## Description
@danielballan proposed this addition to scan() in response to issue #1198:
```python
if not (float(num).is_integer() and num > 0):
    raise ValueError(f"The parameter `num` is expected to be a number of steps (not step size!) "
                     f"It must therefore be a whole number. The given value was {num}.")
```
After making this change and running a test with `num=1.0` this warning was issued:
```
======================================= warnings summary =======================================
bluesky/tests/test_scans.py::test_scan_num
  /home/jlynch/host/project/bluesky/bluesky/plan_patterns.py:293: DeprecationWarning: object of type <class 'float'> cannot be safely interpreted as an integer.
    steps = np.linspace(start, stop, num=num, endpoint=True)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================ 26 passed, 1 warnings in 8.07 seconds =============================
```
This is just a warning but I propose to resolve it with an additional line in `scan()` that will always convert `num` to an integer:
```python
if not (float(num).is_integer() and num > 0):
    raise ValueError(f"The parameter `num` is expected to be a number of steps (not step size!) "
                     f"It must therefore be a whole number. The given value was {num}.")
num = int(num)
```

## Motivation and Context
This change is intended to fix issue #1198.

## How Has This Been Tested?
I have added a test to `test_scans.py` - but is this the correct place for it?
```python
def test_scan_num(RE, hw):
    RE(bp.scan([hw.det], hw.motor1, -1, 1, num=1))
    RE(bp.scan([hw.det], hw.motor1, -1, 1, num=1.0))

    with pytest.raises(ValueError):
        RE(bp.scan([hw.det], hw.motor1, -1, 1, num=0))

    with pytest.raises(ValueError):
        RE(bp.scan([hw.det], hw.motor1, -1, 1, num=0.5))

    with pytest.raises(ValueError):
        RE(bp.scan([hw.det], hw.motor1, -1, 1, num=float('nan')))
```
<!--
## Screenshots (if appropriate):
-->
