### PR TITLE
ENH 'rd'

### DIFF
--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -334,7 +334,7 @@ def rd(obj, *, default_value=0):
         The "single" value of the device
 
     """
-    hints = obj.hints.get("fields", [])
+    hints = getattr(obj, 'hints', {}).get("fields", [])
     if len(hints) > 1:
         msg = (
             f"Your object {obj} ({obj.name}.{obj.dotted_name}) "

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -337,23 +337,21 @@ def rd(obj, *, default_value=0):
     hints = getattr(obj, 'hints', {}).get("fields", [])
     if len(hints) > 1:
         msg = (
-            f"Your object {obj} ({obj.name}.{obj.dotted_name}) "
-            + f"has {len(hints)} items hinted ({hints}).  We "
-            + "do not know how to pick out a single value.  Please "
-            "adjust the hinting by setting the kind of the components of "
-            "this device or by rd ing one of it's components"
+            f"Your object {obj} ({obj.name}.{getattr(obj, 'dotted_name', '')}) "
+            f"has {len(hints)} items hinted ({hints}).  We do not know how to "
+            "pick out a single value.  Please adjust the hinting by setting the "
+            "kind of the components of this device or by rd ing one of it's components"
         )
         raise ValueError(msg)
     elif len(hints) == 0:
         if hasattr(obj, "read_attrs"):
             if len(obj.read_attrs) != 1:
                 msg = (
-                    f"Your object {obj} ({obj.name}.{obj.dotted_name}) "
-                    + f"and has {len(obj.read_attrs)} read attrs.  We "
-                    "do not know how to pick out a single value.  Please "
-                    "adjust the hinting/read_attrs by setting the kind of "
-                    "the components of this device or by rd ing one of it's "
-                    "components"
+                    f"Your object {obj} ({obj.name}.{getattr(obj, 'dotted_name', '')}) "
+                    f"and has {len(obj.read_attrs)} read attrs.  We do not know how to "
+                    "pick out a single value.  Please adjust the hinting/read_attrs by "
+                    "setting the kind of the components of this device or by rd ing one "
+                    "of it's components"
                 )
 
                 raise ValueError(msg)
@@ -378,12 +376,10 @@ def rd(obj, *, default_value=0):
         (data,) = ret.values()
     except ValueError as er:
         msg = (
-            f"Your object {obj} ({obj.name}.{obj.dotted_name}) "
-            f"and has {len(ret)} read values.  We "
-            "do not know how to pick out a single value.  Please "
-            "adjust the hinting/read_attrs by setting the kind of "
-            "the components of this device or by rd ing one of it's "
-            "components"
+            f"Your object {obj} ({obj.name}.{getattr(obj, 'dotted_name', '')}) "
+            f"and has {len(ret)} read values.  We do not know how to pick out a "
+            "single value.  Please adjust the hinting/read_attrs by setting the "
+            "kind of the components of this device or by rd ing one of it's components"
         )
 
         raise ValueError(msg) from er

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -15,8 +15,13 @@ except ImportError:
     from toolz import partition
 
 
-from .utils import (separate_devices, all_safe_rewind, Msg, ensure_generator,
-                    short_uid as _short_uid)
+from .utils import (
+    separate_devices,
+    all_safe_rewind,
+    Msg,
+    ensure_generator,
+    short_uid as _short_uid,
+)
 
 
 def create(name='primary'):
@@ -210,8 +215,12 @@ def rel_set(obj, *args, group=None, wait=False, **kwargs):
     :func:`bluesky.plan_stubs.wait`
     """
     from .preprocessors import relative_set_wrapper
-    return (yield from relative_set_wrapper(
-        abs_set(obj, *args, group=group, wait=wait, **kwargs)))
+
+    return (
+        yield from relative_set_wrapper(
+            abs_set(obj, *args, group=group, wait=wait, **kwargs)
+        )
+    )
 
 
 def mv(*args, group=None, **kwargs):
@@ -241,10 +250,8 @@ def mv(*args, group=None, **kwargs):
     group = group or str(uuid.uuid4())
     status_objects = []
 
