### PR TITLE
FIX: regression in validating the per_step signature for 1d case

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -922,6 +922,8 @@ def scan_nd(detectors, cycler, *, per_step=None, md=None):
         sig = inspect.signature(per_step)
 
         def _verify_1d_step(sig):
+            if len(sig.parameters) < 3:
+                return False
             for name, (p_name, p) in zip_longest(['detectors', 'motor', 'step'], sig.parameters.items()):
                 # this is one of the first 3 positional arguements, check that the name matches
                 if name is not None:

--- a/bluesky/tests/test_plans.py
+++ b/bluesky/tests/test_plans.py
@@ -1,7 +1,6 @@
 import pytest
 from bluesky.tests.utils import DocCollector
 import bluesky.plans as bp
-import bluesky.preprocessors as bpp
 import bluesky.plan_stubs as bps
 import numpy as np
 import pandas as pd

--- a/bluesky/tests/test_plans.py
+++ b/bluesky/tests/test_plans.py
@@ -4,6 +4,7 @@ import bluesky.plans as bp
 import bluesky.plan_stubs as bps
 import numpy as np
 import pandas as pd
+import re
 from bluesky.tests.utils import MsgCollector
 
 
@@ -246,7 +247,7 @@ def _bad_per_step_factory():
 def test_bad_per_step_signature(hw, per_step):
     with pytest.raises(
         TypeError,
-        message=(
+        match=re.escape(
             "per_step must be a callable with the signature "
             "<Signature (detectors, step, pos_cache)> or "
             "<Signature (detectors, motor, step)>."

--- a/bluesky/tests/test_plans.py
+++ b/bluesky/tests/test_plans.py
@@ -222,19 +222,19 @@ def test_good_per_step_signature(hw, per_step):
 
 def _bad_per_step_factory():
     def too_few(detectors, motor):
-        yield from bps.null()
+        "no body"
 
     def too_many(detectors, motor, step, bob):
-        yield from bps.null()
+        "no body"
 
     def extra_required_kwarg(detectors, motor, step, *, some_kwarg):
-        yield from bps.null()
+        "no body"
 
     def wrong_names(a, b, c, take_reading=None):
-        yield from bps.null()
+        "no body"
 
     def per_step_only_args(*args):
-        yield from bps.null()
+        "no body"
 
     return pytest.mark.parametrize(
         "per_step",

--- a/bluesky/tests/test_plans.py
+++ b/bluesky/tests/test_plans.py
@@ -192,3 +192,65 @@ def test_pseudo_mv(hw, RE, pln):
     expecte_objs = [p, None]
     assert len(m_col.msgs) == 2
     assert [m.obj for m in m_col.msgs] == expecte_objs
+
+
+def _good_per_step_factory():
+    def per_step_old(detectors, motor, step):
+        yield from bps.null()
+
+    def per_step_extra(detectors, motor, step, some_kwarg=None):
+        yield from bps.null()
+
+    def per_step_exact(detectors, motor, step, take_reading=None):
+        yield from bps.null()
+
+    def per_step_kwargs(detectors, motor, step, **kwargs):
+        yield from bps.null()
+
+    return pytest.mark.parametrize(
+        "per_step",
+        [per_step_old, per_step_extra, per_step_exact, per_step_kwargs],
+        ids=["no kwargs", "extra kwargs", "exact signature", "with kwargs"],
+    )
+
+
+@_good_per_step_factory()
+def test_good_per_step_signature(hw, per_step):
+
+    list(bp.scan([hw.det], hw.motor, -1, 1, 5, per_step=per_step))
+
+
+def _bad_per_step_factory():
+    def too_few(detectors, motor):
+        yield from bps.null()
+
+    def too_many(detectors, motor, step, bob):
+        yield from bps.null()
+
+    def extra_required_kwarg(detectors, motor, step, *, some_kwarg):
+        yield from bps.null()
+
+    def wrong_names(a, b, c, take_reading=None):
+        yield from bps.null()
+
+    def per_step_only_args(*args):
+        yield from bps.null()
+
+    return pytest.mark.parametrize(
+        "per_step",
+        [too_few, too_many, extra_required_kwarg, wrong_names, per_step_only_args],
+        ids=["too few", "too many", "required kwarg", "bad name", "args only"],
+    )
+
+
+@_bad_per_step_factory()
+def test_bad_per_step_signature(hw, per_step):
+    with pytest.raises(
+        TypeError,
+        message=(
+            "per_step must be a callable with the signature "
+            "<Signature (detectors, step, pos_cache)> or "
+            "<Signature (detectors, motor, step)>."
+        ),
+    ):
+        list(bp.scan([hw.det], hw.motor, -1, 1, 5, per_step=per_step))


### PR DESCRIPTION
closes #1295

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

Fixes a regression in how we validate the per_step functions


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added tests of both passing and failing signatures

<!--
-->