### PR TITLE
FIX: print_summary_wrapper was not forwarding all channels

### DIFF
--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -284,9 +284,18 @@ def print_summary_wrapper(plan):
     ------
     msg : `Msg`
     """
-
     read_cache = []
-    for msg in plan:
+    value = None
+    excep = None
+    while True:
+        try:
+            if excep is None:
+                msg = plan.send(value)
+            else:
+                msg = plan.throw(excep)
+                excep = None
+        except StopIteration as e:
+            return e.value
         cmd = msg.command
         if cmd == 'open_run':
             print('{:=^80}'.format(' Open Run '))
@@ -301,7 +310,10 @@ def print_summary_wrapper(plan):
             read_cache.append(msg.obj.name)
         elif cmd == 'save':
             print('  Read {}'.format(read_cache))
-        yield msg
+        try:
+            value = yield msg
+        except Exception as e:
+            excep = e
 
 
 def run_wrapper(plan, *, md=None):


### PR DESCRIPTION
Was not passing values or exceptions back into the wrapped plan or
forwarding the return value out.

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
-->