### PR TITLE
Rework which version of ophyd to use in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ jobs:
       python: 3.6
       env: PUBLISH_DOCS=1
     - os: linux
+      python: 3.6
+      env: OPHYD_MASTER=true
+    - os: linux
       python: 3.7
     - os: linux
       python: 3.8
@@ -66,7 +69,11 @@ install:
   - pip install --quiet --upgrade --global-option='--without-libyaml' pyyaml
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
-  - pip install -U ophyd --pre
+  # Install ophyd master branch if build settings indicate to do so.
+  - |
+    if [ "$OPHYD_MASTER" = true ] ; then
+      pip install git+https://github.com/bluesky/ophyd@master
+    fi
   - pip install codecov
   - python setup.py install
   # Need to clean the python build directory (and other cruft) or pytest is

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ install:
   # Install ophyd master branch if build settings indicate to do so.
   - |
     if [ "$OPHYD_MASTER" = true ] ; then
-      pip install git+https://github.com/bluesky/ophyd@master
+      pip install -U git+https://github.com/bluesky/ophyd@master
     fi
   - pip install codecov
   - python setup.py install

--- a/bluesky/tests/conftest.py
+++ b/bluesky/tests/conftest.py
@@ -1,4 +1,5 @@
 import asyncio
+from distutils.version import LooseVersion
 from bluesky.run_engine import RunEngine, TransitionError
 import numpy as np
 import os
@@ -28,7 +29,13 @@ def RE(request):
 @pytest.fixture(scope='function')
 def hw(tmpdir):
     from ophyd.sim import hw
-    return hw(str(tmpdir))
+    import ophyd
+    # ophyd 1.4.0 added support for customizing the directory used by simulated
+    # hardware that generates files
+    if LooseVersion(ophyd.__version__) >= LooseVersion('1.4.0'):
+        return hw(str(tmpdir))
+    else:
+        return hw()
 
 
 # vendored from ophyd.sim

--- a/bluesky/tests/test_plans.py
+++ b/bluesky/tests/test_plans.py
@@ -1,3 +1,4 @@
+from distutils.version import LooseVersion
 import pytest
 from bluesky.tests.utils import DocCollector
 import bluesky.plans as bp
@@ -256,9 +257,16 @@ def test_bad_per_step_signature(hw, per_step):
         list(bp.scan([hw.det], hw.motor, -1, 1, 5, per_step=per_step))
 
 
+def require_ophyd_1_4_0():
+    ophyd = pytest.importorskip("ophyd")
+    if LooseVersion(ophyd.__version__) < LooseVersion('1.4.0'):
+        pytest.skip("Needs ophyd 1.4.0 for realistic ophyd.sim Devices.")
+
+
 @pytest.mark.parametrize("val", [0, None, "aardvark"])
 def test_rd_dflt(val):
     ophyd = pytest.importorskip("ophyd")
+    require_ophyd_1_4_0()
     sig = ophyd.Signal(value="0", name="sig")
 
     def tester(obj, dflt):
@@ -271,6 +279,7 @@ def test_rd_dflt(val):
 @pytest.mark.parametrize("val", [0, None, "aardvark"])
 def test_rd(RE, val):
     ophyd = pytest.importorskip("ophyd")
+    require_ophyd_1_4_0()
     sig = ophyd.Signal(value="0", name="sig")
 
     def tester(obj, val):
@@ -282,6 +291,7 @@ def test_rd(RE, val):
 
 
 def test_rd_fails(hw):
+    require_ophyd_1_4_0()
     obj = hw.det
 
     obj.noise.kind = "hinted"
@@ -314,6 +324,7 @@ def test_rd_fails(hw):
 
 @pytest.mark.parametrize("kind", ["hinted", "normal"])
 def test_rd_device(hw, RE, kind):
+    require_ophyd_1_4_0()
     called = False
     hw.det.val.kind = kind
 


### PR DESCRIPTION
Formerly we *always* used ophyd `--pre`. Intead, use ophyd stable for
most builds, and use ophyd `master` for one build.

Justification:

* `master` provides an earlier warning than `--pre` about any changes to
  ophyd that break bluesky tests
* We should have been testing against the latest stable release of ophyd
  to ensure bluesky is not relying on unreleased changes to ophyd.