### PR TITLE
DOC: remove duplicate import in PersistentDict example

### DIFF
--- a/doc/source/metadata.rst
+++ b/doc/source/metadata.rst
@@ -273,7 +273,7 @@ file, so the contents of ``RE.md`` can persist between sessions.
 
 .. code-block:: python
 
-    from bluesky.utils import import PersistentDict
+    from bluesky.utils import PersistentDict
     RE.md = PersistentDict('some/path/here')
 
 Bluesky does not provide a strong recommendation on that path; that a detail

--- a/doc/source/metadata.rst
+++ b/doc/source/metadata.rst
@@ -256,7 +256,7 @@ beginning of each scan, is stored in ``RE.md['scan_id']``.
 Persistence Between Sessions
 ----------------------------
 
-We provide way to save the contents of the metadata stash ``RE.md`` between
+We provide a way to save the contents of the metadata stash ``RE.md`` between
 sessions (e.g., exiting and re-opening IPython).
 
 In general, the ``RE.md`` attribute may be anything that supports the


### PR DESCRIPTION
Minor correction to the example from #1228.