### PR TITLE
Print run key as part of message data in 'ts_msg_hook'

### DIFF
--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -1007,11 +1007,12 @@ def ensure_uid(doc_or_uid):
 
 def ts_msg_hook(msg, file=sys.stdout):
     t = '{:%H:%M:%S.%f}'.format(datetime.datetime.now())
-    msg_fmt = '{: <17s} -> {!s: <15s} args: {}, kwargs: {}'.format(
+    msg_fmt = "{: <17s} -> {!s: <15s} args: {}, kwargs: {}, run: {}".format(
         msg.command,
         msg.obj.name if hasattr(msg.obj, 'name') else msg.obj,
         msg.args,
-        msg.kwargs)
+        msg.kwargs,
+        "'{}'".format(msg.run) if isinstance(msg.run, str) else msg.run)
     print('{} {}'.format(t, msg_fmt), file=file)
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

In this PR, the code of `ts_msg_hook` is changed to print the value of the run key along with the rest of data in the Msg object.

## Description
<!--- Describe your changes in detail -->

Run key is printed in quotes (e.g. `run: 'run_#1'` or `run: '500'`) if it a string, otherwise it is printed without quotes (e.g. `run: 500`, `run: None` or `run: <object object at 0x7f629948aa70>`). Knowing whether run key is a string or not may be useful during debugging of plans.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Information on the message run key is necessary while debugging multirun plans.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->

Example of the message data printed while running a simulated scan.

