### PR TITLE
FIX: Include 'extents' in list_grid_scan md.

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -270,6 +270,8 @@ def list_grid_scan(detectors, *args, snake_axes=False, per_step=None, md=None):
         motors.append(motor)
     _md = {'shape': tuple(len(pos_list)
                           for motor, pos_list in partition(2, args)),
+           'extents': tuple([min(pos_list), max(pos_list)]
+                            for motor, pos_list in partition(2, args)),
            'snake_axes': snake_axes,
            'plan_args': {'detectors': list(map(repr, detectors)),
                          'args': md_args,

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -285,7 +285,6 @@ def list_grid_scan(detectors, *args, snake_axes=False, per_step=None, md=None):
            'hints': {},
            }
     _md.update(md or {})
-    _md['hints'].setdefault('gridding', 'rectilinear')
     try:
         _md['hints'].setdefault('dimensions', [(m.hints['fields'], 'primary')
                                                for m in motors])


### PR DESCRIPTION
The ``LiveGrid`` callback (and presumably other consumers yet to be
written) makes use of the ``'extents'`` metadata from ``grid_scan``. The
new plan ``list_grid_scan`` should include ``'extents'`` as well.

Follow up on #1190.