### PR TITLE
Fix for CI in 1.5.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ matrix:
       python: 3.6
     - os: linux
       python: 3.7
-    - os: linux
-      python: 3.8
     - python: nightly
 
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ matrix:
   include:
     - python: 3.6
       env: BUILD_DOCS=1
+    - os: linux
+      python: 3.7
+    - os: linux
+      python: 3.8
     - python: nightly
   allow_failures:
     - python: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`
   - pip install --upgrade pip
   - pip install --upgrade cython
+  - pip install --upgrade numpy
   - pip install --quiet --upgrade --global-option='--without-libyaml' pyyaml
   - pip install -r requirements.txt
   - pip install -r dev-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,14 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - python: 3.6
-      env: BUILD_DOCS=1
+    - os: linux
+      python: 3.6
     - os: linux
       python: 3.7
     - os: linux
       python: 3.8
-    - python: nightly
+    - os: linux
+      python: nightly
   allow_failures:
     - python: nightly
 

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -128,7 +128,7 @@ def test_table(RE, hw):
         hw.det.precision = 2
         hw.motor.precision = 2
         hw.motor.setpoint.put(0.0)  # Make dtype 'number' not 'integer'.
-        hw.det.put(0.0)  # Make dtype 'number' not 'integer'.
+        hw.det.trigger()
         assert hw.det.describe()['det']['precision'] == 2
         assert hw.motor.describe()['motor']['precision'] == 2
         assert hw.det.describe()['det']['dtype'] == 'number'

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -670,15 +670,3 @@ def test_async_trigger_delay(RE, hw):
 
     _time_test(bps.trigger, .5, hw.det, wait=True)
     _time_test(bps.abs_set, .5, hw.motor, 1, wait=True)
-
-
-def test_reg_reader(hw, db):
-    hw.img.reg = db.reg
-    det = hw.img
-    det.stage()
-    det.trigger()
-    reading = det.read().copy()
-    det.unstage()
-    datum_id = reading['img']['value']
-    arr = db.reg.retrieve(datum_id)
-    assert_array_equal(np.ones((10, 10)), arr)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -19,7 +19,7 @@ pims
 pyepics
 pytest
 pyyaml
-pyzmq==16.0.4
+pyzmq
 requests
 streamz
 sphinx==1.6.4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixed CI for v1.5.x branch:
- removed `test_reg_reader` test (uses deprecated feature of Databroker);
- fixed `test_table` test.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
