### PR TITLE
Fix: BestEffortCallback - table is always printed

### DIFF
--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -174,173 +174,176 @@ class BestEffortCallback(QtAwareCallback):
                 fixed_dim_fields.extend(fields)
             self.dim_fields = fixed_dim_fields
 
-
-        # ## DECIDE WHICH KIND OF PLOT CAN BE USED ## #
-
-        if not self._plots_enabled:
-            return
-        if stream_name in self.noplot_streams:
-            return
-        if not columns:
-            return
-        if ((self._start_doc.get('num_points') == 1) and
-                (stream_name == self.dim_stream) and
-                self.omit_single_point_plot):
-            return
-
-        # This is a heuristic approach until we think of how to hint this in a
-        # generalizable way.
-        if stream_name == self.dim_stream:
-            dim_fields = self.dim_fields
-        else:
-            dim_fields = ['time']  # 'time' once LivePlot can do that
-
-        # Create a figure or reuse an existing one.
-
-        fig_name = '{} vs {}'.format(' '.join(sorted(columns)),
-                                     ' '.join(sorted(dim_fields)))
-        if self.overplot and len(dim_fields) == 1:
-            # If any open figure matches 'figname {number}', use it. If there
-            # are multiple, the most recently touched one will be used.
-            pat1 = re.compile('^' + fig_name + '$')
-            pat2 = re.compile('^' + fig_name + r' \d+$')
-            for label in plt.get_figlabels():
-                if pat1.match(label) or pat2.match(label):
-                    fig_name = label
-                    break
-        else:
-            if plt.fignum_exists(fig_name):
-                # Generate a unique name by appending a number.
-                for number in itertools.count(2):
-                    new_name = '{} {}'.format(fig_name, number)
-                    if not plt.fignum_exists(new_name):
-                        fig_name = new_name
-                        break
-        ndims = len(dim_fields)
-        if not 0 < ndims < 3:
-            # we need 1 or 2 dims to do anything, do not make empty figures
-            return
-
-        if self._fig_factory:
-            fig = self._fig_factory(fig_name)
-        else:
-            fig = plt.figure(fig_name)
-        if not fig.axes:
-            # This is apparently a fresh figure. Make axes.
-            # The complexity here is due to making a shared x axis. This can be
-            # simplified when Figure supports the `subplots` method in a future
-            # release of matplotlib.
-            fig.set_size_inches(6.4, min(950, len(columns) * 400) / fig.dpi)
-            for i in range(len(columns)):
-                if i == 0:
-                    ax = fig.add_subplot(len(columns), 1, 1 + i)
-                    if ndims == 1:
-                        share_kwargs = {'sharex': ax}
-                    elif ndims == 2:
-                        share_kwargs = {'sharex': ax, 'sharey': ax}
-                    else:
-                        raise NotImplementedError("we now support 3D?!")
-                else:
-                    ax = fig.add_subplot(len(columns), 1, 1 + i,
-                                         **share_kwargs)
-        axes = fig.axes
-
         # Ensure that no independent variables ('dimensions') are
         # duplicated here.
         columns = [c for c in columns if c not in self.all_dim_fields]
 
-        # ## LIVE PLOT AND PEAK ANALYSIS ## #
+        # ## DECIDE WHICH KIND OF PLOT CAN BE USED ## #
 
-        if ndims == 1:
-            self._live_plots[doc['uid']] = {}
-            self._peak_stats[doc['uid']] = {}
-            x_key, = dim_fields
-            for y_key, ax in zip(columns, axes):
-                dtype = doc['data_keys'][y_key]['dtype']
-                if dtype not in ('number', 'integer'):
-                    warn("Omitting {} from plot because dtype is {}"
-                         "".format(y_key, dtype))
-                    continue
-                # Create an instance of LivePlot and an instance of PeakStats.
-                live_plot = LivePlotPlusPeaks(y=y_key, x=x_key, ax=ax,
-                                              peak_results=self.peaks)
-                live_plot('start', self._start_doc)
-                live_plot('descriptor', doc)
-                peak_stats = PeakStats(x=x_key, y=y_key)
-                peak_stats('start', self._start_doc)
-                peak_stats('descriptor', doc)
+        plot_data = True
 
-                # Stash them in state.
-                self._live_plots[doc['uid']][y_key] = live_plot
-                self._peak_stats[doc['uid']][y_key] = peak_stats
+        if not self._plots_enabled:
+            plot_data = False
+        if stream_name in self.noplot_streams:
+            plot_data = False
+        if not columns:
+            plot_data = False
+        if ((self._start_doc.get('num_points') == 1) and
+                (stream_name == self.dim_stream) and
+                self.omit_single_point_plot):
+            plot_data = False
 
