### PR TITLE
Provide better exceptions for down-stream consumers

### DIFF
--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -16,7 +16,7 @@ except ImportError:
 
 
 from .utils import (separate_devices, all_safe_rewind, Msg, ensure_generator,
-                    short_uid as _short_uid)
+                    short_uid as _short_uid, IllegalMessageSequence)
 
 
 def create(name='primary'):
@@ -773,6 +773,7 @@ def trigger_and_read(devices, name='primary'):
     msg : Msg
         messages to 'trigger', 'wait' and 'read'
     """
+
     # If devices is empty, don't emit 'create'/'save' messages.
     if not devices:
         yield from null()
@@ -798,8 +799,13 @@ def trigger_and_read(devices, name='primary'):
         yield from save()
         return ret
     from .preprocessors import rewindable_wrapper
-    return (yield from rewindable_wrapper(inner_trigger_and_read(),
-                                          rewindable))
+    try:
+        return (yield from rewindable_wrapper(inner_trigger_and_read(),
+                                              rewindable))
+    except IllegalMessageSequence as excep:
+        excep_str = ('While performing a "trigger_and_read" the following '
+                     f'message sequence issue occurred: {excep!r}')
+        raise type(excep)(excep.msg, excep_str) from excep
 
 
 def broadcast_msg(command, objs, *args, **kwargs):

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -804,7 +804,7 @@ def trigger_and_read(devices, name='primary'):
                                               rewindable))
     except IllegalMessageSequence as excep:
         excep_str = ('While performing a "trigger_and_read" the following '
-                     f'message sequence issue occurred: {excep!r}')
+                     f'message sequence issue occurred:        {excep!r}')
         raise type(excep)(excep.msg, excep_str) from excep
 
 
@@ -910,8 +910,13 @@ def one_1d_step(detectors, motor, step):
         yield Msg('set', motor, step, group=grp)
         yield Msg('wait', None, group=grp)
 
-    yield from move()
-    return (yield from trigger_and_read(list(detectors) + [motor]))
+    try:
+        yield from move()
+        return (yield from trigger_and_read(list(detectors) + [motor]))
+    except IllegalMessageSequence as excep:
+        excep_str = ('While performing a "one_1d_step" the following message '
+                     f'sequence issue occured:        {excep!r}')
+        raise type(excep)(excep.msg, excep_str) from excep
 
 
 def move_per_step(step, pos_cache):
@@ -954,8 +959,13 @@ def one_nd_step(detectors, step, pos_cache):
         mapping motors to their last-set positions
     """
     motors = step.keys()
-    yield from move_per_step(step, pos_cache)
-    yield from trigger_and_read(list(detectors) + list(motors))
+    try:
+        yield from move_per_step(step, pos_cache)
+        yield from trigger_and_read(list(detectors) + list(motors))
+    except IllegalMessageSequence as excep:
+        excep_str = ('While performing a "one_nd_step" the following message '
+                     f'sequence issue occured:        {excep!r}')
+        raise type(excep)(excep.msg, excep_str) from excep
 
 
 def repeat(plan, num=1, delay=None):

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1651,7 +1651,7 @@ class RunEngine:
             current_run = self._run_bundlers[run_key]
         except KeyError as ke:
             raise IllegalRunSequence(msg, "Cannot bundle readings without an "
-                                     "open run. That is, 'create'must be "
+                                     "open run. That is, 'create' must be "
                                      "preceded by 'open_run'.") from ke
 
         return (await current_run.create(msg))

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -30,13 +30,30 @@ except ImportError:
     current_task = Task.current_task
     del Task
 
-from .utils import (CallbackRegistry, SigintHandler,
-                    normalize_subs_input, AsyncInput,
-                    NoReplayAllowed, RequestAbort, RequestStop,
-                    RunEngineInterrupted, IllegalMessageSequence,
-                    FailedPause, FailedStatus, InvalidCommand,
-                    PlanHalt, Msg, ensure_generator, single_gen,
-                    default_during_task)
+from .utils import (
+    AsyncInput,
+    CallbackRegistry,
+    FailedPause,
+    FailedStatus,
+    IllegalBundlingSequence,
+    IllegalMessageSequence,
+    IllegalMonitorSequence,
+    IllegalRunSequence,
+    InvalidCommand,
+    Msg,
+    NoReplayAllowed,
+    PlanHalt,
+    RequestAbort,
+    RequestStop,
+    RunEngineInterrupted,
+    SigintHandler,
+    default_during_task,
+    ensure_generator,
+    new_uid,
+    normalize_subs_input,
+    short_uid,
+    single_gen,
+)
 
 
 class _RunEnginePanic(Exception):
@@ -1559,9 +1576,9 @@ class RunEngine:
         # TODO extract this from the Msg
         run_key = _extract_run_key(msg)
         if run_key in self._run_bundlers:
