### PR TITLE
Clean up sigint test and skip on OSX on travis

### DIFF
--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -578,7 +578,7 @@ def test_sigint_three_hits(RE, hw):
 
     pid = os.getpid()
 
-    def sim_kill(n=1):
+    def sim_kill(n):
         for j in range(n):
             time.sleep(.02)
             os.kill(pid, signal.SIGINT)
@@ -588,8 +588,6 @@ def test_sigint_three_hits(RE, hw):
 
     def self_sig_int_plan():
         threading.Timer(.05, sim_kill, (3,)).start()
-        threading.Timer(.1, sim_kill, (3,)).start()
-        threading.Timer(.2, sim_kill, (3,)).start()
         yield from abs_set(motor, 1, wait=True)
 
     start_time = ttime.time()

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -574,7 +574,7 @@ def test_cleanup_after_pause(RE, unpause_func, hw):
 def test_sigint_three_hits(RE, hw):
     import time
     motor = hw.motor
-    motor.delay = 1
+    motor.delay = .5
 
     pid = os.getpid()
 
@@ -595,10 +595,13 @@ def test_sigint_three_hits(RE, hw):
         RE(finalize_wrapper(self_sig_int_plan(),
                             abs_set(motor, 0, wait=True)))
     end_time = ttime.time()
-    assert end_time - start_time < 0.2  # not enough time for motor to cleanup
+    # not enough time for motor to cleanup, but long enough to start
+    assert 0.05 < end_time - start_time < 0.2
     RE.abort()  # now cleanup
+
     done_cleanup_time = ttime.time()
-    assert done_cleanup_time - end_time > 0.3
+    # this should be 0.5 (the motor.delay) above, leave sloppy for CI
+    assert 0.6 > done_cleanup_time - end_time > 0.3
 
 
 @pytest.mark.skipif(sys.version_info < (3, 5),

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -580,7 +580,7 @@ def test_sigint_three_hits(RE, hw):
 
     def sim_kill(n):
         for j in range(n):
-            time.sleep(.02)
+            time.sleep(.05)
             os.kill(pid, signal.SIGINT)
 
     lp = RE.loop

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -571,6 +571,10 @@ def test_cleanup_after_pause(RE, unpause_func, hw):
     assert motor.position == 1024
 
 
+@pytest.mark.skipif(
+    os.environ.get('TRAVIS', None) == 'true' and sys.platform == 'darwin',
+    reason=("The file-descriptor wake up based signal handling "
+            "does not work on travis on OSX"))
 def test_sigint_three_hits(RE, hw):
     import time
     motor = hw.motor

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -605,7 +605,7 @@ def test_sigint_three_hits(RE, hw):
 
     done_cleanup_time = ttime.time()
     # this should be 0.5 (the motor.delay) above, leave sloppy for CI
-    assert 0.6 > done_cleanup_time - end_time > 0.3
+    assert 0.3 < done_cleanup_time - end_time < 0.6
 
 
 @pytest.mark.skipif(sys.version_info < (3, 5),

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -585,14 +585,16 @@ def test_sigint_three_hits(RE, hw):
 
     lp = RE.loop
     motor.loop = lp
-    start = time.monotonic()
-    threading.Timer(.05, sim_kill, (3,)).start()
-    threading.Timer(.1, sim_kill, (3,)).start()
-    threading.Timer(.2, sim_kill, (3,)).start()
+
+    def self_sig_int_plan():
+        threading.Timer(.05, sim_kill, (3,)).start()
+        threading.Timer(.1, sim_kill, (3,)).start()
+        threading.Timer(.2, sim_kill, (3,)).start()
+        yield from abs_set(motor, 1, wait=True)
 
     start_time = ttime.time()
     with pytest.raises(RunEngineInterrupted):
-        RE(finalize_wrapper(abs_set(motor, 1, wait=True),
+        RE(finalize_wrapper(self_sig_int_plan(),
                             abs_set(motor, 0, wait=True)))
     end_time = ttime.time()
     assert end_time - start_time < 0.2  # not enough time for motor to cleanup


### PR DESCRIPTION
<!--- Describe your changes in detail -->

It was noted that we would sometimes see rouge SIGINTs escaping from
the test suite which would pre-maturely exit the tests.  On further
investigation we found

 1. there was a race condition in the tests that gave a window for the
    killer threads to fire when our context manager was not in place
    and hence the SIGINT would raise a KeybroardIntreupt someplace
    else in the test (sometimes in the pytest / coverage machinery)
 2. the file descriptor wake-up machinery does not work on OSX on
    travis (see #1215 for attempts to debug this).  It works exactly
    as expected on linux on travis and locally and locally on OSX.

This PR cleans the test up and skips it on OSX on travis.