### PR TITLE
Rewrite logging docs.

### DIFF
--- a/doc/source/debugging.rst
+++ b/doc/source/debugging.rst
@@ -1,54 +1,183 @@
+*********************
 Debugging and Logging
-=====================
+*********************
 
-Bluesky uses Python logging framework. See below for a list of the names of the
-loggers it publishes to.
+.. versionchanged:: 1.6.0
+
+   Bluesky's use of Python logging framework has been completely reworked to
+   follow Python's documented best practices for libraries.
+
+Bluesky uses Python's logging framework, which enables sophisticated log
+management. Users who are familiar with that framework or who need to route
+logs to multiple destinations may wish to skip ahead to :ref:`logger_api`. But
+for common simple cases, including viewing logs in the terminal or writing them
+to a file, the next section illustrates streamlined, copy/paste-able examples.
 
 Useful Snippets
----------------
+===============
+
+Log warnings
+------------
+
+This is the recommended standard setup.
+
+.. code-block:: python
+
+   from bluesky import config_bluesky_logging
+   config_bluesky_logging()
+
+It will display log records of ``WARNING`` level or higher in the terminal
+(standard out) with a formatting tailored to bluesky.
+
+Maximum verbosity
+-----------------
 
 If the RunEngine is "hanging," running slowly, or repeatedly encountering an
 error, it is useful to know exactly where in the plan the problem is occurring.
 To follow the RunEngine's progress through the plan, crank up the verbosity of
 the logging.
 
-.. code-block:: python
-
-   RE.log.setLevel('DEBUG')
-
-To direct the output to a file instead of to the screen:
+This will display each message from the plan just before the RunEngine
+processes it, giving a clear indication of when plan execution is stuck.
 
 .. code-block:: python
 
-   from bluesky import set_handler
-   set_handler(file='debugging_bluesky.txt')
+   from bluesky import config_bluesky_logging
+   config_bluesky_logging(level='DEBUG')
+
+.. important::
+
+   We strongly recommend setting levels on *handlers* not on *loggers*.
+   In previous versions of bluesky, we recommended adjusting the level on the
+   *logger*, as in ``RE.log.setLevel('DEBUG')``. We now recommended
+   that you *avoid* setting levels on loggers because it would affect all
+   handlers downstream, potentially inhibiting some other part of the program
+   from collecting the records it wants to collect.
+
+Log to a file
+-------------
+
+This will direct all log messages to a file instead of the terminal (standard
+out).
+
+.. code-block:: python
+
+    from bluesky import config_bluesky_logging
+    config_bluesky_logging(file='/tmp/bluesky.log', level='DEBUG')
+
+.. _logger_api:
 
 Logger Names
 ------------
 
-Here is the complete list of loggers used by bluesky.
+Here are the primary loggers used by bluesky.
 
-* ``'bluesky'`` --- the logger to which all bluesky log messages propagate
-* ``'bluesky.RE'`` --- Messages from a RunEngine. INFO-level notes state
+* ``'bluesky'`` --- the logger to which all bluesky log records propagate
+* ``'bluesky.emit_document'`` --- A log record is emitted whenever a Document
+  is emitted. The log record does not contain the full content of the
+  Document.
+* ``'bluesky.RE'`` --- Records from a RunEngine. INFO-level notes state
   changes. DEBUG-level notes when each message from a plan is about to be
-  processed, when a document has been emitted to subscribed callbacks, and when
-  a status object has completed.
-* ``'bluesky.RE.<id>'`` --- Messages from a specific RunEngine instance,
-  disambiguating the (rare) case where there are multiple RunEngine instances
-  in the same process. This is the logger that the accessor ``RE.log`` refers
-  to.
-* ``'bluesky.RE.<id>.msg'`` --- DEBUG-level notes when each message from a plan
-  is about to be processed.
+  processed and when a status object has completed.
+* ``'bluesky.RE.msg`` --- A log record is emitted when each
+  :class:`~bluesky.utils.Msg` is about to be processed.
+* ``'bluesky.RE.state`` --- A log record is emitted when the RunEngine's state
+  changes.
 
-Logging Handlers
-----------------
+There are also some module-level loggers for specific features.
 
-By default, bluesky prints log messages to the standard out by adding a
-:class:`logging.StreamHandler` to the ``'bluesky'`` logger at import time. You
-can, of course, configure the handlers manually in the standard fashion
-supported by Python. But a convenience function :func:`bluesky.set_handler`,
-makes it easy to address common cases.
+Formatter
+---------
 
