### PR TITLE
TST: don't set the register on test devices

### DIFF
--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -173,7 +173,6 @@ def test_table(RE, hw):
 
 def test_table_external(RE, hw, db):
     RE.subscribe(db.insert)
-    hw.img.reg = db.reg
     RE(count([hw.img]), LiveTable(['img']))
 
 
@@ -420,7 +419,6 @@ def test_broker_base(RE, hw, db):
     RE.subscribe(db.insert)
     bc = BrokerChecker(('img',), db=db)
     RE.subscribe(bc)
-    hw.img.reg = db.reg
     RE(count([hw.img]))
 
 

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -682,15 +682,3 @@ def test_async_trigger_delay(RE, hw):
 
     _time_test(bps.trigger, .5, hw.det, wait=True)
     _time_test(bps.abs_set, .5, hw.motor, 1, wait=True)
-
-
-def test_reg_reader(hw, db):
-    hw.img.reg = db.reg
-    det = hw.img
-    det.stage()
-    det.trigger()
-    reading = det.read().copy()
-    det.unstage()
-    datum_id = reading['img']['value']
-    arr = db.reg.retrieve(datum_id)
-    assert_array_equal(np.ones((10, 10)), arr)

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -1416,7 +1416,6 @@ def test_filled(RE, hw, db):
     assert event['filled'] == {}
     collector.clear()
 
-    hw.img.reg = db.reg
     RE(count([hw.img]), collect)
     event, = collector
     assert event['filled'] == {'img': False}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This will reduce the number of warnings from the test suite.

The deleted test is explicitly testing the old "internal mode" which
if we continue to test it, should be tested in ophyd or databroker,
but not in bluesky.

We want to push the test suite to be fail-on-warning.


It is changes to the tests