### PR TITLE
FIX: make sure we never tell tqdm values it considers invalid

### DIFF
--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -1115,7 +1115,8 @@ class ProgressBar:
         if all(x is not None for x in (current, initial, target)):
             # Display a proper progress bar.
             total = round(_L2norm(target, initial), precision or 3)
-            n = round(_L2norm(current, initial), precision or 3)
+            # make sure we ignore overshoot to prevent tqdm from exploding.
+            n = np.clip(round(_L2norm(current, initial), precision or 3), 0, total)
             # Compute this only if the status object did not provide it.
             if time_elapsed is None:
                 time_elapsed = time.time() - self.creation_time


### PR DESCRIPTION
If the motors over-shoot then `n > total` which eventually causes an
assertion failure in tqdm due to `n / total > 1`.

Closes https://github.com/aps-8id-trr/ipython-8idiuser/issues/126
Closes #1278