### PR TITLE
Backport of PersistentDict

### DIFF
--- a/bluesky/tests/test_persistent_dict.py
+++ b/bluesky/tests/test_persistent_dict.py
@@ -1,0 +1,60 @@
+import collections.abc
+
+import numpy
+from numpy.testing import assert_array_equal
+
+from ..utils import PersistentDict
+from ..plans import count
+
+
+def test_persistent_dict(tmp_path):
+    d = PersistentDict(tmp_path)
+    d['a'] = 1
+    d['b'] = (1, 2)
+    d['c'] = numpy.zeros((5, 5))
+    d['d'] = {'a': 10, 'b': numpy.ones((5, 5))}
+    expected = dict(d)
+    actual = PersistentDict(tmp_path)
+    recursive_assert_equal(actual, expected)
+
+    # Update a value and check again.
+    d['a'] = 2
+    expected = dict(d)
+    recursive_assert_equal(actual, expected)
+
+    # Smoke test the accessor and the __repr__.
+    assert d.directory == tmp_path
+    d.__repr__()
+
+
+def test_integration(tmp_path, RE, hw):
+    """
+    Test integration with RE.
+
+    Not looking for anything *specific* here, just general paranoia in case
+    unforseen future changes create a bad interaction between PersistentDict
+    and RE, as happened with HistoryDict and RE.
+    """
+    d = PersistentDict(tmp_path)
+    d['a'] = 1
+    d['b'] = (1, 2)
+    d['c'] = numpy.zeros((5, 5))
+    d['d'] = {'a': 10, 'b': numpy.ones((5, 5))}
+    expected = dict(d)
+    expected['scan_id'] = 1
+
+    RE.md = d
+    RE(count([hw.det]))
+    recursive_assert_equal(RE.md, expected)
+
+    reloaded = PersistentDict(tmp_path)
+    recursive_assert_equal(reloaded, expected)
+
+
+def recursive_assert_equal(actual, expected):
+    assert set(actual.keys()) == set(expected.keys())
+    for key in actual:
+        if isinstance(actual[key], collections.abc.MutableMapping):
+            recursive_assert_equal(actual[key], expected[key])
+        else:
+            assert_array_equal(actual[key], expected[key])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,10 @@
 cycler
 event-model>=1.10.0
 historydict
+msgpack
+msgpack-numpy
 numpy
 super_state_machine
 toolz
 tqdm
+zict


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
 
Backport the feature of using `PersistentDict` for `RE.md`. The changes include the code copied from Bluesky v1.6.0.

