### PR TITLE
change https://travis-ci.org/NSLS-II to https://travis-ci.org/bluesky

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 bluesky
 =======
 
-[![Build Status](https://travis-ci.org/NSLS-II/bluesky.svg)](https://travis-ci.org/NSLS-II/bluesky)
+[![Build Status](https://travis-ci.org/bluesky/bluesky.svg)](https://travis-ci.org/bluesky/bluesky)
 
 a Python data collection interface for experimental science
 


### PR DESCRIPTION
Update link to Travis-CI build badge. This fixes issue #1210.

## Description
Changed https://travis-ci.org/NSLS-II to https://travis-ci.org/bluesky.
Are there other links on this page in need of update?

## Screen Shots
![Screen Shot 2019-06-03 at 9 43 41 AM](https://user-images.githubusercontent.com/4492613/58806434-2cabb900-85e4-11e9-9c74-76ef201e568c.png)

![Screen Shot 2019-06-03 at 9 46 59 AM](https://user-images.githubusercontent.com/4492613/58806620-962bc780-85e4-11e9-8502-6f34a7163a54.png)
