### PR TITLE
remove nlls from PeakStats

### DIFF
--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -443,7 +443,7 @@ class BestEffortCallback(QtAwareCallback):
 
 
 class PeakResults:
-    ATTRS = ('com', 'cen', 'max', 'min', 'fwhm', 'nlls')
+    ATTRS = ('com', 'cen', 'max', 'min', 'fwhm')
 
     def __init__(self):
         for attr in self.ATTRS:

--- a/bluesky/callbacks/fitting.py
+++ b/bluesky/callbacks/fitting.py
@@ -215,7 +215,6 @@ class PeakStats(CollectThenCompute):
         self.cen = None
         self.max = None
         self.min = None
-        self.nlls = None
         self.crossings = None
         self.fwhm = None
         self.lin_bkg = None
@@ -235,7 +234,6 @@ class PeakStats(CollectThenCompute):
         self.cen = None
         self.max = None
         self.min = None
-        self.nlls = None
         self.crossings = None
         self.fwhm = None
         self.lin_bkg = None


### PR DESCRIPTION
fixes #1263 

## Description
The nlls attribute in `PeakStats` is for a planned, undocumented, and unimplemented feature.  Since it has not been implemented, its presence invites questions from new users as to why `nlls` is defined in the results but always `None`.
