### PR TITLE
Paranoid decorator

### DIFF
--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -16,11 +16,15 @@ import time
 from warnings import warn
 import weakref
 
-from .core import LiveTable
+from .core import LiveTable, make_class_safe
 from .mpl_plotting import LivePlot, LiveGrid, LiveScatter, QtAwareCallback
 from .fitting import PeakStats
+import logging
+
+logger = logging.getLogger(__name__)
 
 
+@make_class_safe(logger=logger)
 class BestEffortCallback(QtAwareCallback):
     def __init__(self, *, fig_factory=None, table_enabled=True, **kwargs):
         super().__init__(**kwargs)

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -3,6 +3,8 @@ Useful callbacks for the Run Engine
 """
 from itertools import count
 import warnings
+import os
+
 from collections import deque, namedtuple, OrderedDict
 import time as ttime
 from functools import wraps as _wraps, partial as _partial
@@ -26,6 +28,8 @@ def make_callback_safe(func=None, *, logger=None):
         except Exception as ex:
             if logger is not None:
                 logger.exception(ex)
+            if os.environ.get('BLUESKY_DEBUG_CALLBACKS', False):
+                raise ex
 
     return inner
 
@@ -350,6 +354,8 @@ class LiveTable(CallbackBase):
             self._print('{{k:*^{self._min_width}}}'
                         .format(self=self)
                         .format(k=' failed to format row '))
+            if os.environ.get('BLUESKY_DEBUG_CALLBACKS', False):
+                raise ex
         super().event(doc)
 
     def stop(self, doc):

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -10,6 +10,11 @@ from functools import wraps as _wraps, partial as _partial
 from datetime import datetime
 import logging
 from ..utils import ensure_uid
+import logging
+
+logger = logging.getLogger(__name__)
+
+
 def make_callback_safe(func=None, *, logger=None):
     if func is None:
         return _partial(make_callback_safe, logger=logger)
@@ -179,6 +184,7 @@ class CollectThenCompute(CallbackBase):
         raise NotImplementedError("This method must be defined by a subclass.")
 
 
+@make_class_safe(logger=logger)
 class LiveTable(CallbackBase):
     '''Live updating table
 

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -26,11 +26,21 @@ def make_callback_safe(func=None, *, logger=None):
     def inner(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except Exception as ex:
+        except Exception:
+            debug_mode = os.environ.get("BLUESKY_DEBUG_CALLBACKS", False)
             if logger is not None:
-                logger.exception(ex)
-            if os.environ.get('BLUESKY_DEBUG_CALLBACKS', False):
-                raise ex
+                if debug_mode:
+                    msg = f"Exception in {func}"
+                else:
+                    msg = (
+                        f"An exception raised in the callback {func} "
+                        + "is being suppressed to not interupt plan "
+                        + "execution.  To investigate try setting the "
+                        + "BLUESKY_DEBUG_CALLBACKS env to '1'"
+                    )
+                logger.exception()
+            if debug_mode:
+                raise
 
     return inner
 

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -368,3 +368,17 @@ def make_callback_safe(func=None, *, logger=None):
 
     return inner
 
+
+def make_class_safe(cls=None, *, to_wrap=None, logger=None):
+    from event_model import DocumentNames
+
+    if cls is None:
+        return _partial(make_class_safe, to_wrap=to_wrap, logger=logger)
+
+    if to_wrap is None:
+        to_wrap = ['__call__']
+
+    for f_name in to_wrap:
+        setattr(cls, f_name, make_callback_safe(getattr(cls, f_name), logger=logger))
+
+    return cls

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -34,7 +34,7 @@ def make_callback_safe(func=None, *, logger=None):
                 else:
                     msg = (
                         f"An exception raised in the callback {func} "
-                        + "is being suppressed to not interupt plan "
+                        + "is being suppressed to not interrupt plan "
                         + "execution.  To investigate try setting the "
                         + "BLUESKY_DEBUG_CALLBACKS env to '1'"
                     )

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -33,11 +33,11 @@ def make_callback_safe(func=None, *, logger=None):
                 else:
                     msg = (
                         f"An exception raised in the callback {func} "
-                        + "is being suppressed to not interrupt plan "
-                        + "execution.  To investigate try setting the "
-                        + "BLUESKY_DEBUG_CALLBACKS env to '1'"
+                        "is being suppressed to not interrupt plan "
+                        "execution.  To investigate try setting the "
+                        "BLUESKY_DEBUG_CALLBACKS env to '1'"
                     )
-                logger.exception()
+                logger.exception(msg)
             if debug_mode:
                 raise
 

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -12,7 +12,8 @@ from functools import wraps as _wraps, partial as _partial
 from datetime import datetime
 import logging
 from ..utils import ensure_uid
-import logging
+from event_model import DocumentNames
+
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +36,6 @@ def make_callback_safe(func=None, *, logger=None):
 
 
 def make_class_safe(cls=None, *, to_wrap=None, logger=None):
-    from event_model import DocumentNames
 
     if cls is None:
         return _partial(make_class_safe, to_wrap=to_wrap, logger=logger)
@@ -51,6 +51,7 @@ def make_class_safe(cls=None, *, to_wrap=None, logger=None):
 
 class CallbackBase:
     log = None
+
     def __call__(self, name, doc):
         "Dispatch to methods expecting particular doc types."
         return getattr(self, name)(doc)

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -5,6 +5,7 @@ from itertools import count
 import warnings
 from collections import deque, namedtuple, OrderedDict
 import time as ttime
+from functools import wraps as _wraps, partial as _partial
 
 from datetime import datetime
 import logging
@@ -351,3 +352,19 @@ class LiveTable(CallbackBase):
     def _print(self, out_str):
         self._rows.append(out_str)
         self._out(out_str)
+
+
+def make_callback_safe(func=None, *, logger=None):
+    if func is None:
+        return _partial(make_callback_safe, logger=logger)
+
+    @_wraps(func)
+    def inner(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception as ex:
+            if logger is not None:
+                logger.exception(ex)
+
+    return inner
+

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -12,7 +12,6 @@ from functools import wraps as _wraps, partial as _partial
 from datetime import datetime
 import logging
 from ..utils import ensure_uid
-from event_model import DocumentNames
 
 
 logger = logging.getLogger(__name__)

--- a/bluesky/callbacks/mpl_plotting.py
+++ b/bluesky/callbacks/mpl_plotting.py
@@ -3,8 +3,10 @@ from cycler import cycler
 import numpy as np
 import warnings
 import functools
-from .core import CallbackBase, get_obj_fields
+from .core import CallbackBase, get_obj_fields, make_class_safe
+import logging
 
+logger = logging.getLogger(__name__)
 
 # use function + LRU cache to hide Matplotib import until needed
 @functools.lru_cache(maxsize=1)
@@ -36,6 +38,7 @@ class QtAwareCallback(CallbackBase):
             return CallbackBase.__call__(self, name, doc)
 
 
+@make_class_safe(logger=logger)
 class LivePlot(QtAwareCallback):
     """
     Build a function that updates a plot from a stream of Events.
