### PR TITLE
TST: Fix our usage of pytest ExceptionInfo.

### DIFF
--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -667,18 +667,18 @@ def test_per_step(RE, hw):
     # that the problem is with 'per_step':
 
     # You can't usage one_1d_step signature with more than one motor.
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(TypeError) as excinfo:
         RE(scan([hw.det],
                 hw.motor, -1, 1,
                 hw.motor2, -1, 1,
                 3,
                 per_step=one_1d_step))
-    assert "Signature of per_step assumes 1D trajectory" in str(exc)
+    assert excinfo.match("Signature of per_step assumes 1D trajectory")
 
     # The signature must be either like one_1d_step or one_nd_step:
     def bad_sig(detectors, mtr, step):
         ...
 
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(TypeError) as excinfo:
         RE(scan([hw.det], hw.motor, -1, 1, 3, per_step=bad_sig))
-    assert "per_step must be a callable with the signature" in str(exc)
+    assert excinfo.match("per_step must be a callable with the signature")


### PR DESCRIPTION
One test has started failing consistently on the OSX builds, and the
cause is a pytest major release that dropped on June 28. Travis' Ubuntu
virtual machines come with an older version of pytest included, and we do not
force it to upgrade, so we have only encountered this on the OSX builds
so far.

The usage

```python
with pytest.raises(Exception) as exc
```

puts an [``ExceptionInfo``](https://docs.pytest.org/en/latest/reference.html#exceptioninfo)
object into ``exc``, not the exception itself. We were trying ``exc``
like an exception object and relying on the fact that
``ExceptionInfo.__str__`` returned the same thing as ``exc.__str__``
would. The
[pytest 5.0.0 release](https://docs.pytest.org/en/latest/changelog.html#pytest-5-0-0-2019-06-28)
broke that assumption. See https://github.com/pytest-dev/pytest/issues/5412.