### PR TITLE
CI: disable OSX testing on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ matrix:
       env: PUBLISH_DOCS=1
     - os: linux
       python: 3.7
+    - os: linux
+      python: 3.8
     #     - os: osx
     #       language: generic
     #       env: PYTHON=3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,12 @@ matrix:
       env: PUBLISH_DOCS=1
     - os: linux
       python: 3.7
-    - os: osx
-      language: generic
-      env: PYTHON=3.6
-    - os: osx
-      language: generic
-      env: PYTHON=3.7
+    #     - os: osx
+    #       language: generic
+    #       env: PYTHON=3.6
+    #     - os: osx
+    #       language: generic
+    #       env: PYTHON=3.7
     - os: linux
       python: nightly
   allow_failures:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

The workers we are getting on travis seem to be significantly throttled and
we are getting persistent failures due to some of the timing tests.

Also add linux py38