@@ -186,6 +189,7 @@ class LivePlot(QtAwareCallback):
         super().stop(doc)
 
 
+@make_class_safe(logger=logger)
 class LiveScatter(QtAwareCallback):
     """Plot scattered 2D data in a "heat map".
 
@@ -300,6 +304,7 @@ class LiveScatter(QtAwareCallback):
             self.sc.set_clim(*clim)
 
 
+@make_class_safe(logger=logger)
 class LiveMesh(LiveScatter):
     __doc__ = LiveScatter.__doc__
 
@@ -309,6 +314,7 @@ class LiveMesh(LiveScatter):
         super().__init__(*args, **kwargs)
 
 
+@make_class_safe(logger=logger)
 class LiveGrid(QtAwareCallback):
     """Plot gridded 2D data in a "heat map".
 
@@ -453,6 +459,7 @@ class LiveGrid(QtAwareCallback):
         self.im.set_array(self._Idata)
 
 
+@make_class_safe(logger=logger)
 class LiveRaster(LiveGrid):
     __doc__ = LiveGrid.__doc__
 
@@ -462,6 +469,7 @@ class LiveRaster(LiveGrid):
         super().__init__(*args, **kwargs)
 
 
+@make_class_safe(logger=logger)
 class LiveFitPlot(LivePlot):
     """
     Add a plot to an instance of LiveFit.


### PR DESCRIPTION
This adds two decorators (one function level, one class level) to use to make callbacks "safe" and wrap all of our built-in callbacks with them.

We have had too many cases of bugs in callbacks crashing runs.  This should prevent that at the cost of debugging _why_ plots or tables are not working.