### PR TITLE
submit_info plan

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1843,6 +1843,22 @@ def x2x_scan(detectors, motor1, motor2, start, stop, num, *,
         md=_md))
 
 
+def submit_info(info, plan_name='info', field_name='info'):
+    """
+    Submit info into the metadata of the start document.
+
+    Parameters
+    ----------
+    info : any serializable object
+        the information to submit
+    plan_name : str, optional
+        the name of the plan (useful for further searches)
+    field_name : str, optional
+        the name of the field under which the info will appear in the metadata
+    """
+    yield from count([], md={'plan_name': plan_name, field_name: info})
+
+
 relative_list_scan = rel_list_scan  # back-compat
 relative_scan = rel_scan  # back-compat
 relative_log_scan = rel_log_scan  # back-compat

--- a/bluesky/tests/test_plans.py
+++ b/bluesky/tests/test_plans.py
@@ -192,3 +192,16 @@ def test_pseudo_mv(hw, RE, pln):
     expecte_objs = [p, None]
     assert len(m_col.msgs) == 2
     assert [m.obj for m in m_col.msgs] == expecte_objs
+
+
+def test_submit_info(RE):
+    col = DocCollector()
+    RE.subscribe(col.insert)
+    info = 'test message'
+    RE(bp.submit_info(info=info))
+
+    st = col.start[0]
+
+    assert st['plan_name'] == 'info'
+    assert 'info' in st
+    assert st['info'] == info


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR provides a plan that can be used to submit information to databroker with the customizable `plan_name`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I was asked about it by @lyang11973, and the implementation here is the extension of the original suggestion to use `bp.count([], md={...})`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A pytest was added to the test suite.

<!--
## Screenshots (if appropriate):
-->
