### PR TITLE
Unit test updates for ophyd simulated Devices

### DIFF
--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -151,7 +151,7 @@ def test_table(RE, hw):
         hw.det.precision = 2
         hw.motor.precision = 2
         hw.motor.setpoint.put(0.0)  # Make dtype 'number' not 'integer'.
-        hw.det.trigger()  # Make dtype 'number' not 'integer'.
+        hw.det.trigger()
         assert hw.det.describe()['det']['precision'] == 2
         assert hw.motor.describe()['motor']['precision'] == 2
         assert hw.det.describe()['det']['dtype'] == 'number'

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -151,7 +151,7 @@ def test_table(RE, hw):
         hw.det.precision = 2
         hw.motor.precision = 2
         hw.motor.setpoint.put(0.0)  # Make dtype 'number' not 'integer'.
-        hw.det.put(0.0)  # Make dtype 'number' not 'integer'.
+        hw.det.trigger()  # Make dtype 'number' not 'integer'.
         assert hw.det.describe()['det']['precision'] == 2
         assert hw.motor.describe()['motor']['precision'] == 2
         assert hw.det.describe()['det']['dtype'] == 'number'

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -642,7 +642,7 @@ def test_no_rewind_device(hw):
 
 def test_monitor(RE, hw):
     from ophyd.sim import SynSignal
-    signal = SynSignal(name='signal')
+    signal = SynSignal(name='signal', value=0.0)
     RE(monitor_during_wrapper(count([hw.det], 5), [signal]))
 
 

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -642,7 +642,8 @@ def test_no_rewind_device(hw):
 
 def test_monitor(RE, hw):
     from ophyd.sim import SynSignal
-    signal = SynSignal(name='signal', value=0.0)
+    signal = SynSignal(name='signal')
+    signal.put(0.0)
     RE(monitor_during_wrapper(count([hw.det], 5), [signal]))
 
 

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -641,7 +641,9 @@ def test_no_rewind_device(hw):
 
 
 def test_monitor(RE, hw):
-    RE(monitor_during_wrapper(count([hw.det], 5), [hw.det1]))
+    from ophyd.sim import SynSignal
+    signal = SynSignal(name='signal')
+    RE(monitor_during_wrapper(count([hw.det], 5), [signal]))
 
 
 def test_per_step(RE, hw):


### PR DESCRIPTION
Two small changes to unit tests for compatibility with updated ophyd simulated hardware.
This is really the work of @tacaswell, in case that is not obvious.

## Motivation and Context
This PR corresponds to the larger PR for ophyd #762, which aligns simulated hardware classes with "real" ophyd objects. This resolves an issue in suitcase-utils, which currently depends on an ophyd branch.

## How Has This Been Tested?
The bluesky tests pass with ophyd PR #762.