```
09:41:12.405496 open_run          -> None            args: (), kwargs: {'run_id': 'run_1'}, run: 'run_1'
09:41:12.409168 set               -> motor           args: (0,), kwargs: {'group': '74a1b030-acc3-4719-9d9d-efef61948936'}, run: 'run_1'
09:41:12.409775 wait              -> None            args: (), kwargs: {'group': '74a1b030-acc3-4719-9d9d-efef61948936'}, run: 'run_1'
09:41:12.410461 trigger           -> motor           args: (), kwargs: {'group': 'trigger-443794'}, run: 'run_1'


Transient Scan ID: 1     Time: 2020-02-25 09:41:12
09:41:12.411109 trigger           -> det             args: (), kwargs: {'group': 'trigger-443794'}, run: 'run_1'
Persistent Unique Scan ID: 'db9170c9-6477-430f-8ee4-2909207cc99f'
09:41:12.411925 wait              -> None            args: (), kwargs: {'group': 'trigger-443794'}, run: 'run_1'
09:41:12.412280 create            -> None            args: (), kwargs: {'name': 'primary'}, run: 'run_1'
09:41:12.412614 read              -> motor           args: (), kwargs: {}, run: 'run_1'
09:41:12.413379 read              -> det             args: (), kwargs: {}, run: 'run_1'
09:41:12.413983 save              -> None            args: (), kwargs: {}, run: 'run_1'
09:41:12.419403 sleep             -> None            args: (0.5,), kwargs: {}, run: 'run_1'
New stream: 'primary'
+-----------+------------+------------+------------+
|   seq_num |       time |      motor |        det |
+-----------+------------+------------+------------+
|         1 | 09:41:12.4 |          0 |      1.000 |
09:41:12.921057 set               -> motor           args: (1,), kwargs: {'group': '95b6d4ea-6a98-4bf6-aa5c-2f856856fac2'}, run: 'run_1'
09:41:12.921588 wait              -> None            args: (), kwargs: {'group': '95b6d4ea-6a98-4bf6-aa5c-2f856856fac2'}, run: 'run_1'
09:41:12.922093 trigger           -> motor           args: (), kwargs: {'group': 'trigger-19575b'}, run: 'run_1'
09:41:12.922364 trigger           -> det             args: (), kwargs: {'group': 'trigger-19575b'}, run: 'run_1'
09:41:12.922897 wait              -> None            args: (), kwargs: {'group': 'trigger-19575b'}, run: 'run_1'
09:41:12.923212 create            -> None            args: (), kwargs: {'name': 'primary'}, run: 'run_1'
09:41:12.923353 read              -> motor           args: (), kwargs: {}, run: 'run_1'
09:41:12.923599 read              -> det             args: (), kwargs: {}, run: 'run_1'
09:41:12.923812 save              -> None            args: (), kwargs: {}, run: 'run_1'
09:41:12.924553 sleep             -> None            args: (0.5,), kwargs: {}, run: 'run_1'
|         2 | 09:41:12.9 |          1 |      0.607 |
09:41:13.426036 set               -> motor           args: (2,), kwargs: {'group': '4942a42f-b2c0-4baa-92f9-77c1e20d35f4'}, run: 'run_1'
09:41:13.426577 wait              -> None            args: (), kwargs: {'group': '4942a42f-b2c0-4baa-92f9-77c1e20d35f4'}, run: 'run_1'
09:41:13.427117 trigger           -> motor           args: (), kwargs: {'group': 'trigger-c73447'}, run: 'run_1'
09:41:13.427398 trigger           -> det             args: (), kwargs: {'group': 'trigger-c73447'}, run: 'run_1'
09:41:13.427877 wait              -> None            args: (), kwargs: {'group': 'trigger-c73447'}, run: 'run_1'
09:41:13.428173 create            -> None            args: (), kwargs: {'name': 'primary'}, run: 'run_1'
09:41:13.428313 read              -> motor           args: (), kwargs: {}, run: 'run_1'
09:41:13.428544 read              -> det             args: (), kwargs: {}, run: 'run_1'
09:41:13.428744 save              -> None            args: (), kwargs: {}, run: 'run_1'
09:41:13.429479 sleep             -> None            args: (0.5,), kwargs: {}, run: 'run_1'
|         3 | 09:41:13.4 |          2 |      0.135 |
09:41:13.931243 set               -> motor           args: (3,), kwargs: {'group': '4ee10b61-16f3-470e-81e1-074ac2debb29'}, run: 'run_1'
09:41:13.931877 wait              -> None            args: (), kwargs: {'group': '4ee10b61-16f3-470e-81e1-074ac2debb29'}, run: 'run_1'
09:41:13.932389 trigger           -> motor           args: (), kwargs: {'group': 'trigger-0618b7'}, run: 'run_1'
09:41:13.932670 trigger           -> det             args: (), kwargs: {'group': 'trigger-0618b7'}, run: 'run_1'
09:41:13.933169 wait              -> None            args: (), kwargs: {'group': 'trigger-0618b7'}, run: 'run_1'
09:41:13.933529 create            -> None            args: (), kwargs: {'name': 'primary'}, run: 'run_1'
09:41:13.933688 read              -> motor           args: (), kwargs: {}, run: 'run_1'
09:41:13.933935 read              -> det             args: (), kwargs: {}, run: 'run_1'
09:41:13.934167 save              -> None            args: (), kwargs: {}, run: 'run_1'
09:41:13.934986 sleep             -> None            args: (0.5,), kwargs: {}, run: 'run_1'
|         4 | 09:41:13.9 |          3 |      0.011 |
09:41:14.436750 set               -> motor           args: (4,), kwargs: {'group': '680f91ed-bfcf-4c46-92d9-ed1b6b43a3e1'}, run: 'run_1'
09:41:14.437298 wait              -> None            args: (), kwargs: {'group': '680f91ed-bfcf-4c46-92d9-ed1b6b43a3e1'}, run: 'run_1'
09:41:14.437797 trigger           -> motor           args: (), kwargs: {'group': 'trigger-cc5dc3'}, run: 'run_1'
09:41:14.438069 trigger           -> det             args: (), kwargs: {'group': 'trigger-cc5dc3'}, run: 'run_1'
09:41:14.438583 wait              -> None            args: (), kwargs: {'group': 'trigger-cc5dc3'}, run: 'run_1'
09:41:14.438929 create            -> None            args: (), kwargs: {'name': 'primary'}, run: 'run_1'
09:41:14.439072 read              -> motor           args: (), kwargs: {}, run: 'run_1'
09:41:14.439311 read              -> det             args: (), kwargs: {}, run: 'run_1'
09:41:14.439511 save              -> None            args: (), kwargs: {}, run: 'run_1'
09:41:14.440380 sleep             -> None            args: (0.5,), kwargs: {}, run: 'run_1'
```