-            for ax in axes[:-1]:
-                ax.set_xlabel('')
-        elif ndims == 2:
-            # Decide whether to use LiveGrid or LiveScatter. LiveScatter is the
-            # safer one to use, so it is the fallback..
-            gridding = self._start_doc.get('hints', {}).get('gridding')
-            if gridding == 'rectilinear':
-                self._live_grids[doc['uid']] = {}
-                slow, fast = dim_fields
-                try:
-                    extents = self._start_doc['extents']
-                    shape = self._start_doc['shape']
-                except KeyError:
-                    warn("Need both 'shape' and 'extents' in plan metadata to "
-                         "create LiveGrid.")
-                else:
-                    data_range = np.array([float(np.diff(e)) for e in extents])
-                    y_step, x_step = data_range / [max(1, s - 1) for s in shape]
-                    adjusted_extent = [extents[1][0] - x_step / 2,
-                                       extents[1][1] + x_step / 2,
-                                       extents[0][0] - y_step / 2,
-                                       extents[0][1] + y_step / 2]
-                    for I_key, ax in zip(columns, axes):
-                        # MAGIC NUMBERS based on what tacaswell thinks looks OK
-                        data_aspect_ratio = np.abs(data_range[1]/data_range[0])
-                        MAR = 2
-                        if (1/MAR < data_aspect_ratio < MAR):
-                            aspect = 'equal'
-                            ax.set_aspect(aspect, adjustable='box')
-                        else:
-                            aspect = 'auto'
-                            ax.set_aspect(aspect, adjustable='datalim')
+        if plot_data:
 
-                        live_grid = LiveGrid(shape, I_key,
-                                             xlabel=fast, ylabel=slow,
-                                             extent=adjusted_extent,
-                                             aspect=aspect,
-                                             ax=ax)
-
-                        live_grid('start', self._start_doc)
-                        live_grid('descriptor', doc)
-                        self._live_grids[doc['uid']][I_key] = live_grid
+            # This is a heuristic approach until we think of how to hint this in a
+            # generalizable way.
+            if stream_name == self.dim_stream:
+                dim_fields = self.dim_fields
             else:
-                self._live_scatters[doc['uid']] = {}
-                x_key, y_key = dim_fields
-                for I_key, ax in zip(columns, axes):
+                dim_fields = ['time']  # 'time' once LivePlot can do that
+
+            # Create a figure or reuse an existing one.
+
+            fig_name = '{} vs {}'.format(' '.join(sorted(columns)),
+                                        ' '.join(sorted(dim_fields)))
+            if self.overplot and len(dim_fields) == 1:
+                # If any open figure matches 'figname {number}', use it. If there
+                # are multiple, the most recently touched one will be used.
+                pat1 = re.compile('^' + fig_name + '$')
+                pat2 = re.compile('^' + fig_name + r' \d+$')
+                for label in plt.get_figlabels():
+                    if pat1.match(label) or pat2.match(label):
+                        fig_name = label
+                        break
+            else:
+                if plt.fignum_exists(fig_name):
+                    # Generate a unique name by appending a number.
+                    for number in itertools.count(2):
+                        new_name = '{} {}'.format(fig_name, number)
+                        if not plt.fignum_exists(new_name):
+                            fig_name = new_name
+                            break
+            ndims = len(dim_fields)
+            if not 0 < ndims < 3:
+                # we need 1 or 2 dims to do anything, do not make empty figures
+                return
+
+            if self._fig_factory:
+                fig = self._fig_factory(fig_name)
+            else:
+                fig = plt.figure(fig_name)
+            if not fig.axes:
+                # This is apparently a fresh figure. Make axes.
+                # The complexity here is due to making a shared x axis. This can be
+                # simplified when Figure supports the `subplots` method in a future
+                # release of matplotlib.
+                fig.set_size_inches(6.4, min(950, len(columns) * 400) / fig.dpi)
+                for i in range(len(columns)):
+                    if i == 0:
+                        ax = fig.add_subplot(len(columns), 1, 1 + i)
+                        if ndims == 1:
+                            share_kwargs = {'sharex': ax}
+                        elif ndims == 2:
+                            share_kwargs = {'sharex': ax, 'sharey': ax}
+                        else:
+                            raise NotImplementedError("we now support 3D?!")
+                    else:
+                        ax = fig.add_subplot(len(columns), 1, 1 + i,
+                                            **share_kwargs)
+            axes = fig.axes
+
+            # ## LIVE PLOT AND PEAK ANALYSIS ## #
+
+            if ndims == 1:
+                self._live_plots[doc['uid']] = {}
+                self._peak_stats[doc['uid']] = {}
+                x_key, = dim_fields
+                for y_key, ax in zip(columns, axes):
+                    dtype = doc['data_keys'][y_key]['dtype']
+                    if dtype not in ('number', 'integer'):
+                        warn("Omitting {} from plot because dtype is {}"
+                            "".format(y_key, dtype))
+                        continue
+                    # Create an instance of LivePlot and an instance of PeakStats.
+                    live_plot = LivePlotPlusPeaks(y=y_key, x=x_key, ax=ax,
+                                                peak_results=self.peaks)
+                    live_plot('start', self._start_doc)
+                    live_plot('descriptor', doc)
+                    peak_stats = PeakStats(x=x_key, y=y_key)
+                    peak_stats('start', self._start_doc)
+                    peak_stats('descriptor', doc)
+
+                    # Stash them in state.
+                    self._live_plots[doc['uid']][y_key] = live_plot
+                    self._peak_stats[doc['uid']][y_key] = peak_stats
+
+                for ax in axes[:-1]:
+                    ax.set_xlabel('')
+            elif ndims == 2:
+                # Decide whether to use LiveGrid or LiveScatter. LiveScatter is the
+                # safer one to use, so it is the fallback..
+                gridding = self._start_doc.get('hints', {}).get('gridding')
+                if gridding == 'rectilinear':
+                    self._live_grids[doc['uid']] = {}
+                    slow, fast = dim_fields
                     try:
                         extents = self._start_doc['extents']
