### PR TITLE
Update tutorial from lightsource2-tag -> nsls2forge.

### DIFF
--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -51,7 +51,7 @@ Before You Begin
 
   .. code-block:: bash
 
-    conda install -c lightsource2-tag bluesky ophyd databroker ipython matplotlib
+    conda install -c nsls2forge bluesky ophyd databroker ipython matplotlib
 
 * Start IPython:
 


### PR DESCRIPTION
Thanks to @petercj reporting the issue. The `lightsource2-tag` channel
is now deprecated.