-See the Examples section below.
+.. autoclass:: bluesky.log.LogFormatter
 
-.. autofunction:: bluesky.set_handler
+Global Handler
+---------------
+
+Following Python's recommendation, bluesky does not install any handlers at
+import time, but it provides a function to set up a basic useful configuration
+in one line, similar to Python's :py:func:`logging.basicConfig` but with some
+additional options---and scoped to the ``'bluesky'`` logger with bluesky's
+:class:`bluesky.log.LogFormatter`. It streamlines common use cases without
+interfering with more sophisticated use cases.
+
+.. autofunction:: bluesky.log.config_bluesky_logging
+.. autofunction:: bluesky.log.get_handler
+
+Advanced Example
+================
+
+The flow of log event information in loggers and handlers is illustrated in the
+following diagram:
+
+.. image:: https://docs.python.org/3/_images/logging_flow.png
+
+For further reference, see the Python 3 logging howto:
+https://docs.python.org/3/howto/logging.html#logging-flow
+
+As an illustrative example, we will set up two handlers using the Python
+logging framework directly, ignoring bluesky's convenience function.
+
+Suppose we set up a handler aimed at a file:
+
+.. code-block:: python
+
+    import logging
+    file_handler = logging.FileHandler('bluesky.log')
+
+And another aimed at `Logstash <https://www.elastic.co/products/logstash>`_:
+
+.. code-block:: python
+
+    import logstash  # requires python-logstash package
+    logstash_handler = logstash.TCPLogstashHandler(<host>, <port>, version=1)
+
+We can attach the handlers to the bluesky logger, to which all log records
+created by bluesky propagate:
+
+.. code-block:: python
+
+    logger = logging.getLogger('bluesky')
+    logger.addHandler(logstash_handler)
+    logger.addHandler(file_filter)
+
+We can set the verbosity of each handler. Suppose want maximum verbosity in the
+file but only medium verbosity in logstash.
+
+.. code-block:: python
+
+    logstash_handler.setLevel('INFO')
+    file_handler.setLevel('DEBUG')
+
+Finally, ensure that "effective level" of ``logger`` is at least as verbose as
+the most verbose handler---in this case, ``'DEBUG'``. By default, at import,
+its level is not set
+
+.. ipython:: python
+   :verbatim:
+
+    logging.getLevelName(logger.level)
+    'NOTSET'
+
+and so it inherits the level of Python's default
+"handler of last resort," :py:obj:`logging.lastResort`, which is ``'WARNING'``.
+
+.. ipython:: python
+   :verbatim:
+
+    logging.getLevelName(logger.getEffectiveLevel())
+    'WARNING'
+
+In this case we should set it to ``'DEBUG'``, to match the most verbose level
+of the handler we have added.
+
+.. code-block:: python
+
+   logger.setLevel('DEBUG')
+
+This makes DEBUG-level records *available* to all handlers. Our logstash
+handler, set to ``'INFO'``, will filter out DEBUG-level records.
+
+To globally disable the generation of any log records at or below a certain
+verbosity, which may be helpful for optimising performance, Python provides
+:py:func:`logging.disable`.

--- a/doc/source/debugging.rst
+++ b/doc/source/debugging.rst
@@ -4,7 +4,7 @@ Debugging and Logging
 
 .. versionchanged:: 1.6.0
 
-   Bluesky's use of Python logging framework has been completely reworked to
+   Bluesky's use of Python's logging framework has been completely reworked to
    follow Python's documented best practices for libraries.
 
 Bluesky uses Python's logging framework, which enables sophisticated log
@@ -28,7 +28,7 @@ This is the recommended standard setup.
    config_bluesky_logging()
 
 It will display ``'bluesky'`` log records of ``WARNING`` level or higher in the
-terminal (standard out) with a formatting tailored to bluesky.
+terminal (standard out) with a format tailored to bluesky.
 
 Maximum verbosity
 -----------------
@@ -105,8 +105,8 @@ additional options---and scoped to the ``'bluesky'`` logger with bluesky's
 :class:`bluesky.log.LogFormatter`. It streamlines common use cases without
 interfering with more sophisticated use cases.
 