+                        shape = self._start_doc['shape']
                     except KeyError:
-                        xlim = ylim = None
+                        warn("Need both 'shape' and 'extents' in plan metadata to "
+                            "create LiveGrid.")
                     else:
-                        xlim, ylim = extents
-                    live_scatter = LiveScatter(x_key, y_key, I_key,
-                                               xlim=xlim, ylim=ylim,
-                                               # Let clim autoscale.
-                                               ax=ax)
-                    live_scatter('start', self._start_doc)
-                    live_scatter('descriptor', doc)
-                    self._live_scatters[doc['uid']][I_key] = live_scatter
+                        data_range = np.array([float(np.diff(e)) for e in extents])
+                        y_step, x_step = data_range / [max(1, s - 1) for s in shape]
+                        adjusted_extent = [extents[1][0] - x_step / 2,
+                                        extents[1][1] + x_step / 2,
+                                        extents[0][0] - y_step / 2,
+                                        extents[0][1] + y_step / 2]
+                        for I_key, ax in zip(columns, axes):
+                            # MAGIC NUMBERS based on what tacaswell thinks looks OK
+                            data_aspect_ratio = np.abs(data_range[1]/data_range[0])
+                            MAR = 2
+                            if (1/MAR < data_aspect_ratio < MAR):
+                                aspect = 'equal'
+                                ax.set_aspect(aspect, adjustable='box')
+                            else:
+                                aspect = 'auto'
+                                ax.set_aspect(aspect, adjustable='datalim')
 
-        else:
-            raise NotImplementedError("we do not support 3D+ in BEC yet "
-                                      "(and it should have bailed above)")
-        try:
-            fig.tight_layout()
-        except ValueError:
-            pass
+                            live_grid = LiveGrid(shape, I_key,
+                                                xlabel=fast, ylabel=slow,
+                                                extent=adjusted_extent,
+                                                aspect=aspect,
+                                                ax=ax)
+
+                            live_grid('start', self._start_doc)
+                            live_grid('descriptor', doc)
+                            self._live_grids[doc['uid']][I_key] = live_grid
+                else:
+                    self._live_scatters[doc['uid']] = {}
+                    x_key, y_key = dim_fields
+                    for I_key, ax in zip(columns, axes):
+                        try:
+                            extents = self._start_doc['extents']
+                        except KeyError:
+                            xlim = ylim = None
+                        else:
+                            xlim, ylim = extents
+                        live_scatter = LiveScatter(x_key, y_key, I_key,
+                                                xlim=xlim, ylim=ylim,
+                                                # Let clim autoscale.
+                                                ax=ax)
+                        live_scatter('start', self._start_doc)
+                        live_scatter('descriptor', doc)
+                        self._live_scatters[doc['uid']][I_key] = live_scatter
+
+            else:
+                raise NotImplementedError("we do not support 3D+ in BEC yet "
+                                        "(and it should have bailed above)")
+            try:
+                fig.tight_layout()
+            except ValueError:
+                pass
 
         # ## TABLE ## #
 


### PR DESCRIPTION
**Fix to BestEffortCallback function.** 

As a result of recent changes, Bluesky stopped printing the table during acquisition. For example, the following code (part of the basic Bluesky tutorial) would not print the table if run with python or ipython:

```
from bluesky import RunEngine
RE = RunEngine({})

from bluesky.callbacks.best_effort import BestEffortCallback
bec = BestEffortCallback()
RE.subscribe(bec)

from databroker import Broker
db = Broker.named('temp')
RE.subscribe(db.insert)

from bluesky.utils import ProgressBarManager
RE.waiting_hook = ProgressBarManager()

from ophyd.sim import det1, det2

from bluesky.plans import count, scan
dets = [det1, det2]

RE(count(dets, num=5, delay=1))
```

After the proposed change, the table printing code is executed even if there is no useful data to print. 

