### PR TITLE
Accept kwargs in bps.mv

### DIFF
--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -214,7 +214,7 @@ def rel_set(obj, *args, group=None, wait=False, **kwargs):
         abs_set(obj, *args, group=group, wait=wait, **kwargs)))
 
 
-def mv(*args, **kwargs):
+def mv(*args, group=None, **kwargs):
     """
     Move one or more devices to a setpoint. Wait for all to complete.
 
@@ -224,6 +224,8 @@ def mv(*args, **kwargs):
     ----------
     args :
         device1, value1, device2, value2, ...
+    group : string, optional
+        Used to mark these as a unit to be waited on.
     kwargs :
         passed to obj.set()
 
@@ -236,7 +238,7 @@ def mv(*args, **kwargs):
     :func:`bluesky.plan_stubs.abs_set`
     :func:`bluesky.plan_stubs.mvr`
     """
-    group = str(uuid.uuid4())
+    group = group or str(uuid.uuid4())
     status_objects = []
 
     cyl = reduce(operator.add,

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -255,7 +255,7 @@ def mv(*args, group=None, **kwargs):
 mov = mv  # synonym
 
 
-def mvr(*args):
+def mvr(*args, group=None, **kwargs):
     """
     Move one or more devices to a relative setpoint. Wait for all to complete.
 
@@ -265,6 +265,10 @@ def mvr(*args):
     ----------
     args :
         device1, value1, device2, value2, ...
+    group : string, optional
+        Used to mark these as a unit to be waited on.
+    kwargs :
+        passed to obj.set()
 
     Yields
     ------
@@ -283,7 +287,7 @@ def mvr(*args):
 
     @relative_set_decorator(objs)
     def inner_mvr():
-        return (yield from mv(*args))
+        return (yield from mv(*args, group=group, **kwargs))
 
     return (yield from inner_mvr())
 

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -214,7 +214,7 @@ def rel_set(obj, *args, group=None, wait=False, **kwargs):
         abs_set(obj, *args, group=group, wait=wait, **kwargs)))
 
 
-def mv(*args):
+def mv(*args, **kwargs):
     """
     Move one or more devices to a setpoint. Wait for all to complete.
 
@@ -224,6 +224,8 @@ def mv(*args):
     ----------
     args :
         device1, value1, device2, value2, ...
+    kwargs :
+        passed to obj.set()
 
     Yields
     ------
@@ -242,7 +244,7 @@ def mv(*args):
                   obj, val in partition(2, args)])
     step, = utils.merge_cycler(cyl)
     for obj, val in step.items():
-        ret = yield Msg('set', obj, val, group=group)
+        ret = yield Msg('set', obj, val, group=group, **kwargs)
         status_objects.append(ret)
     yield Msg('wait', None, group=group)
     return tuple(status_objects)

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -140,6 +140,15 @@ def test_mv(hw):
     assert actual[2] == Msg('wait', None)
 
 
+def test_mv_with_timeout(hw):
+    # special-case mv because the group is not configurable
+    # move motors first to ensure that movement is absolute, not relative
+    actual = list(mv(hw.motor1, 1, hw.motor2, 2, timeout=42))
+    for msg in actual[:2]:
+        msg.command == 'set'
+        msg.kwargs['timeout'] == 42
+
+
 def test_mvr(RE, hw):
     # special-case mv because the group is not configurable
     # move motors first to ensure that movement is relative, not absolute
@@ -154,6 +163,15 @@ def test_mvr(RE, hw):
         msg.command == 'set'
     assert set([msg.obj for msg in actual[:2]]) == set([hw.motor1, hw.motor2])
     assert actual[2] == Msg('wait', None)
+
+
+def test_mvr_with_timeout(hw):
+    # special-case mv because the group is not configurable
+    # move motors first to ensure that movement is absolute, not relative
+    actual = list(mvr(hw.motor1, 1, hw.motor2, 2, timeout=42))
+    for msg in actual[:2]:
+        msg.command == 'set'
+        msg.kwargs['timeout'] == 42
 
 
 def strip_group(plan):


### PR DESCRIPTION
The `bps.abs_set` plan accepts `**kwargs` and passes them through to
`obj.set(..., **kwargs)`. This PR makes `bps.mv` do so as well. I
suspect that we might have omitted it this on purpose because, unlike
`abs_set`, `mv` accepts *multiple* devices and there is no way to
express specific `kwargs` for each device without making the signature
complex. However, for common `kwargs` like `timeout` this might be nice
to have.


<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
-->