-    cyl = reduce(operator.add,
-                 [cycler(obj, [val]) for
-                  obj, val in partition(2, args)])
-    step, = utils.merge_cycler(cyl)
+    cyl = reduce(operator.add, [cycler(obj, [val]) for obj, val in partition(2, args)])
+    (step,) = utils.merge_cycler(cyl)
     for obj, val in step.items():
         ret = yield Msg('set', obj, val, group=group, **kwargs)
         status_objects.append(ret)

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -305,8 +305,8 @@ movr = mvr  # synonym
 def rd(obj, *, default_value=0):
     """Reads a single-value non-triggered object
 
-    This is a helper plan to get the scalar value out of a Device (such as an EpicsMotor or a
-    single EpicsSignal).
+    This is a helper plan to get the scalar value out of a Device
+    (such as an EpicsMotor or a single EpicsSignal).
 
     For devices that have more than one read key the following rules are used:
 
@@ -325,8 +325,15 @@ def rd(obj, *, default_value=0):
         The device to be read
 
     default_value : Any
-        The value to return when not running in a "live" RunEngine (when
-        ret = yield from obj.read() returns None)
+        The value to return when not running in a "live" RunEngine.
+        This come ups when ::
+
+           ret = yield Msg('read', obj)
+           assert ret is None
+
+        the plan is passed to `list` or some other iterator that
+        repeatedly sends `None` into the plan to advance the
+        generator.
 
     Returns
     -------

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -374,8 +374,21 @@ def rd(obj, *, default_value=0):
         return ret[hint]["value"]
 
     # handle the no hint 1 field case
-    (data,) = ret.values()
-    return data["value"]
+    try:
+        (data,) = ret.values()
+    except ValueError as er:
+        msg = (
+            f"Your object {obj} ({obj.name}.{obj.dotted_name}) "
+            f"and has {len(ret)} read values.  We "
+            "do not know how to pick out a single value.  Please "
+            "adjust the hinting/read_attrs by setting the kind of "
+            "the components of this device or by rd ing one of it's "
+            "components"
+        )
+
+        raise ValueError(msg) from er
+    else:
+        return data["value"]
 
 
 def stop(obj):

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -351,7 +351,7 @@ def rd(obj, *, default_value=0):
                     f"and has {len(obj.read_attrs)} read attrs.  We do not know how to "
                     "pick out a single value.  Please adjust the hinting/read_attrs by "
                     "setting the kind of the components of this device or by rd ing one "
-                    "of it's components"
+                    "of its components"
                 )
 
                 raise ValueError(msg)
@@ -379,7 +379,7 @@ def rd(obj, *, default_value=0):
             f"Your object {obj} ({obj.name}.{getattr(obj, 'dotted_name', '')}) "
             f"and has {len(ret)} read values.  We do not know how to pick out a "
             "single value.  Please adjust the hinting/read_attrs by setting the "
-            "kind of the components of this device or by rd ing one of it's components"
+            "kind of the components of this device or by rd ing one of its components"
         )
 
         raise ValueError(msg) from er

--- a/bluesky/tests/test_plans.py
+++ b/bluesky/tests/test_plans.py
@@ -258,7 +258,8 @@ def test_bad_per_step_signature(hw, per_step):
 
 @pytest.mark.parametrize("val", [0, None, "aardvark"])
 def test_rd_dflt(val):
-    sig = Signal(value="0", name="sig")
+    ophyd = pytest.importorskip("ophyd")
+    sig = ophyd.Signal(value="0", name="sig")
 
     def tester(obj, dflt):
         ret = yield from bps.rd(obj, default_value=dflt)
@@ -269,7 +270,8 @@ def test_rd_dflt(val):
 
 @pytest.mark.parametrize("val", [0, None, "aardvark"])
 def test_rd(RE, val):
-    sig = Signal(value=val, name="sig")
+    ophyd = pytest.importorskip("ophyd")
+    sig = ophyd.Signal(value="0", name="sig")
 
     def tester(obj, val):
         yield from bps.mv(sig, val)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is the mirror of `mv` and for many devices we would expect
the value from `rd` to go into `mv` / `abs_set` correctly.

This idea was suggested by Claudio Mazzoli (@cmazzoli ) to Andi Barbour (@ambarb) and then
explained to me by Andi. 

I would like to try and sneak this in under the wire for 1.6 because due to investigating https://github.com/bluesky/ophyd/issues/814 it is clear there is a strong demand for this.  I think this would cover about a third of the usages of `obj.value (a third are covered by `bps.mvr`, and the last third by `@reset_position_decorator`).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Frequently in plan users want to get "the value" from a Device.  The easy to get thing is the reading, which is a dictionary, which you need to know the right key to get out, but sometimes it comes back as None so you have to be careful.

```python
ret = ((yield from read(obj)) or {}).get('det', {}).get('value', default)

```
is probably the shortest way to write that logic _if_ you know the key already.  This lets you spell that as 

```python
ret = yield from bps.rd(obj, default_value=default)
```

which does not require the plan author to know the name and raises nice errors (even when only `list`ed) if we can not guess what key to use.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added a number of tests to the test suite.

<!--
## Screenshots (if appropriate):
-->
