### PR TITLE
change default serialization for ZMQ to msgpack

### DIFF
--- a/bluesky/callbacks/zmq.py
+++ b/bluesky/callbacks/zmq.py
@@ -1,9 +1,6 @@
 import asyncio
 import copy
-import multiprocessing
 import pickle
-import socket
-import time
 import warnings
 from ..run_engine import Dispatcher, DocumentNames
 

--- a/bluesky/callbacks/zmq.py
+++ b/bluesky/callbacks/zmq.py
@@ -2,7 +2,15 @@ import asyncio
 import copy
 import pickle
 import warnings
+
+import msgpack
+import msgpack_numpy
+
 from ..run_engine import Dispatcher, DocumentNames
+
+
+def msgpack_serialize(document)
+    return msgpack.packb(document, default=msgpack_numpy.encode)
 
 
 class Publisher:
@@ -37,7 +45,7 @@ class Publisher:
     >>> RE.subscribe(publisher)
     """
     def __init__(self, address, *, prefix=b'',
-                 RE=None, zmq=None, serializer=pickle.dumps):
+                 RE=None, zmq=None, serializer=msgpack_serialize):
         if RE is not None:
             warnings.warn("The RE argument to Publisher is deprecated and "
                           "will be removed in a future release of bluesky. "

--- a/bluesky/callbacks/zmq.py
+++ b/bluesky/callbacks/zmq.py
@@ -1,16 +1,12 @@
 import asyncio
 import copy
-import pickle
+from functools import partial
 import warnings
 
 import msgpack
 import msgpack_numpy
 
 from ..run_engine import Dispatcher, DocumentNames
-
-
-def msgpack_serialize(document)
-    return msgpack.packb(document, default=msgpack_numpy.encode)
 
 
 class Publisher:
@@ -45,7 +41,10 @@ class Publisher:
     >>> RE.subscribe(publisher)
     """
     def __init__(self, address, *, prefix=b'',
-                 RE=None, zmq=None, serializer=msgpack_serialize):
+                 RE=None, zmq=None,
+                 serializer=partial(msgpack.packb,
+                                    use_bin_type=True,
+                                    default=msgpack_numpy.encode)):
         if RE is not None:
             warnings.warn("The RE argument to Publisher is deprecated and "
                           "will be removed in a future release of bluesky. "
@@ -224,7 +223,10 @@ class RemoteDispatcher(Dispatcher):
     """
     def __init__(self, address, *, prefix=b'',
                  loop=None, zmq=None, zmq_asyncio=None,
-                 deserializer=pickle.loads):
+                 deserializer=partial(msgpack.unpackb,
+                                      use_list=True,
+                                      raw=False,
+                                      object_hook=msgpack_numpy.decode)):
         if isinstance(prefix, str):
             raise ValueError("prefix must be bytes, not string")
         if b' ' in prefix:


### PR DESCRIPTION
This PR sets default serialization for ZMQ to msgpack. **This change breaks two unit tests because msgpack does not distinguish lists from tuples.** Deserialized data can have lists or tuples but not both.

The default value for bluesky.callbacks.zmq.Publisher is set to 
 ```python
serializer=partial(
    msgpack.packb,
    use_bin_type=True,
    default=msgpack_numpy.encode)
```
The default value for bluesky.callbacks.zmq.RemoteDispatcher is set to
```python
deserializer=partial(
    msgpack.unpackb,
    use_list=True,
    raw=False,
    object_hook=msgpack_numpy.decode)
```

## Motivation and Context
This change addresses issue #1207. 

## How Has This Been Tested?
All bluesky unit tests pass except test_zmq() and test_zmq_prefix().

This is the pytest output of the problematic deserialization done both ways.

First with `msgpack.unpackb(..., use_list=True)`:
```python
E         [('start',
E         {'detectors': ['det'],
E         -    'hints': {'dimensions': [[['time'], 'primary']]},   <- output from msgpack.unpackb
E         ?                             ^^      -           ^
E         +    'hints': {'dimensions': [(('time',), 'primary')]},  <- input to msgpack.packb
E         ?                             ^^       ++          ^
E         'num_intervals': 0,
E         'num_points': 1,
```
Now with `msgpack.unpackb(..., use_list=False)`.
```python
E         Full diff:
E         [('start',
E         -   {'detectors': ('det',),  <- output from msgpack.unpackb
E         ?                 ^      --
E         +   {'detectors': ['det'],   <- input to msgpack.packb
E         ?                 ^     +
E         -    'hints': {'dimensions': ((('time',), 'primary'),)},  <- output from msgpack.unpackb
E         ?                            ^                      ^^
E         +    'hints': {'dimensions': [(('time',), 'primary')]},   <- input to msgpack.packb
E         ?                            ^                      ^
E         'num_intervals': 0,
E         'num_points': 1,
```