### PR TITLE
FIX: setting run name for nested runs (`set_run_name_decorator')

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`
   - pip install --upgrade pip
   - pip install --upgrade cython
+  - pip install --upgrade numpy
   - pip install --quiet --upgrade --global-option='--without-libyaml' pyyaml
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt

--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -1331,4 +1331,4 @@ def set_run_id_wrapper(plan, run):
 
     return (yield from msg_mutator(plan, _set_run_id))
 
-set_run_name_decorator = make_decorator(set_run_id_wrapper)
+set_run_id_decorator = make_decorator(set_run_id_wrapper)

--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -1319,7 +1319,9 @@ def define_run_wrapper(plan, run):
         The run to set on each Msg
     """
     def _set_run_id(msg):
-        return msg._replace(run=run)
+        if not isinstance(msg.run, str):
+            msg = msg._replace(run=run)
+        return msg
 
     return (yield from msg_mutator(plan, _set_run_id))
 

--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -1307,7 +1307,7 @@ class SupplementalData:
         return (yield from plan)
 
 
-def set_run_name_wrapper(plan, run):
+def set_run_id_wrapper(plan, run):
     """
     Add a run id to each message in wrapped plan
 
@@ -1328,4 +1328,4 @@ def set_run_name_wrapper(plan, run):
 
     return (yield from msg_mutator(plan, _set_run_id))
 
-set_run_name_decorator = make_decorator(set_run_name_wrapper)
+set_run_name_decorator = make_decorator(set_run_id_wrapper)

--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -1307,7 +1307,7 @@ class SupplementalData:
         return (yield from plan)
 
 
-def set_run_name_wrapper(plan, run_name):
+def set_run_name_wrapper(plan, run):
     """
     Add a run id to each message in wrapped plan
 
@@ -1315,15 +1315,15 @@ def set_run_name_wrapper(plan, run_name):
     ----------
     plan : iterable or iterator
         a generator, list, or similar containing `Msg` objects
-    run_name : str
+    run : str
         The run to set on each Msg
     """
 
-    if not isinstance(run_name, str):
-        raise ValueError(f"run name must be a string: passed value {run_name} is of type {type(run_name)}")
+    if not isinstance(run, str):
+        raise ValueError(f"run name must be a string: passed value {run} is of type {type(run)}")
     def _set_run_id(msg):
         if not isinstance(msg.run, str):
-            msg = msg._replace(run=run_name)
+            msg = msg._replace(run=run)
         return msg
 
     return (yield from msg_mutator(plan, _set_run_id))

--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -1307,28 +1307,28 @@ class SupplementalData:
         return (yield from plan)
 
 
-def set_run_id_wrapper(plan, run):
+def set_run_key_wrapper(plan, run):
     """
-    Add a run id to each message in wrapped plan
+    Add a run key to each message in wrapped plan
 
     Parameters
     ----------
     plan : iterable or iterator
         a generator, list, or similar containing `Msg` objects
     run : str or any other type except None
-        The run ID to set on each Msg. It is recommended that run ID represents
+        The run key to set on each Msg. It is recommended that run key represents
         informative string for better readability of plans. But value of any other
         type can be used if needed.
     """
     if run is None:
         raise ValueError(f"run ID can not be None")
 
-    def _set_run_id(msg):
+    def _set_run_key(msg):
         # Replace only the default value None
         if msg.run is None:
             msg = msg._replace(run=run)
         return msg
 
-    return (yield from msg_mutator(plan, _set_run_id))
+    return (yield from msg_mutator(plan, _set_run_key))
 
-set_run_id_decorator = make_decorator(set_run_id_wrapper)
+set_run_key_decorator = make_decorator(set_run_key_wrapper)

--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -1307,7 +1307,7 @@ class SupplementalData:
         return (yield from plan)
 
 
-def define_run_wrapper(plan, run):
+def set_run_name_wrapper(plan, run_name):
     """
     Add a run id to each message in wrapped plan
 
@@ -1315,14 +1315,17 @@ def define_run_wrapper(plan, run):
     ----------
     plan : iterable or iterator
         a generator, list, or similar containing `Msg` objects
-    run_id : str
+    run_name : str
         The run to set on each Msg
     """
+
+    if not isinstance(run_name, str):
+        raise ValueError(f"run name must be a string: passed value {run_name} is of type {type(run_name)}")
     def _set_run_id(msg):
         if not isinstance(msg.run, str):
-            msg = msg._replace(run=run)
+            msg = msg._replace(run=run_name)
         return msg
 
     return (yield from msg_mutator(plan, _set_run_id))
 
-define_run_decorator = make_decorator(define_run_wrapper)
+set_run_name_decorator = make_decorator(set_run_name_wrapper)

--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -1316,7 +1316,7 @@ def set_run_name_wrapper(plan, run):
     plan : iterable or iterator
         a generator, list, or similar containing `Msg` objects
     run : str
-        The run to set on each Msg
+        The run name to set on each Msg
     """
 
     if not isinstance(run, str):

--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -1315,14 +1315,17 @@ def set_run_id_wrapper(plan, run):
     ----------
     plan : iterable or iterator
         a generator, list, or similar containing `Msg` objects
-    run : str
-        The run name to set on each Msg
+    run : str or any other type except None
+        The run ID to set on each Msg. It is recommended that run ID represents
+        informative string for better readability of plans. But value of any other
+        type can be used if needed.
     """
+    if run is None:
+        raise ValueError(f"run ID can not be None")
 
-    if not isinstance(run, str):
-        raise ValueError(f"run name must be a string: passed value {run} is of type {type(run)}")
     def _set_run_id(msg):
-        if not isinstance(msg.run, str):
+        # Replace only the default value None
+        if msg.run is None:
             msg = msg._replace(run=run)
         return msg
 

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -147,11 +147,6 @@ def _state_locked(func):
     return inner
 
 
-def _extract_run_key(msg):
-    return msg.run or _extract_run_key.__default_run
-_extract_run_key.__default_run = object()
-
-
 class RunEngine:
     """The Run Engine execute messages and emits Documents.
 
@@ -1563,7 +1558,7 @@ class RunEngine:
         the RunStart document
         """
         # TODO extract this from the Msg
-        run_key = _extract_run_key(msg)
+        run_key = msg.run
         if run_key in self._run_bundlers:
             raise IllegalMessageSequence("A 'close_run' message was not "
                                          "received before the 'open_run' "
@@ -1606,7 +1601,7 @@ class RunEngine:
         stashed on the RE.
         """
         # TODO extract this from the Msg
-        run_key = _extract_run_key(msg)
+        run_key = msg.run
         try:
             current_run = self._run_bundlers[run_key]
         except KeyError as ke:
@@ -1632,7 +1627,7 @@ class RunEngine:
         Also note that changing the 'name' of the Event will create a new
         Descriptor document.
         """
-        run_key = _extract_run_key(msg)
+        run_key = msg.run
         try:
             current_run = self._run_bundlers[run_key]
         except KeyError as ke:
@@ -1658,7 +1653,7 @@ class RunEngine:
                 f"The read of {obj.name} returned None. "
                 "This is a bug in your object implementation, "
                 "`read` must return a dictionary.")
-        run_key = _extract_run_key(msg)
+        run_key = msg.run
         try:
             current_run = self._run_bundlers[run_key]
         except KeyError:
@@ -1685,7 +1680,7 @@ class RunEngine:
         where kwargs are passed through to ``obj.subscribe()``
         """
 
-        run_key = _extract_run_key(msg)
+        run_key = msg.run
         try:
             current_run = self._run_bundlers[run_key]
         except KeyError as ke:
@@ -1702,7 +1697,7 @@ class RunEngine:
 
             Msg('unmonitor', obj)
         """
-        run_key = _extract_run_key(msg)
+        run_key = msg.run
         try:
             current_run = self._run_bundlers[run_key]
         except KeyError as ke:
@@ -1719,7 +1714,7 @@ class RunEngine:
 
             Msg('save')
         """
-        run_key = _extract_run_key(msg)
+        run_key = msg.run
         try:
             current_run = self._run_bundlers[run_key]
         except KeyError as ke:
@@ -1738,7 +1733,7 @@ class RunEngine:
 
             Msg('drop')
         """
-        run_key = _extract_run_key(msg)
+        run_key = msg.run
         try:
             current_run = self._run_bundlers[run_key]
         except KeyError as ke:
@@ -1767,7 +1762,7 @@ class RunEngine:
             Msg('kickoff', flyer_object, start, stop, step)
             Msg('kickoff', flyer_object, start, stop, step, group=<name>)
         """
-        run_key = _extract_run_key(msg)
+        run_key = msg.run
         try:
             current_run = self._run_bundlers[run_key]
         except KeyError as ke:
@@ -1821,7 +1816,7 @@ class RunEngine:
 
         where <GROUP> is a hashable identifier.
         """
-        run_key = _extract_run_key(msg)
+        run_key = msg.run
         try:
             current_run = self._run_bundlers[run_key]
         except KeyError as ke:
@@ -1865,7 +1860,7 @@ class RunEngine:
             Msg('collect', flyer_object)
             Msg('collect', flyer_object, stream=True, return_payload=False)
         """
-        run_key = _extract_run_key(msg)
+        run_key = msg.run
         try:
             current_run = self._run_bundlers[run_key]
         except KeyError as ke:
@@ -2115,7 +2110,7 @@ class RunEngine:
 
             object.configure(*args, **kwargs)
         """
-        run_key = _extract_run_key(msg)
+        run_key = msg.run
         try:
             current_run = self._run_bundlers[run_key]
         except KeyError:

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -5,7 +5,7 @@ import sys
 import logging
 from warnings import warn
 from inspect import Parameter, Signature
-from itertools import count, tee
+from itertools import count
 from collections import deque, defaultdict, ChainMap
 from enum import Enum
 import functools

--- a/bluesky/tests/test_multi_runs.py
+++ b/bluesky/tests/test_multi_runs.py
@@ -2,6 +2,7 @@ from bluesky import preprocessors as bpp
 from bluesky import plans as bp
 from bluesky import plan_stubs as bps
 from bluesky.preprocessors import set_run_name_wrapper as srnw
+import bluesky.preprocessors as bsp
 from bluesky.tests.utils import DocCollector
 import pytest
 
@@ -11,16 +12,16 @@ def test_multirun_smoke(RE, hw):
 
     def interlaced_plan(dets, motor):
         to_read = (motor, *dets)
-        run_ids = list("abc")
-        for rid in run_ids:
+        run_names = ["run_one", "run_two", "run_three"]
+        for rid in run_names:
             yield from srnw(bps.open_run(md={rid: rid}), run=rid)
 
         for j in range(5):
-            for i, rid in enumerate(run_ids):
+            for i, rid in enumerate(run_names):
                 yield from bps.mov(motor, j + 0.1 * i)
                 yield from srnw(bps.trigger_and_read(to_read), run=rid)
 
-        for rid in run_ids:
+        for rid in run_names:
             yield from srnw(bps.close_run(), run=rid)
 
     RE(interlaced_plan([hw.det], hw.motor), dc.insert)
@@ -35,12 +36,86 @@ def test_multirun_smoke(RE, hw):
             assert start["time"] < stop["time"]
 
 
+def test_multirun_smoke_nested(RE, hw):
+
+    dc = DocCollector()
+    to_read = (hw.motor, hw.det)
+
+    def some_plan():
+        """This plan is called on each level of nesting"""
+        for j in range(5):
+            yield from bps.mov(hw.motor, j)
+            yield from bps.trigger_and_read(to_read)
+
+    @bsp.set_run_name_decorator("run_one")
+    @bsp.run_decorator(md={})
+    def plan_inner():
+        yield from some_plan()
+
+    @bsp.set_run_name_decorator("run_two")
+    @bsp.run_decorator(md={})
+    def plan_middle():
+        yield from some_plan()
+        yield from plan_inner()
+
+    @bsp.set_run_name_decorator(run="run_three")  # Try kwarg
+    @bsp.run_decorator(md={})
+    def plan_outer():
+        yield from some_plan()
+        yield from plan_middle()
+
+    RE(plan_outer(), dc.insert)
+
+    assert len(dc.start) == 3
+    for start in dc.start:
+        desc, = dc.descriptor[start["uid"]]
+        assert len(dc.event[desc["uid"]]) == 5
+
+    for stop in dc.stop.values():
+        for start in dc.start:
+            assert start["time"] < stop["time"]
+
+
+def test_multirun_run_name(RE, hw):
+    # Check if string type is checked for run name
+
+    dc = DocCollector()
+
+    @bsp.run_decorator(md={})
+    def empty_plan():
+        yield from bps.mov(hw.motor, 5)
+
+    # Check if the wrapper accepts integer
+    with pytest.raises(ValueError, match="run name must be a string"):
+        def plan1():
+            yield from srnw(empty_plan(), 50)
+        RE(plan1(), dc.insert)
+
+    # Check if the parameter is a reference (as default value)
+    with pytest.raises(ValueError, match="run name must be a string"):
+        def plan2():
+            yield from srnw(empty_plan(), object())
+        RE(plan2(), dc.insert)
+    with pytest.raises(ValueError, match="run name must be a string"):
+        def plan3():
+            yield from srnw(empty_plan(), run=object())
+        RE(plan3(), dc.insert)
+
+    # Check if call with correct parameter type are successful
+    def plan4():
+        yield from srnw(empty_plan(), "run_name")
+    RE(plan4(), dc.insert)
+    def plan5():
+        yield from srnw(empty_plan(), run="run_name")
+    RE(plan5(), dc.insert)
+
+
 def test_multirun_smoke_fail(RE, hw):
     dc = DocCollector()
 
     def interlaced_plan(dets, motor):
-        run_ids = list("abc")
-        for rid in run_ids:
+        run_names = ["run_one", "run_two", "run_three"]
+        for rid in run_names:
             yield from srnw(bps.open_run(md={rid: rid}), run=rid)
         raise Exception("womp womp")
 

--- a/bluesky/tests/test_multi_runs.py
+++ b/bluesky/tests/test_multi_runs.py
@@ -1,7 +1,7 @@
 from bluesky import preprocessors as bpp
 from bluesky import plans as bp
 from bluesky import plan_stubs as bps
-from bluesky.preprocessors import define_run_wrapper as drw
+from bluesky.preprocessors import set_run_name_wrapper as srnw
 from bluesky.tests.utils import DocCollector
 import pytest
 
@@ -13,15 +13,15 @@ def test_multirun_smoke(RE, hw):
         to_read = (motor, *dets)
         run_ids = list("abc")
         for rid in run_ids:
-            yield from drw(bps.open_run(md={rid: rid}), run=rid)
+            yield from srnw(bps.open_run(md={rid: rid}), run=rid)
 
         for j in range(5):
             for i, rid in enumerate(run_ids):
                 yield from bps.mov(motor, j + 0.1 * i)
-                yield from drw(bps.trigger_and_read(to_read), run=rid)
+                yield from srnw(bps.trigger_and_read(to_read), run=rid)
 
         for rid in run_ids:
-            yield from drw(bps.close_run(), run=rid)
+            yield from srnw(bps.close_run(), run=rid)
 
     RE(interlaced_plan([hw.det], hw.motor), dc.insert)
 
@@ -41,7 +41,7 @@ def test_multirun_smoke_fail(RE, hw):
     def interlaced_plan(dets, motor):
         run_ids = list("abc")
         for rid in run_ids:
-            yield from drw(bps.open_run(md={rid: rid}), run=rid)
+            yield from srnw(bps.open_run(md={rid: rid}), run=rid)
         raise Exception("womp womp")
 
     with pytest.raises(Exception):

--- a/bluesky/tests/test_multi_runs.py
+++ b/bluesky/tests/test_multi_runs.py
@@ -48,18 +48,18 @@ def test_multirun_smoke_nested(RE, hw):
             yield from bps.mov(hw.motor, j)
             yield from bps.trigger_and_read(to_read)
 
-    @bsp.set_run_name_decorator("run_one")
+    @bsp.set_run_id_decorator("run_one")
     @bsp.run_decorator(md={})
     def plan_inner():
         yield from some_plan()
 
-    @bsp.set_run_name_decorator("run_two")
+    @bsp.set_run_id_decorator("run_two")
     @bsp.run_decorator(md={})
     def plan_middle():
         yield from some_plan()
         yield from plan_inner()
 
-    @bsp.set_run_name_decorator(run="run_three")  # Try kwarg
+    @bsp.set_run_id_decorator(run="run_three")  # Try kwarg
     @bsp.run_decorator(md={})
     def plan_outer():
         yield from some_plan()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR includes fix for the existing issue with management of run names in multirun plans. If the plan includes nested runs, the implementation of ``set_run_name_wrapper`` would always overwrite the plan name in the message (``Msg.run``) so that the message returned by the plan would always contain the name assigned to the outermost run. The modified wrapper overwrites the run name only if it has the default value. If the name is modified in the inner run, it passes through the wrapper of the outer run unmodified.

## Description
<!--- Describe your changes in detail -->

The default value for the run name is a fixed reference to an instance of ``object()``. The reference remains constant for the whole instance of the run engine. If the name is assigned to the run using ``set_run_name_wrapper`` or ``set_run_name_decorator``, it always has ``str`` type. The modified wrapper checks the type of the run name type (``Msg.run``) and replaces it with the new value only if the type is not ``str``. 

Additional changes:

-- ``define_run_wrapper`` and ``define_run_decorator`` were renamed into ``set_run_name_wrapper`` and ``set_run_name_decorator``.

-- the type of the new run name, passed to the wrapper as a parameter, is verified. If the type is not ``str``, ``ValueError`` is raised. This prevents users for setting run names to any values other than strings.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The issue was discovered while testing the new features, which allows interlaced (and nested) runs in a single plan.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The changes are covered by tests. New tests: ``test_multirun_smoke_nested`` and ``test_multirun_run_name``. The existing tests were slightly modified for consistency.

<!--
## Screenshots (if appropriate):
-->
