### PR TITLE
ENH: add message to query the type of the RE

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -381,6 +381,7 @@ class RunEngine:
             'monitor': self._monitor,
             'unmonitor': self._unmonitor,
             'null': self._null,
+            'RE_class': self._RE_class,
             'stop': self._stop,
             'set': self._set,
             'trigger': self._trigger,
@@ -1879,6 +1880,12 @@ class RunEngine:
         A no-op message, mainly for debugging and testing.
         """
         pass
+
+    async def _RE_class(self, msg):
+        """
+        A no-op message, mainly for debugging and testing.
+        """
+        return type(self)
 
     async def _set(self, msg):
         """

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -1631,3 +1631,11 @@ def test_broken_read_exception(RE):
     obj = Dummy('broken read')
     with pytest.raises(RuntimeError):
         RE([Msg('read', obj)])
+
+
+def test_self_describe(RE):
+    def inner():
+        cls = yield Msg('RE_class')
+        assert type(RE) is cls
+
+    RE(inner())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

Adds a new message 'RE_class' which defaults to being on the RE to
query what the class of the RE running the plan is.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is useful in at least two cases:
 - identify if we are being listified
 - determine if we are running in a RE-subclass

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added a test.

<!--
-->

This can be used to reliably determine if we are in "simulation mode"
or if the RunEngine has been sub-classed etc.