### PR TITLE
BLD: require event-model 1.14 or better for RunRouter changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cycler
-event-model>=1.10.0
+event-model>=1.14.0
 historydict
 msgpack
 msgpack-numpy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Follow on to #1317 to make sure the tests don't break due to an old version of event-model

## Description
<!--- Describe your changes in detail -->

Update the pinned version requirement floor.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We rely on an API change in 1.14 in the tests

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

CI

<!--
## Screenshots (if appropriate):
-->