### PR TITLE
Support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
       python: 3.6
     - os: linux
       python: 3.7
+    - os: linux
+      python: 3.8
     - python: nightly
 
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ install:
   - git clean -xfd
   # make sure the sqlite file exists to avoid race conditions
   - python -c "from bluesky.utils import get_history; get_history()"
-  - conda list
   - pip list
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 env:
   global:
     - secure: "UC5rEkKAKQHvpCojJAedrx1aVsplZ0xOq5xdFME3UxrKDOsihRIDBYV6YOnpDcWVxzI3iZAJOJG1rNqMZ/4pOnI/DQ5n2nCIbqZlhPh6xPbr//g88Y3dlQifPWbC6pqmh+WJCfde99lYNDI2XauD4AvRARI9MnRP9vGF0gyTbUMeA0ybLdXScawnhL48Gh7nj64R7e0F1SgF1iEXaU0LvWUW2UK9yIg/kqWfL0XKpgpvxcy0n+VGe9gbwiA70F3nd7iZ/aM7K1MRiLeppCbj3xlLwGE4mw6svF5uim6oYZoDp0si70Ux2yw7TNOYpn82dTBIq1KU59jGUyP/rH/nx0erPzCUJFak8YQTSrbhO08u/baRt5Qb0KWfqGJZcHzPknRC66PzI47zO5ol9qvnIo68xfuIrlJZRhTF7ewNWzmJP5MeJ85mgoQSTmZYyCgFTYDcPdoePerhjBepYngvT1EzS9BPTuUXhStH7lRgbriGVreOQ9bDvW5hTb/n9CKmI/XhQBOGy7T1HYAaIP1N+rlQw0lmp2uYIvZ53wGjqoKB+yLBpAAzXPBbK3sjDtuquou/jEqvyJnL9/VEbohPfIK3AlTTC0zIDi5QZq/h4zqMIKOybd3jmvT4P+Pvy8YGolXtlV6P/erA05GAOXijs/pki/BVcGsHNNjr1xRE0qU="
@@ -9,7 +8,7 @@ cache:
     - $HOME/.cache/pip
     - $HOME/.cache/matplotlib
 
-matrix:
+jobs:
   fast_finish: true
   include:
     - os: linux
@@ -18,10 +17,12 @@ matrix:
       python: 3.7
     - os: linux
       python: 3.8
-    - python: nightly
+    - os: linux
+      python: nightly
 
   allow_failures:
-    - python: nightly
+    - os: linux
+      python: nightly
 
 before_install:
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
@@ -44,6 +45,8 @@ install:
   - git clean -xfd
   # make sure the sqlite file exists to avoid race conditions
   - python -c "from bluesky.utils import get_history; get_history()"
+  - conda list
+  - pip list
 
 script:
   # ensure that callbacks import without matplotlib

--- a/bluesky/callbacks/zmq.py
+++ b/bluesky/callbacks/zmq.py
@@ -249,11 +249,10 @@ class RemoteDispatcher(Dispatcher):
 
         super().__init__()
 
-    @asyncio.coroutine
-    def _poll(self):
+    async def _poll(self):
         our_prefix = self._prefix  # local var to save an attribute lookup
         while True:
-            message = yield from self._socket.recv()
+            message = await self._socket.recv()
             prefix, name, doc = message.split(b' ', 2)
             name = name.decode()
             if (not our_prefix) or prefix == our_prefix:

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -2399,8 +2399,7 @@ class Dispatcher:
             self._token_mapping[public_token] = private_tokens
             return public_token
 
-        if name not in DocumentNames:
-            name = DocumentNames[name]
+        name = DocumentNames[name]
         private_token = self.cb_registry.connect(name, func)
         public_token = next(self._counter)
         self._token_mapping[public_token] = [private_token]

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -667,18 +667,16 @@ def test_per_step(RE, hw):
     # that the problem is with 'per_step':
 
     # You can't usage one_1d_step signature with more than one motor.
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(TypeError, match="Signature of per_step assumes 1D trajectory"):
         RE(scan([hw.det],
                 hw.motor, -1, 1,
                 hw.motor2, -1, 1,
                 3,
                 per_step=one_1d_step))
-    assert "Signature of per_step assumes 1D trajectory" in str(exc)
 
     # The signature must be either like one_1d_step or one_nd_step:
     def bad_sig(detectors, mtr, step):
         ...
 
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(TypeError, match="per_step must be a callable with the signature"):
         RE(scan([hw.det], hw.motor, -1, 1, 3, per_step=bad_sig))
-    assert "per_step must be a callable with the signature" in str(exc)

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -89,8 +89,7 @@ def test_register(RE):
     mutable = {}
     RE.verbose = True
 
-    @asyncio.coroutine
-    def func(msg):
+    async def func(msg):
         mutable['flag'] = True
 
     def plan():

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -934,10 +934,9 @@ class AsyncInput:
     def got_input(self):
         asyncio.ensure_future(self.q.put(sys.stdin.readline()), loop=self.loop)
 
-    @asyncio.coroutine
-    def __call__(self, prompt, end='\n', flush=False):
+    async def __call__(self, prompt, end='\n', flush=False):
         print(prompt, end=end, flush=flush)
-        return (yield from self.q.get()).rstrip('\n')
+        return (await self.q.get()).rstrip('\n')
 
 
 def new_uid():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR is expected to make the branch compatible with Python 3.8. The changes include:
- removal of use of deprecated feature (exactly the same change was applied in v1.6.0);
- replaced all occurrances of `@asyncio.coroutine` by `async def` (optional change, does not influence the build)