-We recommend that facilities using bluesky leave this functions for users and
-configuring any standardized, facility-managed logging handlers separately, as
+We recommend that facilities using bluesky leave this function for users and
+configure any standardized, facility-managed logging handlers separately, as
 described in the next section.
 
 .. autofunction:: bluesky.log.config_bluesky_logging
@@ -187,5 +187,5 @@ This makes DEBUG-level records *available* to all handlers. Our logstash
 handler, set to ``'INFO'``, will filter out DEBUG-level records.
 
 To globally disable the generation of any log records at or below a certain
-verbosity, which may be helpful for optimising performance, Python provides
+verbosity, which may be helpful for optimizing performance, Python provides
 :py:func:`logging.disable`.

--- a/doc/source/debugging.rst
+++ b/doc/source/debugging.rst
@@ -27,8 +27,8 @@ This is the recommended standard setup.
    from bluesky import config_bluesky_logging
    config_bluesky_logging()
 
-It will display log records of ``WARNING`` level or higher in the terminal
-(standard out) with a formatting tailored to bluesky.
+It will display ``'bluesky'`` log records of ``WARNING`` level or higher in the
+terminal (standard out) with a formatting tailored to bluesky.
 
 Maximum verbosity
 -----------------
@@ -46,15 +46,6 @@ processes it, giving a clear indication of when plan execution is stuck.
    from bluesky import config_bluesky_logging
    config_bluesky_logging(level='DEBUG')
 
-.. important::
-
-   We strongly recommend setting levels on *handlers* not on *loggers*.
-   In previous versions of bluesky, we recommended adjusting the level on the
-   *logger*, as in ``RE.log.setLevel('DEBUG')``. We now recommended
-   that you *avoid* setting levels on loggers because it would affect all
-   handlers downstream, potentially inhibiting some other part of the program
-   from collecting the records it wants to collect.
-
 Log to a file
 -------------
 
@@ -65,6 +56,15 @@ out).
 
     from bluesky import config_bluesky_logging
     config_bluesky_logging(file='/tmp/bluesky.log', level='DEBUG')
+
+.. important::
+
+   We strongly recommend setting levels on *handlers* not on *loggers*.
+   In previous versions of bluesky, we recommended adjusting the level on the
+   *logger*, as in ``RE.log.setLevel('DEBUG')``. We now recommended
+   that you *avoid* setting levels on loggers because it would affect all
+   handlers downstream, potentially inhibiting some other part of the program
+   from collecting the records it wants to collect.
 
 .. _logger_api:
 

--- a/doc/source/debugging.rst
+++ b/doc/source/debugging.rst
@@ -8,10 +8,11 @@ Debugging and Logging
    follow Python's documented best practices for libraries.
 
 Bluesky uses Python's logging framework, which enables sophisticated log
-management. Users who are familiar with that framework or who need to route
-logs to multiple destinations may wish to skip ahead to :ref:`logger_api`. But
-for common simple cases, including viewing logs in the terminal or writing them
-to a file, the next section illustrates streamlined, copy/paste-able examples.
+management. For common simple cases, including viewing logs in the terminal or
+writing them to a file, the next section illustrates streamlined,
+copy/paste-able examples. Users who are familiar with that framework or who
+need to route logs to multiple destinations may wish to skip ahead to
+:ref:`logger_api`.
 
 Useful Snippets
 ===============
@@ -67,6 +68,9 @@ out).
 
 .. _logger_api:
 
+Bluesky's Logging-Related API
+=============================
+
 Logger Names
 ------------
 
@@ -100,6 +104,10 @@ in one line, similar to Python's :py:func:`logging.basicConfig` but with some
 additional options---and scoped to the ``'bluesky'`` logger with bluesky's
 :class:`bluesky.log.LogFormatter`. It streamlines common use cases without
 interfering with more sophisticated use cases.
+
+We recommend that facilities using bluesky leave this functions for users and
+configuring any standardized, facility-managed logging handlers separately, as
+described in the next section.
 
 .. autofunction:: bluesky.log.config_bluesky_logging
 .. autofunction:: bluesky.log.get_handler

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,4 +26,9 @@ requests
 sphinx==1.6.4
 sphinx_rtd_theme
 streamz
+# These suitcases are test deps of databroker which we need to acces
+# databroker fixtures.
+suitcase-jsonl
+suitcase-mongo
+suitcase-msgpack
 tifffile


### PR DESCRIPTION
This borrows substantially from caproto, but it's different enough
that it cannot practically share source with it.