### PR TITLE
MNT: passing `loop=` to asyncio.Event is deprecated in py38

### DIFF
--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -994,13 +994,13 @@ def caching_repeater(n, plan):
     """
     warnings.warn("The caching_repeater will be removed in a future version "
                   "of bluesky.", stacklevel=2)
-    it = range
     if n is None:
-        n = 0
-        it = itertools.count
+        gen = itertools.count(0)
+    else:
+        gen = range(n)
 
     lst_plan = list(plan)
-    for j in it(n):
+    for _ in gen:
         yield from (m for m in lst_plan)
 
 

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -993,7 +993,7 @@ def caching_repeater(n, plan):
     :func:`bluesky.plan_stubs.repeater`
     """
     warnings.warn("The caching_repeater will be removed in a future version "
-                  "of bluesky.")
+                  "of bluesky.", stacklevel=2)
     it = range
     if n is None:
         n = 0

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1565,7 +1565,7 @@ class RunEngine:
 
         """
         futs, = msg.args
-        futs = [f() for f in futs]
+        futs = [asyncio.ensure_future(f()) for f in futs]
         await asyncio.wait(futs, loop=self._loop_for_kwargs, **msg.kwargs)
 
     async def _open_run(self, msg):

--- a/bluesky/suspenders.py
+++ b/bluesky/suspenders.py
@@ -127,7 +127,7 @@ class SuspenderBase(metaclass=ABCMeta):
         with self._lock:
             if self._should_suspend(value):
                 self._tripped = True
-                loop = self.RE._loop
+                loop = self.RE._loop_for_kwargs
                 # this does dirty things with internal state
                 if (self._ev is None and self.RE is not None):
                     self.__make_event()

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -5,11 +5,11 @@ from bluesky import (Msg, IllegalMessageSequence,
 import bluesky.plan_stubs as bps
 import os
 import signal
-import asyncio
 import time as ttime
 import time
 import threading
 from functools import partial
+from .utils import _fabricate_asycio_event
 
 with pytest.warns(UserWarning):
     from bluesky.examples import (simple_scan, sleepy, wait_one,
@@ -267,7 +267,7 @@ def test_list_of_msgs(RE, hw):
 
 
 def test_suspend(RE, hw):
-    ev = asyncio.Event(loop=RE.loop)
+    ev = _fabricate_asycio_event(RE.loop)
 
     test_list = [
         Msg('open_run'),
@@ -310,7 +310,7 @@ def test_suspend(RE, hw):
 def test_pause_resume(RE):
     from bluesky.utils import ts_msg_hook
     RE.msg_hook = ts_msg_hook
-    ev = asyncio.Event(loop=RE.loop)
+    ev = _fabricate_asycio_event(RE.loop)
 
     def done():
         print("Done")
@@ -342,7 +342,7 @@ def test_pause_resume(RE):
 
 
 def test_pause_abort(RE):
-    ev = asyncio.Event(loop=RE.loop)
+    ev = _fabricate_asycio_event(RE.loop)
 
     def done():
         print("Done")
@@ -373,7 +373,7 @@ def test_pause_abort(RE):
 
 
 def test_abort(RE):
-    ev = asyncio.Event(loop=RE.loop)
+    ev = _fabricate_asycio_event(RE.loop)
 
     def done():
         print("Done")

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -540,12 +540,14 @@ def test_caching_repeater():
         yield from args
 
     plan_instance = plan(1, 2, 3)
-    actual = list(caching_repeater(3, plan_instance))
+    with pytest.warns(UserWarning):
+        actual = list(caching_repeater(3, plan_instance))
     assert actual == 3 * [1, 2, 3]
 
     plan_instance = plan(1, 2, 3)
     p = caching_repeater(None, plan_instance)
-    assert next(p) == 1
+    with pytest.warns(UserWarning):
+        assert next(p) == 1
     assert next(p) == 2
     assert next(p) == 3
     assert next(p) == 1

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -25,6 +25,7 @@ from bluesky.preprocessors import (finalize_wrapper, run_decorator,
                                    run_wrapper, rewindable_wrapper,
                                    subs_wrapper, baseline_wrapper,
                                    SupplementalData)
+from .utils import _fabricate_asycio_event
 
 
 def test_states():
@@ -462,7 +463,7 @@ def test_unrewindable_det_suspend(RE, plan, motor, det, msg_seq):
 
     RE.msg_hook = collector
 
-    ev = asyncio.Event(loop=loop)
+    ev = _fabricate_asycio_event(loop)
 
     threading.Timer(.5, RE.request_suspend,
                     kwargs=dict(fut=ev.wait)).start()
@@ -858,7 +859,7 @@ def test_exception_cascade_REside(RE):
 
     with pytest.raises(RunEngineInterrupted):
         RE(pausing_plan())
-    ev = asyncio.Event(loop=RE.loop)
+    ev = _fabricate_asycio_event(RE.loop)
     ev.set()
     RE.request_suspend(ev.wait, pre_plan=pre_plan())
     with pytest.raises(KeyError):
@@ -889,7 +890,7 @@ def test_exception_cascade_planside(RE):
 
     with pytest.raises(RunEngineInterrupted):
         RE(pausing_plan())
-    ev = asyncio.Event(loop=RE.loop)
+    ev = _fabricate_asycio_event(RE.loop)
     ev.set()
     RE.request_suspend(ev.wait, pre_plan=pre_plan())
     with pytest.raises(RuntimeError):
@@ -899,7 +900,7 @@ def test_exception_cascade_planside(RE):
 
 def test_sideband_cancel(RE):
     loop = RE.loop
-    ev = asyncio.Event(loop=RE.loop)
+    ev = _fabricate_asycio_event(RE.loop)
 
     def done():
         ev.set()

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -1,4 +1,3 @@
-import asyncio
 from event_model import DocumentNames
 import threading
 import types

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -114,8 +114,7 @@ def test_register(RE):
     mutable = {}
     RE.verbose = True
 
-    @asyncio.coroutine
-    def func(msg):
+    async def func(msg):
         mutable['flag'] = True
 
     def plan():

--- a/bluesky/tests/test_scans.py
+++ b/bluesky/tests/test_scans.py
@@ -1,11 +1,11 @@
 from bluesky.callbacks import collector, CallbackCounter
 import bluesky.plans as bp
 from bluesky import Msg
-import asyncio
 import time as ttime
 import numpy as np
 import numpy.testing
 import pytest
+from .utils import _fabricate_asycio_event
 
 
 def test_scan_num(RE, hw):
@@ -505,7 +505,7 @@ def test_count(RE, hw):
 
 
 def test_wait_for(RE):
-    ev = asyncio.Event(loop=RE.loop)
+    ev = _fabricate_asycio_event(RE.loop)
 
     def done():
         ev.set()

--- a/bluesky/tests/test_suspenders.py
+++ b/bluesky/tests/test_suspenders.py
@@ -25,13 +25,22 @@ from .utils import _fabricate_asycio_event
      (SuspendFloor, (.5,), 1, 0, 1, .2),
      (SuspendCeil, (.5,), 0, 1, 0, .2),
      (SuspendWhenOutsideBand, (.5, 1.5), 1, 0, 1, .2),
-     (SuspendInBand, (.5, 1.5), 1, 0, 1, .2),  # renamed to WhenOutsideBand
-     (SuspendOutBand, (.5, 1.5), 0, 1, 0, .2)])  # deprecated
+     ((SuspendInBand, True), (.5, 1.5), 1, 0, 1, .2),  # renamed to WhenOutsideBand
+     ((SuspendOutBand, True), (.5, 1.5), 0, 1, 0, .2)])  # deprecated
 def test_suspender(klass, sc_args, start_val, fail_val,
                    resume_val, wait_time, RE, hw):
     sig = hw.bool_sig
-    my_suspender = klass(sig,
-                         *sc_args, sleep=wait_time)
+    try:
+        klass, deprecated = klass
+    except TypeError:
+        deprecated = False
+    if deprecated:
+        with pytest.warns(UserWarning):
+            my_suspender = klass(sig,
+                                 *sc_args, sleep=wait_time)
+    else:
+        my_suspender = klass(sig,
+                             *sc_args, sleep=wait_time)
     my_suspender.install(RE)
 
     def putter(val):

--- a/bluesky/tests/test_suspenders.py
+++ b/bluesky/tests/test_suspenders.py
@@ -1,5 +1,4 @@
 import pytest
-import asyncio
 from functools import partial
 from bluesky.preprocessors import suspend_wrapper
 from bluesky.suspenders import (SuspendBoolHigh,

--- a/bluesky/tests/test_suspenders.py
+++ b/bluesky/tests/test_suspenders.py
@@ -15,6 +15,7 @@ import time as ttime
 from bluesky.run_engine import RunEngineInterrupted
 import threading
 import time
+from .utils import _fabricate_asycio_event
 
 
 @pytest.mark.parametrize(
@@ -179,7 +180,7 @@ def test_unresumable_suspend_fail(RE):
     m_coll = MsgCollector()
     RE.msg_hook = m_coll
 
-    ev = asyncio.Event(loop=RE.loop)
+    ev = _fabricate_asycio_event(RE.loop)
     threading.Timer(.1, partial(RE.request_suspend, fut=ev.wait)).start()
     threading.Timer(1, ev.set).start()
     start = time.time()

--- a/bluesky/tests/utils.py
+++ b/bluesky/tests/utils.py
@@ -5,6 +5,7 @@ import sys
 import threading
 import asyncio
 
+
 @contextlib.contextmanager
 def _print_redirect():
     old_stdout = sys.stdout


### PR DESCRIPTION
This shims it out in our core code, there is still some usage in the
tests that will be trickier to remove.

This will become critical for the first facility that moves to py38 (it is _super_ noisy).

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
