### PR TITLE
Using existing callbacks with nested multirun plans

### DIFF
--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -400,10 +400,6 @@ class BestEffortCallback(QtAwareCallback):
             if peak_stats is not None:
                 peak_stats('event', doc)
 
-    #def event_page(self, doc):
-    #    for d in unpack_event_page(doc):
-    #        self.event(d)
-
     def stop(self, doc):
         if self._table is not None:
             self._table('stop', doc)

--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -16,6 +16,7 @@ import threading
 import time
 from warnings import warn
 import weakref
+from event_model import unpack_event_page
 
 from .core import LiveTable, make_class_safe
 from .mpl_plotting import LivePlot, LiveGrid, LiveScatter, QtAwareCallback
@@ -398,6 +399,10 @@ class BestEffortCallback(QtAwareCallback):
             peak_stats = self._peak_stats.get(doc['descriptor'], {}).get(y_key)
             if peak_stats is not None:
                 peak_stats('event', doc)
+
+    def event_page(self, doc):
+        for d in unpack_event_page(doc):
+            self.event(d)
 
     def stop(self, doc):
         if self._table is not None:

--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -143,7 +143,7 @@ class BestEffortCallback(QtAwareCallback):
         # Print heading.
         tt = datetime.fromtimestamp(self._start_doc['time']).utctimetuple()
         if self._heading_enabled:
-            print("Transient Scan ID: {0}     Time: {1}".format(
+            print("\n\nTransient Scan ID: {0}     Time: {1}".format(
                 self._start_doc.get('scan_id', ''),
                 time.strftime("%Y-%m-%d %H:%M:%S", tt)))
             print("Persistent Unique Scan ID: '{0}'".format(

--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -400,9 +400,9 @@ class BestEffortCallback(QtAwareCallback):
             if peak_stats is not None:
                 peak_stats('event', doc)
 
-    def event_page(self, doc):
-        for d in unpack_event_page(doc):
-            self.event(d)
+    #def event_page(self, doc):
+    #    for d in unpack_event_page(doc):
+    #        self.event(d)
 
     def stop(self, doc):
         if self._table is not None:

--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -356,7 +356,7 @@ class BestEffortCallback(QtAwareCallback):
         if stream_name == self.dim_stream:
             if self._table_enabled:
                 # plot everything, independent or dependent variables
-                self._table = LiveTable(list(self.all_dim_fields) + columns)
+                self._table = LiveTable(list(self.all_dim_fields) + columns, separator_lines=False)
                 self._table('start', self._start_doc)
                 self._table('descriptor', doc)
 

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -61,43 +61,7 @@ def make_class_safe(cls=None, *, to_wrap=None, logger=None):
 
 class CallbackBase(DocumentRouter):
     log = None
-"""
-    def __call__(self, name, doc):
-        "Dispatch to methods expecting particular doc types."
-        return getattr(self, name)(doc)
 
-    def event(self, doc):
-        pass
-
-    def event_page(self, doc):
-        for d in unpack_event_page(doc):
-            self.event(d)
-
-    def bulk_events(self, doc):
-        pass
-
-    def resource(self, doc):
-        pass
-
-    def datum(self, doc):
-        pass
-
-    def datum_page(self, doc):
-        for d in unpack_datum_page(doc):
-            self.datum(d)
-
-    def bulk_datum(self, doc):
-        pass
-
-    def descriptor(self, doc):
-        pass
-
-    def start(self, doc):
-        pass
-
-    def stop(self, doc):
-        pass
-"""
 
 class CallbackCounter:
     "As simple as it sounds: count how many times a callback is called."

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -13,7 +13,7 @@ from datetime import datetime
 import logging
 from ..utils import ensure_uid
 
-from event_model import unpack_event_page, unpack_datum_page
+from event_model import DocumentRouter
 
 logger = logging.getLogger(__name__)
 
@@ -59,9 +59,9 @@ def make_class_safe(cls=None, *, to_wrap=None, logger=None):
     return cls
 
 
-class CallbackBase:
+class CallbackBase(DocumentRouter):
     log = None
-
+"""
     def __call__(self, name, doc):
         "Dispatch to methods expecting particular doc types."
         return getattr(self, name)(doc)
@@ -97,7 +97,7 @@ class CallbackBase:
 
     def stop(self, doc):
         pass
-
+"""
 
 class CallbackCounter:
     "As simple as it sounds: count how many times a callback is called."

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -195,6 +195,9 @@ class LiveTable(CallbackBase):
     extra_pad : int, optional
          Number of extra spaces to put around the printed data, defaults to 1
 
+    separator_lines : bool, optional
+        Add empty lines before and after the printed table, default True
+
     logbook : callable, optional
         Must take a sting as the first positional argument
 
@@ -219,7 +222,7 @@ class LiveTable(CallbackBase):
 
     def __init__(self, fields, *, stream_name='primary',
                  print_header_interval=50,
-                 min_width=12, default_prec=3, extra_pad=1,
+                 min_width=12, default_prec=3, extra_pad=1, separator_lines=True,
                  logbook=None, out=print):
         super().__init__()
         self._header_interval = print_header_interval
@@ -233,6 +236,7 @@ class LiveTable(CallbackBase):
         self._extra_pad = ' ' * extra_pad
         self._min_width = min_width
         self._default_prec = default_prec
+        self._separator_lines = separator_lines
         self._format_info = OrderedDict([
             ('seq_num', self._fm_sty(10 + self._pad_len, '', 'd')),
             (self.ev_time_key, self._fm_sty(10 + 2 * extra_pad, 10, 's'))
@@ -303,7 +307,8 @@ class LiveTable(CallbackBase):
 
         self._count = 0
 
-        self._print("\n")
+        if self._separator_lines:
+            self._print("\n")
         self._print(self._sep_format)
         self._print(self._header)
         self._print(self._sep_format)
@@ -364,7 +369,8 @@ class LiveTable(CallbackBase):
         self._out(wm)
         if self.logbook:
             self.logbook('\n'.join([wm] + self._rows))
-        self._print("\n")
+        if self._separator_lines:
+            self._print("\n")
         super().stop(doc)
 
     def start(self, doc):

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -13,6 +13,7 @@ from datetime import datetime
 import logging
 from ..utils import ensure_uid
 
+from event_model import unpack_event_page, unpack_datum_page
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +69,10 @@ class CallbackBase:
     def event(self, doc):
         pass
 
+    def event_page(self, doc):
+        for d in unpack_event_page(doc):
+            self.event(d)
+
     def bulk_events(self, doc):
         pass
 
@@ -76,6 +81,10 @@ class CallbackBase:
 
     def datum(self, doc):
         pass
+
+    def datum_page(self, doc):
+        for d in unpack_datum_page(doc):
+            self.datum(d)
 
     def bulk_datum(self, doc):
         pass

--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -303,6 +303,7 @@ class LiveTable(CallbackBase):
 
         self._count = 0
 
+        self._print("\n")
         self._print(self._sep_format)
         self._print(self._header)
         self._print(self._sep_format)
@@ -363,6 +364,7 @@ class LiveTable(CallbackBase):
         self._out(wm)
         if self.logbook:
             self.logbook('\n'.join([wm] + self._rows))
+        self._print("\n")
         super().stop(doc)
 
     def start(self, doc):

--- a/bluesky/callbacks/mpl_plotting.py
+++ b/bluesky/callbacks/mpl_plotting.py
@@ -39,7 +39,7 @@ def _get_teleporter():
 
     if threading.current_thread() is not threading.main_thread():
         raise RuntimeError(
-            "A bluesky QtAwareCallback was instantiated from a backgrond "
+            "A bluesky QtAwareCallback was instantiated from a background "
             "thread before the bluesky qt 'teleporter' was created. "
             "To avoid this issue, "
             "call bluesky.mpl_plotting.initialize_teleporter() "

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -341,6 +341,9 @@ class RunEngine:
         self.record_interruptions = False
         self.pause_msg = PAUSE_MSG
 
+        from .utils import initialize_backend
+        initialize_backend()
+
         # The RunEngine keeps track of a *lot* of state.
         # All flags and caches are defined here with a comment. Good luck.
 

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -14,6 +14,7 @@ from contextlib import ExitStack
 import threading
 import weakref
 from .bundlers import RunBundler
+from .utils import initialize_backend
 
 import concurrent
 
@@ -341,7 +342,6 @@ class RunEngine:
         self.record_interruptions = False
         self.pause_msg = PAUSE_MSG
 
-        from .utils import initialize_backend
         initialize_backend()
 
         # The RunEngine keeps track of a *lot* of state.

--- a/bluesky/tests/test_bec.py
+++ b/bluesky/tests/test_bec.py
@@ -1,11 +1,13 @@
 import ast
 import pytest
 import jsonschema
+import re
 from bluesky.plans import scan, grid_scan
 import bluesky.preprocessors as bpp
 import bluesky.plan_stubs as bps
 from bluesky.preprocessors import SupplementalData
 from bluesky.callbacks.best_effort import BestEffortCallback
+from event_model import RunRouter
 
 
 def test_hints(RE, hw):
@@ -90,21 +92,66 @@ def test_live_grid(RE, hw):
     RE(grid_scan([hw.det4], hw.motor1, 0, 1, 1, hw.motor2, 0, 1, 2, True))
 
 
-def test_multirun_nested_plan(RE, hw):
-
+def test_multirun_nested_plan(capsys, caplog, RE, hw):
+    # This test only checks if the plan runs without crashing. If BEC crashes,
+    #   the plan will still run, but data will not be displayed.
     @bpp.set_run_id_decorator(run="inner_run")
     def plan_inner():
-        yield from scan([hw.det1], hw.motor, 1, 5, 5)
+        yield from grid_scan([hw.det4], hw.motor1, 0, 1, 1, hw.motor2, 0, 1, 2, True)
+
+    def sequence():
+        for n in range(5):
+            yield from bps.create()
+            yield from bps.abs_set(hw.motor, n * 0.1 + 1, group="motor")
+            yield from bps.wait(group="motor")
+            yield from bps.read(hw.det1)
+            yield from bps.save()
 
     @bpp.set_run_id_decorator(run="outer_run")
+    @bpp.stage_decorator([hw.det1, hw.motor])
+    @bpp.run_decorator(md={})
     def plan_outer():
-        yield from grid_scan([hw.det4], hw.motor1, 0, 1, 1, hw.motor2, 0, 1, 2, True)
+        yield from sequence()
         # Call inner plan from within the plan
         yield from plan_inner()
         # Run another set of commands
-        yield from grid_scan([hw.det4], hw.motor1, 0, 1, 1, hw.motor2, 0, 1, 2, True)
+        yield from sequence()
 
+    # The first test should fail. We check if expected error message is printed in case
+    #   of failure.
+    bec = BestEffortCallback()
+    bec_token = RE.subscribe(bec)
     RE(plan_outer())
+
+    captured = capsys.readouterr()
+
+    # Check for the number of runs (the number of times UID is printed in the output)
+    scan_uid_substr = "Persistent Unique Scan ID"
+    n_runs = captured.out.count(scan_uid_substr)
+    assert n_runs == 2, "scan output contains incorrect number of runs"
+    # Check if the expected error message is printed once the callback fails. The same
+    #   substring will be used in the second part of the test to check if BEC did not fail.
+    err_msg_substr = "is being suppressed to not interrupt plan execution"
+    assert err_msg_substr in str(caplog.text), \
+        "Best Effort Callback failed, but expected error message was not printed"
+
+    RE.unsubscribe(bec_token)
+    caplog.clear()
+
+    # The second test should succeed, i.e. the error message should not be printed
+    def wrapper(name, doc):
+        bec = BestEffortCallback()
+        bec(name, doc)
+        return [bec], []
+    rr = RunRouter([wrapper])
+    RE.subscribe(rr)
+    RE(plan_outer())
+
+    captured = capsys.readouterr()
+    n_runs = captured.out.count(scan_uid_substr)
+    assert n_runs == 2, "scan output contains incorrect number of runs"
+    assert err_msg_substr not in caplog.text, \
+        "Best Effort Callback failed while executing nested plans"
 
 
 @pytest.mark.xfail(not (jsonschema.__version__.split('.') < ['3', ]),

--- a/bluesky/tests/test_bec.py
+++ b/bluesky/tests/test_bec.py
@@ -95,7 +95,7 @@ def test_live_grid(RE, hw):
 def test_multirun_nested_plan(capsys, caplog, RE, hw):
     # This test only checks if the plan runs without crashing. If BEC crashes,
     #   the plan will still run, but data will not be displayed.
-    @bpp.set_run_id_decorator(run="inner_run")
+    @bpp.set_run_key_decorator(run="inner_run")
     def plan_inner():
         yield from grid_scan([hw.det4], hw.motor1, 0, 1, 1, hw.motor2, 0, 1, 2, True)
 
@@ -104,7 +104,7 @@ def test_multirun_nested_plan(capsys, caplog, RE, hw):
             yield from bps.mov(hw.motor, n * 0.1 + 1)
             yield from bps.trigger_and_read([hw.det1])
 
-    @bpp.set_run_id_decorator(run="outer_run")
+    @bpp.set_run_key_decorator(run="outer_run")
     @bpp.stage_decorator([hw.det1, hw.motor])
     @bpp.run_decorator(md={})
     def plan_outer():

--- a/bluesky/tests/test_bec.py
+++ b/bluesky/tests/test_bec.py
@@ -101,11 +101,8 @@ def test_multirun_nested_plan(capsys, caplog, RE, hw):
 
     def sequence():
         for n in range(5):
-            yield from bps.create()
-            yield from bps.abs_set(hw.motor, n * 0.1 + 1, group="motor")
-            yield from bps.wait(group="motor")
-            yield from bps.read(hw.det1)
-            yield from bps.save()
+            yield from bps.mov(hw.motor, n * 0.1 + 1)
+            yield from bps.trigger_and_read([hw.det1])
 
     @bpp.set_run_id_decorator(run="outer_run")
     @bpp.stage_decorator([hw.det1, hw.motor])

--- a/bluesky/tests/test_bec.py
+++ b/bluesky/tests/test_bec.py
@@ -90,6 +90,23 @@ def test_live_grid(RE, hw):
     RE(grid_scan([hw.det4], hw.motor1, 0, 1, 1, hw.motor2, 0, 1, 2, True))
 
 
+def test_multirun_nested_plan(RE, hw):
+
+    @bpp.set_run_id_decorator(run="inner_run")
+    def plan_inner():
+        yield from scan([hw.det1], hw.motor, 1, 5, 5)
+
+    @bpp.set_run_id_decorator(run="outer_run")
+    def plan_outer():
+        yield from grid_scan([hw.det4], hw.motor1, 0, 1, 1, hw.motor2, 0, 1, 2, True)
+        # Call inner plan from within the plan
+        yield from plan_inner()
+        # Run another set of commands
+        yield from grid_scan([hw.det4], hw.motor1, 0, 1, 1, hw.motor2, 0, 1, 2, True)
+
+    RE(plan_outer())
+
+
 @pytest.mark.xfail(not (jsonschema.__version__.split('.') < ['3', ]),
                    reason='Deprecations in jsonschema')
 def test_plot_ints(RE):

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -157,7 +157,7 @@ def test_table(RE, hw):
         assert hw.det.describe()['det']['dtype'] == 'number'
         assert hw.motor.describe()['motor']['dtype'] == 'number'
 
-        table = LiveTable(['det', 'motor'], min_width=16, extra_pad=2)
+        table = LiveTable(['det', 'motor'], min_width=16, extra_pad=2, separator_lines=False)
         ad_scan = bp.adaptive_scan([hw.det], 'det', hw.motor,
                                    -15.0, 5., .01, 1, .05,
                                    True)
@@ -171,7 +171,6 @@ def test_table(RE, hw):
     for ln, kn in zip(fout, KNOWN_TABLE.split('\n')):
         # this is to strip the `\n` from the print output
         ln = ln.rstrip()
-
         if ln[0] == '+':
             # test the full line on the divider lines
             assert ln == kn
@@ -523,7 +522,8 @@ def test_broken_table():
     sio.seek(0)
     lines = sio.readlines()
 
-    assert len(lines) == 7
+    # The instance of LiveTable will include two empty separator lines by default
+    assert len(lines) == 9
     for ln in lines[-2:]:
         assert ln.strip() == "failed to format row"
 

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -1359,7 +1359,12 @@ def default_during_task(blocking_event):
         backend = matplotlib.get_backend().lower()
         # if with a Qt backend, do the scary thing
         if 'qt' in backend:
+
             from matplotlib.backends.qt_compat import QtCore, QtWidgets
+            from .callbacks.mpl_plotting import initialize_qt_teleporter
+
+            initialize_qt_teleporter()
+
             app = QtWidgets.QApplication.instance()
             if app is None:
                 _qapp = app = QtWidgets.QApplication([b'bluesky'])

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -1338,7 +1338,7 @@ _qapp = None
 
 class DuringTask:
 
-    def initialize(self):
+    def __init__(self):
         pass
 
     def block(self, blocking_event):
@@ -1347,7 +1347,7 @@ class DuringTask:
 
 class DefaultDuringTask(DuringTask):
 
-    def initialize(self):
+    def __init__(self):
         """
         Initialize backend. Currently on Qt backend is supported. The function
         is initalizing the 'teleporter' if Qt backend is used.

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -1336,6 +1336,19 @@ def merge_cycler(cyc):
 _qapp = None
 
 
+def initialize_backend():
+    """
+    Initialize backend. Currently on Qt backend is supported. The function
+    is initalizing the 'teleporter' if Qt backend is used.
+    """
+    if 'matplotlib' in sys.modules:
+        import matplotlib
+        backend = matplotlib.get_backend().lower()
+        if 'qt' in backend:
+            from .callbacks.mpl_plotting import initialize_qt_teleporter
+            initialize_qt_teleporter()
+
+
 def default_during_task(blocking_event):
     """
     The default setting for the RunEngine's during_task parameter.
@@ -1361,10 +1374,6 @@ def default_during_task(blocking_event):
         if 'qt' in backend:
 
             from matplotlib.backends.qt_compat import QtCore, QtWidgets
-            from .callbacks.mpl_plotting import initialize_qt_teleporter
-
-            initialize_qt_teleporter()
-
             app = QtWidgets.QApplication.instance()
             if app is None:
                 _qapp = app = QtWidgets.QApplication([b'bluesky'])

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -1342,7 +1342,7 @@ class DuringTask:
         pass
 
     def block(self, blocking_event):
-        pass
+        blocking_event.wait()
 
 
 class DefaultDuringTask(DuringTask):

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -1349,8 +1349,8 @@ class DefaultDuringTask(DuringTask):
 
     def __init__(self):
         """
-        Initialize backend. Currently on Qt backend is supported. The function
-        is initalizing the 'teleporter' if Qt backend is used.
+        Initialize backend. Currently only the Qt backend is supported. The function
+        is initializing the 'teleporter' if Qt backend is used.
         """
         if 'matplotlib' in sys.modules:
             import matplotlib
@@ -1459,8 +1459,8 @@ class DefaultDuringTask(DuringTask):
 
                 # we also need to make sure that the qApp never sees
                 # exceptions raised by python inside of a c++ callback (as
-                # it will segfault its self because due to the way the
-                # code is called there is no clear way to propgate that
+                # it will segfault itself because due to the way the
+                # code is called there is no clear way to propagate that
                 # back to the python code.
                 vals = (None, None, None)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The change in the PR allow to use existing callbacks, including ``BestEffortCallback``, `LivePlot` and `LiveTable` with plans that contain nested runs. Following is the example of such scan, which starts and completes separate run `sim_plan_inner` from `sim_plan`: 
```
@bpp.set_run_key_decorator("run_inner")
@bpp.run_decorator(md={"run_key": "run_1"})
def sim_plan_inner():
    # ... some commands, e.g. use simulated 'hw.motor1', 'hw.motor2' and 'hw.det2'

@bpp.set_run_key_decorator("run_outer")
@bpp.run_decorator(md={"run_key": "run_1"})
def sim_plan(npts):
    # ... some commands, e.g. use simulated 'hw.motor', 'hw.det'
    yield from sim_plan_inner()
    # ... some commands, continue 'sim_plan'
```

Regular subscription to RunEngine can not be used with nested plans, since it provides no mechanism for routing data to different callbacks or different instances of the same callback based on ID of the run producing the data. Instead, the callbacks should be subscribed to the RunEngine via RunRouter (example for the plan above):
```
from event_model import RunRouter

def factory(name, doc):
    cb_list = []
    if doc["run_key"] == "run_1":
        # Pick a set of callbacks based on metadata in the start document
        cb_list.append(LiveTable([hw.motor, hw.det]))
        cb_list.append(LivePlot('det', x='motor'))
    elif doc["run_key"] == "run_2":
        cb_list.append(LiveTable([hw.motor1, hw.motor2, hw.det2]))
    for cb in cb_list:
        cb(name, doc)
    return cb_list, []

RE = RunEngine({})
rr = RunRouter([factory])
RE.subscribe(rr)
```

## Description
<!--- Describe your changes in detail -->
The changes include:

-- `CallbackBase` is now derived from `event_model.DocumentRouter`, which provides default implementations for the `event_page` and `datum_page` methods.

-- 'QT teleporter' is initialized from within the `RunEngine`, not during callback instatiation.

-- Blank separator lines are added before and after tables in `BestEffortCallback` and `LiveTable` for better visual presentation of nested tables. Additional parameter `separator_lines` is added `LiveTable` initalization arguments, that allows to disable additional separator lines. It is used when `LiveTable` is called from `BestEffortCallback` to avoid insertion of unnecessary blank lines.

-- Additional tests are added.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
PR addresses a problem of visualization of data from nested multirun scans.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Additional unit tests are included. The operation was also manually tested to check quality of visual presentation of output data.
<!--
## Screenshots (if appropriate):
-->