-            raise IllegalMessageSequence("A 'close_run' message was not "
-                                         "received before the 'open_run' "
-                                         "message")
+            raise IllegalRunSequence(msg, "A 'close_run' message was not "
+                                     "received before the 'open_run' "
+                                     "message")
 
         # Run scan_id calculation method
         self.md['scan_id'] = self.scan_id_source(self.md)
@@ -1604,9 +1621,12 @@ class RunEngine:
         try:
             current_run = self._run_bundlers[run_key]
         except KeyError as ke:
-            raise IllegalMessageSequence("A 'close_run' message was not "
-                                         "received before the 'open_run' "
-                                         "message") from ke
+            raise IllegalRunSequence(msg, "A 'close_run' message was received "
+                                     "but there is no run open. If this "
+                                     "occurred after a pause/resume, add a "
+                                     "'checkpoint' message after the "
+                                     "'close_run' message.") from ke
+
         ret = (await current_run.close_run(msg))
         del self._run_bundlers[run_key]
         return ret
@@ -1630,9 +1650,10 @@ class RunEngine:
         try:
             current_run = self._run_bundlers[run_key]
         except KeyError as ke:
-            raise IllegalMessageSequence("Cannot bundle readings without "
-                                         "an open run. That is, 'create' must "
-                                         "be preceded by 'open_run'.") from ke
+            raise IllegalRunSequence(msg, "Cannot bundle readings without an "
+                                     "open run. That is, 'create'must be "
+                                     "preceded by 'open_run'.") from ke
+
         return (await current_run.create(msg))
 
     async def _read(self, msg):
@@ -1683,8 +1704,9 @@ class RunEngine:
         try:
             current_run = self._run_bundlers[run_key]
         except KeyError as ke:
-            raise IllegalMessageSequence("A 'monitor' message was sent but no "
-                                         "run is open.") from ke
+            raise IllegalRunSequence(msg, "A 'monitor' message was sent but "
+                                     "no run is open.") from ke
+
         await current_run.monitor(msg)
         await self._reset_checkpoint_state_coro()
 
@@ -1700,7 +1722,7 @@ class RunEngine:
         try:
             current_run = self._run_bundlers[run_key]
         except KeyError as ke:
-            raise IllegalMessageSequence(
+            raise IllegalRunSequence(msg,
                 "A 'unmonitor' message was sent but no "
                 "run is open.") from ke
         await current_run.unmonitor(msg)
@@ -1719,9 +1741,8 @@ class RunEngine:
         except KeyError as ke:
             # sanity check -- this should be caught by 'create' which makes
             # this code path impossible
-            raise IllegalMessageSequence(
-                "A 'save' message was sent but no " "run is open."
-            ) from ke
+            raise IllegalRunSequence(msg, "A 'save' message was sent but no "
+                                     "run is open.") from ke
 
         await current_run.save(msg)
 
@@ -1736,9 +1757,9 @@ class RunEngine:
         try:
             current_run = self._run_bundlers[run_key]
         except KeyError as ke:
-            raise IllegalMessageSequence(
-                "A 'drop' message was sent but no " "run is open."
-            ) from ke
+            raise IllegalRunSequence(msg, "A 'drop' message was sent but no "
+                                     "run is open.") from ke
+
         await current_run.drop(msg)
 
     async def _kickoff(self, msg):
@@ -1769,8 +1790,8 @@ class RunEngine:
         try:
             current_run = self._run_bundlers[run_key]
         except KeyError as ke:
-            raise IllegalMessageSequence("A 'kickoff' message was sent but no "
-                                         "run is open.") from ke
+            raise IllegalRunSequence(msg, "A 'kickoff' message was sent but "
+                                     "no run is open.") from ke
 
         _, obj, args, kwargs, _ = msg
         kwargs = dict(msg.kwargs)
@@ -1882,8 +1903,10 @@ class RunEngine:
         try:
             current_run = self._run_bundlers[run_key]
         except KeyError as ke:
-            raise IllegalMessageSequence("A 'collect' message was sent but no "
-                                         "run is open.") from ke
+            # sanity check -- 'kickoff' should catch this and make this
+            # code path impossible
+            raise IllegalRunSequence(msg, "A 'collect' message was sent but "
+                                     "no run is open.") from ke
 
         return (await current_run.collect(msg))
 
@@ -2064,8 +2087,9 @@ class RunEngine:
         """
         for current_run in self._run_bundlers.values():
             if current_run.bundling:
-                raise IllegalMessageSequence("Cannot 'checkpoint' after 'create' "
-                                             "and before 'save'. Aborting!")
+                raise IllegalBundlingSequence(msg, "Cannot 'checkpoint' after "
+                                              "'create' and before 'save'. "
+                                              "Aborting!")
 
         await self._reset_checkpoint_state_coro()
 
@@ -2135,9 +2159,11 @@ class RunEngine:
             current_run = None
         else:
             if current_run.bundling:
-                raise IllegalMessageSequence(
-                    "Cannot configure after 'create' but before 'save'"
+                raise IllegalBundlingSequence(
+                    msg,
+                    "Cannot configure after 'create' but before 'save'. "
                     "Aborting!")
+
         _, obj, args, kwargs, _ = msg
 
         old, new = obj.configure(*args, **kwargs)

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1,11 +1,10 @@
 import asyncio
 from datetime import datetime
-import time as ttime
 import sys
 import logging
 from warnings import warn
 from inspect import Parameter, Signature
-from itertools import count, tee
+from itertools import count
 from collections import deque, defaultdict, ChainMap
 from enum import Enum
 import functools
@@ -37,7 +36,6 @@ from .utils import (
     FailedStatus,
     IllegalBundlingSequence,
     IllegalMessageSequence,
-    IllegalMonitorSequence,
     IllegalRunSequence,
     InvalidCommand,
     Msg,
@@ -49,9 +47,7 @@ from .utils import (
     SigintHandler,
     default_during_task,
     ensure_generator,
-    new_uid,
     normalize_subs_input,
-    short_uid,
     single_gen,
 )
 

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -365,6 +365,11 @@ def test_flying_outside_a_run_is_illegal(RE, hw):
     assert excep_info.value.msg is illegal_message
 
 
+def test_trigger_and_read_without_an_open_run_is_illegal(RE, hw):
+    with pytest.raises(IllegalRunSequence) as excep_info:
+        RE(trigger_and_read([hw.det]))
+
+
 def test_empty_bundle(RE, hw):
     mutable = {}
 

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -15,7 +15,8 @@ from bluesky import Msg
 from functools import partial
 from bluesky.tests.utils import MsgCollector, DocCollector
 from bluesky.plans import (fly, count, grid_scan)
-from bluesky.plan_stubs import (abs_set, trigger_and_read)
+from bluesky.plan_stubs import (abs_set, trigger_and_read, one_1d_step,
+                                one_nd_step)
 from bluesky.preprocessors import (finalize_wrapper, run_decorator,
                                    reset_positions_decorator,
                                    run_wrapper, rewindable_wrapper,
@@ -366,8 +367,18 @@ def test_flying_outside_a_run_is_illegal(RE, hw):
 
 
 def test_trigger_and_read_without_an_open_run_is_illegal(RE, hw):
-    with pytest.raises(IllegalRunSequence) as excep_info:
+    with pytest.raises(IllegalRunSequence):
         RE(trigger_and_read([hw.det]))
+
+
+def test_one_1d_step_without_an_open_run_is_illegal(RE, hw):
+    with pytest.raises(IllegalRunSequence):
+        RE(one_1d_step([hw.det], hw.motor, 0))
+
+
+def test_one_nd_step_without_an_open_run_is_illegal(RE, hw):
+    with pytest.raises(IllegalRunSequence):
+        RE(one_nd_step([hw.det], {hw.motor: 1}, {hw.motor: 0}))
 
 
 def test_empty_bundle(RE, hw):

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -64,6 +64,32 @@ class NoReplayAllowed(Exception):
 
 
 class IllegalMessageSequence(Exception):
+    '''Base exception to raise for wrong message sequences.
+
+    Parameters
+    ----------
+    msg : Msg Object
+        the message object that was passed into the command which raised the
+        error.
+    '''
+
+    def __init__(self, msg, *args, **kwargs):
+        self.msg = msg
+        super().__init__(*args, **kwargs)
+
+
+class IllegalRunSequence(IllegalMessageSequence):
+    '''Exception to raise for wrong message sequence for open_run/close_run.'''
+    pass
+
+
+class IllegalBundlingSequence(IllegalMessageSequence):
+    '''Exception to raise for wrong message sequence for create/save/drop.'''
+    pass
+
+
+class IllegalMonitorSequence(IllegalMessageSequence):
+    '''Exception to raise for wrong message sequence for monitor/unmonitor.'''
     pass
 
 


### PR DESCRIPTION
This PR attempts to make the exception exposed to the users easier to understand. 

## Description
This adds 3 new exceptions (splitting the existing 'IllegalMessageSequence' exception into : IllegalRunSequence, IllegalBundlingSequence and IllegalMonitorSequence. It also adds a new attribute ``RunEngine._exception_attrs`` (a dict mapping required exception attribute names to RunEngine attributes to extract the values from) and a new method ``RunEngine._add_attrs_to_exception(exception, msg, obj=None)`` that adds the attributes defined in the above dictionary and ``msg`` and ``obj`` attributes to the exception before returning it.

Finally this PR updates all of the existing instances of ``IllegalMessageSequence`` to use the above changes.

## Motivation and Context
A discussion of the motivation can be found in PR #1240 

## How Has This Been Tested?
It is yet to be tested, and is submitted as a Draft to gain feedback on the approach taken before completing it and adding tests.

closes #1240 
