### PR TITLE
Fix: segmentation fault while plotting from BestEffortCallback

### DIFF
--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -23,7 +23,7 @@ from .fitting import PeakStats
 
 class BestEffortCallback(QtAwareCallback):
     def __init__(self, *, fig_factory=None, table_enabled=True, **kwargs):
-        super().__init__(use_teleporter=kwargs.pop('use_teleporter', None))
+        super().__init__(**kwargs)
         # internal state
         self._start_doc = None
         self._descriptors = {}

--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -23,7 +23,8 @@ from .fitting import PeakStats
 
 class BestEffortCallback(QtAwareCallback):
     def __init__(self, *, fig_factory=None, table_enabled=True, **kwargs):
-        super().__init__(**kwargs)
+        import matplotlib.pyplot as plt
+        super().__init__(use_teleporter=kwargs.pop('use_teleporter', None))
         # internal state
         self._start_doc = None
         self._descriptors = {}

--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -23,7 +23,6 @@ from .fitting import PeakStats
 
 class BestEffortCallback(QtAwareCallback):
     def __init__(self, *, fig_factory=None, table_enabled=True, **kwargs):
-        import matplotlib.pyplot as plt
         super().__init__(use_teleporter=kwargs.pop('use_teleporter', None))
         # internal state
         self._start_doc = None

--- a/bluesky/callbacks/mpl_plotting.py
+++ b/bluesky/callbacks/mpl_plotting.py
@@ -20,7 +20,7 @@ class QtAwareCallback(CallbackBase):
     def __init__(self, *args, use_teleporter=None, **kwargs):
         if use_teleporter is None:
             import matplotlib
-            use_teleporter = 'qt' in matplotlib.get_backend()
+            use_teleporter = 'qt' in matplotlib.get_backend().lower()
         if use_teleporter:
             Teleporter = _get_teleporter()
             self.__teleporter = Teleporter()


### PR DESCRIPTION
** Fix for segmentation fault while plotting with BestEffortCallback in IPython **

If run in IPython, the following code would cause segmentation fault during execution of BestEffortCallback. It was found that the Qt backend is not identified by QtAwareCallback.__init__(). As a result, Teleporter object is not created and Qt is called directly from background thread. Converting Qt backend name ('Qt5Add') to lowercase ```use_teleporter = 'qt' in matplotlib.get_backend().lower()``` fixed the problem. 

```
from bluesky import RunEngine
RE = RunEngine({})

from bluesky.callbacks.best_effort import BestEffortCallback
bec = BestEffortCallback()
RE.subscribe(bec)

from databroker import Broker
db = Broker.named('temp')
RE.subscribe(db.insert)

from bluesky.utils import ProgressBarManager
RE.waiting_hook = ProgressBarManager()

from ophyd.sim import det, det1, det2, motor

from bluesky.plans import count, scan
dets = [det1, det2]
det1.kind = "hinted"  # This will cause BestEffortCallback to plot data from 'det1'

RE(count(dets, num=5, delay=1))

RE(scan(dets, motor, -2, 2, 5))

from bluesky.callbacks.mpl_plotting import LivePlot
lp = LivePlot('det', 'motor')
RE.subscribe(lp)
RE(scan([det], motor, -5, 5, 30))
```
