### PR TITLE
ENH: add a message to reset the user position on a motor

### DIFF
--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -1084,3 +1084,43 @@ def repeat(plan, num=1, delay=None):
                     yield Msg('sleep', None, d)
 
     return (yield from repeated_plan())
+
+
+def reset_user_position(obj, value, *, verbose=False):
+    """
+    Repeat a plan num times with delay and checkpoint between each repeat.
+
+    This is different from ``repeater`` and ``caching_repeater`` in that it
+    adds ``checkpoint`` and optionally ``sleep`` messages if delay is provided.
+    This is intended for users who need the structure of ``count`` but do not
+    want to reimplement the control flow.
+
+    Parameters
+    ----------
+    obj : EpicsMotor
+        Must have position attribute and set_current_position methods
+
+    value : number
+        What to set the current user position to.
+
+    verbose : bool, optional
+        If we should print out a log of what we are doing
+
+    Returns
+    -------
+    old_value : number
+        Where the user setpoint was before
+
+    new_value : number
+        Where the user setpoint is now
+
+    """
+    ret = yield Msg('reset_user_position', obj, value)
+    if ret is not None:
+        old_value, new_value = ret
+    else:
+        old_value = None
+        new_value = value
+    if verbose:
+        print(f"{obj.name} reset from {old_value} to {new_value}")
+    return old_value, new_value

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -377,6 +377,7 @@ class RunEngine:
             'null': self._null,
             'stop': self._stop,
             'set': self._set,
+            'reset_user_position': self._reset_user_position,
             'trigger': self._trigger,
             'sleep': self._sleep,
             'wait': self._wait,
@@ -1910,6 +1911,44 @@ class RunEngine:
         self._status_objs[group].add(ret)
 
         return ret
+
+    @staticmethod
+    async def _reset_user_position(msg):
+        """
+        Reset the user coordinate system on a motor
+
+        Expected message object is:
+
+            Msg('reset_user_position', obj, new_position)
+
+        The object passed in must have:
+
+           - position attribute
+           - set_current_position method
+
+        Returns
+        -------
+        old_value, new_value
+        """
+        obj = msg.obj
+
+        (new_value,) = msg.args
+
+        try:
+            old_value = obj.position
+        except AttributeError as ex:
+            raise ValueError(
+                "Expected a positioner (must have) position attribute "
+                f"but the object {obj.name} does not."
+            ) from ex
+        try:
+            obj.set_current_position(new_value)
+        except AttributeError as ex:
+            raise ValueError(
+                "Expected object to have set_current_position method "
+                f"but the object {obj.name} does not."
+            ) from ex
+        return (old_value, new_value)
 
     async def _trigger(self, msg):
         """


### PR DESCRIPTION
This came up at JPLS at NSLS-II.  Due to their geometry and the fact
that their sample is fluid and evaporates, they need to frequently
reset the user position.

attn @prjemian 