### PR TITLE
Flake8 Compliance

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,9 @@
+[flake8]
+exclude =
+    .git,
+    __pycache__,
+    build,
+    dist,
+    versioneer.py,
+    doc/source/conf.py
+max-line-length = 115

--- a/.flake8
+++ b/.flake8
@@ -6,4 +6,5 @@ exclude =
     dist,
     versioneer.py,
     doc/source/conf.py
+    doc/source/examples
 max-line-length = 115

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,8 +67,9 @@ install:
   - if [ "$FLAKE_8" ]; then
         pip install flake8;
         flake8 .;
-        echo "The project code was verified by 'flake8'";
-        exit;
+        let res=$?;
+        echo "The project code was verified by 'flake8'. Exit code ($res).";
+        exit $res;
     fi
 
   - env | sort -u

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,7 @@ install:
   - pip list
 
 script:
+  - flake8
   # ensure that callbacks import without matplotlib
   - python -c 'import sys, bluesky.callbacks; assert "matplotlib" not in sys.modules'
   - coverage run -m pytest -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ jobs:
   fast_finish: true
   include:
     - os: linux
+      python: 3.7
+      env: FLAKE_8=1
+    - os: linux
       python: 3.6
       env: PUBLISH_DOCS=1
     - os: linux
@@ -61,6 +64,13 @@ before_install:
     fi
 
 install:
+  - if [ "$FLAKE_8" ]; then
+        pip install flake8;
+        flake8 .;
+        echo "The project code was verified by 'flake8'";
+        exit;
+    fi
+
   - env | sort -u
   - export GIT_FULL_HASH=`git rev-parse HEAD`
   - pip install --upgrade pip
@@ -85,7 +95,6 @@ install:
   - pip list
 
 script:
-  - flake8
   # ensure that callbacks import without matplotlib
   - python -c 'import sys, bluesky.callbacks; assert "matplotlib" not in sys.modules'
   - coverage run -m pytest -v

--- a/bluesky/__init__.py
+++ b/bluesky/__init__.py
@@ -1,11 +1,11 @@
-from .utils import Msg
-from .utils import RunEngineInterrupted
-from .utils import IllegalMessageSequence
-from .utils import FailedStatus
+from .utils import Msg  # noqa: F401
+from .utils import RunEngineInterrupted  # noqa: F401
+from .utils import IllegalMessageSequence  # noqa: F401
+from .utils import FailedStatus  # noqa: F401
 
-from .run_engine import RunEngine
-from .preprocessors import SupplementalData
-from .log import set_handler
+from .run_engine import RunEngine  # noqa: F401
+from .preprocessors import SupplementalData  # noqa: F401
+from .log import set_handler  # noqa: F401
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/bluesky/bundlers.py
+++ b/bluesky/bundlers.py
@@ -2,7 +2,7 @@ from collections import deque
 from itertools import count, tee
 import time as ttime
 from event_model import DocumentNames
-from .log import doc_logger, msg_logger, state_logger
+from .log import doc_logger
 from .utils import (
     new_uid,
     IllegalMessageSequence,
@@ -52,8 +52,8 @@ class RunBundler:
         doc = dict(uid=self._run_start_uid, time=ttime.time(), **self._md)
         await self.emit(DocumentNames.start, doc)
         doc_logger.debug("[start] document is emitted (run_uid=%r)", self._run_start_uid,
-        extra={'doc_name': 'start',
-               'run_uid': self._run_start_uid})
+                         extra={'doc_name': 'start',
+                                'run_uid': self._run_start_uid})
         await self.reset_checkpoint_state_coro()
 
         # Emit an Event Descriptor for recording any interruptions as Events.
@@ -411,11 +411,11 @@ class RunBundler:
             )
             await self.emit(DocumentNames.descriptor, doc)
             doc_logger.debug("[descriptor] document is emitted with name %r containing "
-                         "data keys %r (run_uid=%r)", name, data_keys.keys(),
-                         self._run_start_uid,
-                         extra={'doc_name': 'descriptor',
-                                'run_uid': self._run_start_uid,
-                                'data_keys': data_keys.keys()})
+                             "data keys %r (run_uid=%r)", name, data_keys.keys(),
+                             self._run_start_uid,
+                             extra={'doc_name': 'descriptor',
+                                    'run_uid': self._run_start_uid,
+                                    'data_keys': data_keys.keys()})
             self._descriptors[desc_key] = (objs_read, doc)
 
         descriptor_uid = doc["uid"]
@@ -454,10 +454,10 @@ class RunBundler:
         )
         await self.emit(DocumentNames.event, doc)
         doc_logger.debug("[event] document is emitted with data keys %r (run_uid=%r)", data.keys(),
-                 self._run_start_uid,
-                 extra={'doc_name': 'event',
-                        'run_uid': self._run_start_uid,
-                        'data_keys': data.keys()})
+                         self._run_start_uid,
+                         extra={'doc_name': 'event',
+                                'run_uid': self._run_start_uid,
+                                'data_keys': data.keys()})
 
     def clear_monitors(self):
         for obj, (cb, kwargs) in list(self._monitor_params.items()):
@@ -603,11 +603,11 @@ class RunBundler:
                 )
                 await self.emit(DocumentNames.descriptor, doc)
                 doc_logger.debug("[descriptor] document is emitted with name %r "
-                    "containing data keys %r (run_uid=%r)", stream_name,
-                    data_keys.keys(), self._run_start_uid,
-                    extra={'doc_name': 'descriptor',
-                           'run_uid': self._run_start_uid,
-                           'data_keys': data_keys.keys()})
+                                 "containing data keys %r (run_uid=%r)", stream_name,
+                                 data_keys.keys(), self._run_start_uid,
+                                 extra={'doc_name': 'descriptor',
+                                        'run_uid': self._run_start_uid,
+                                        'data_keys': data_keys.keys()})
                 self._descriptors[desc_key] = (objs_read, doc)
                 self._sequence_counters[desc_key] = count(1)
             else:
@@ -653,11 +653,11 @@ class RunBundler:
 
             if stream:
                 doc_logger.debug("[event] document is emitted with data keys %r (run_uid=%r)",
-                     ev['data'].keys(), self._run_start_uid,
-                     event_uid,
-                     extra={'doc_name': 'event',
-                            'run_uid': self._run_start_uid,
-                            'data_keys': ev['data'].keys()})
+                                 ev['data'].keys(), self._run_start_uid,
+                                 event_uid,
+                                 extra={'doc_name': 'event',
+                                        'run_uid': self._run_start_uid,
+                                        'data_keys': ev['data'].keys()})
                 await self.emit(DocumentNames.event, ev)
             else:
                 bulk_data[descriptor_uid].append(ev)
@@ -665,9 +665,9 @@ class RunBundler:
         if not stream:
             await self.emit(DocumentNames.bulk_events, bulk_data)
             doc_logger.debug("[bulk events] document is emitted for descriptors (run_uid=%r)",
-                    self._run_start_uid,
-                    extra={'doc_name': 'bulk_events',
-                           'run_uid': self._run_start_uid})
+                             self._run_start_uid,
+                             extra={'doc_name': 'bulk_events',
+                                    'run_uid': self._run_start_uid})
         if return_payload:
             return payload
 

--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -16,7 +16,6 @@ import threading
 import time
 from warnings import warn
 import weakref
-from event_model import unpack_event_page
 
 from .core import LiveTable, make_class_safe
 from .mpl_plotting import LivePlot, LiveGrid, LiveScatter, QtAwareCallback
@@ -211,7 +210,7 @@ class BestEffortCallback(QtAwareCallback):
             # Create a figure or reuse an existing one.
 
             fig_name = '{} vs {}'.format(' '.join(sorted(columns)),
-                                        ' '.join(sorted(dim_fields)))
+                                         ' '.join(sorted(dim_fields)))
             if self.overplot and len(dim_fields) == 1:
                 # If any open figure matches 'figname {number}', use it. If there
                 # are multiple, the most recently touched one will be used.
@@ -255,7 +254,7 @@ class BestEffortCallback(QtAwareCallback):
                             raise NotImplementedError("we now support 3D?!")
                     else:
                         ax = fig.add_subplot(len(columns), 1, 1 + i,
-                                            **share_kwargs)
+                                             **share_kwargs)
             axes = fig.axes
 
             # ## LIVE PLOT AND PEAK ANALYSIS ## #
@@ -268,11 +267,11 @@ class BestEffortCallback(QtAwareCallback):
                     dtype = doc['data_keys'][y_key]['dtype']
                     if dtype not in ('number', 'integer'):
                         warn("Omitting {} from plot because dtype is {}"
-                            "".format(y_key, dtype))
+                             "".format(y_key, dtype))
                         continue
                     # Create an instance of LivePlot and an instance of PeakStats.
                     live_plot = LivePlotPlusPeaks(y=y_key, x=x_key, ax=ax,
-                                                peak_results=self.peaks)
+                                                  peak_results=self.peaks)
                     live_plot('start', self._start_doc)
                     live_plot('descriptor', doc)
                     peak_stats = PeakStats(x=x_key, y=y_key)
@@ -297,14 +296,14 @@ class BestEffortCallback(QtAwareCallback):
                         shape = self._start_doc['shape']
                     except KeyError:
                         warn("Need both 'shape' and 'extents' in plan metadata to "
-                            "create LiveGrid.")
+                             "create LiveGrid.")
                     else:
                         data_range = np.array([float(np.diff(e)) for e in extents])
                         y_step, x_step = data_range / [max(1, s - 1) for s in shape]
                         adjusted_extent = [extents[1][0] - x_step / 2,
-                                        extents[1][1] + x_step / 2,
-                                        extents[0][0] - y_step / 2,
-                                        extents[0][1] + y_step / 2]
+                                           extents[1][1] + x_step / 2,
+                                           extents[0][0] - y_step / 2,
+                                           extents[0][1] + y_step / 2]
                         for I_key, ax in zip(columns, axes):
                             # MAGIC NUMBERS based on what tacaswell thinks looks OK
                             data_aspect_ratio = np.abs(data_range[1]/data_range[0])
@@ -317,10 +316,10 @@ class BestEffortCallback(QtAwareCallback):
                                 ax.set_aspect(aspect, adjustable='datalim')
 
                             live_grid = LiveGrid(shape, I_key,
-                                                xlabel=fast, ylabel=slow,
-                                                extent=adjusted_extent,
-                                                aspect=aspect,
-                                                ax=ax)
+                                                 xlabel=fast, ylabel=slow,
+                                                 extent=adjusted_extent,
+                                                 aspect=aspect,
+                                                 ax=ax)
 
                             live_grid('start', self._start_doc)
                             live_grid('descriptor', doc)
@@ -336,16 +335,16 @@ class BestEffortCallback(QtAwareCallback):
                         else:
                             xlim, ylim = extents
                         live_scatter = LiveScatter(x_key, y_key, I_key,
-                                                xlim=xlim, ylim=ylim,
-                                                # Let clim autoscale.
-                                                ax=ax)
+                                                   xlim=xlim, ylim=ylim,
+                                                   # Let clim autoscale.
+                                                   ax=ax)
                         live_scatter('start', self._start_doc)
                         live_scatter('descriptor', doc)
                         self._live_scatters[doc['uid']][I_key] = live_scatter
 
             else:
                 raise NotImplementedError("we do not support 3D+ in BEC yet "
-                                        "(and it should have bailed above)")
+                                          "(and it should have bailed above)")
             try:
                 fig.tight_layout()
             except ValueError:
@@ -455,10 +454,10 @@ class BestEffortCallback(QtAwareCallback):
         num_lines: int
             number of lines (plotted scans) to keep, must be >= 0
         x_signal: object
-            instance of ophyd.Signal (or subclass), 
+            instance of ophyd.Signal (or subclass),
             independent (x) axis
         y_signal: object
-            instance of ophyd.Signal (or subclass), 
+            instance of ophyd.Signal (or subclass),
             dependent (y) axis
         """
         if num_lines < 0:
@@ -475,10 +474,10 @@ class BestEffortCallback(QtAwareCallback):
             lines = [
                 tr
                 for tr in lp.ax.lines
-                if len(tr._x) != 2 
-                    or len(tr._y) != 2 
-                    or (len(tr._x) == 2 
-                        and tr._x[0] != tr._x[1])
+                if len(tr._x) != 2
+                or len(tr._y) != 2
+                or (len(tr._x) == 2
+                    and tr._x[0] != tr._x[1])
             ]
             if len(lines) > num_lines:
                 keepers = lines[-num_lines:]
@@ -573,8 +572,8 @@ class LivePlotPlusPeaks(LivePlot):
                 for artist in self.__arts:
                     artist.set_visible(True)
         elif self.__arts is not None:
-                for artist in self.__arts:
-                    artist.set_visible(False)
+            for artist in self.__arts:
+                artist.set_visible(False)
         self.ax.legend(loc='best')
         self.ax.figure.canvas.draw_idle()
 

--- a/bluesky/callbacks/fitting.py
+++ b/bluesky/callbacks/fitting.py
@@ -1,5 +1,4 @@
 import warnings
-from cycler import cycler
 import numpy as np
 
 from .core import CallbackBase, CollectThenCompute

--- a/bluesky/callbacks/mpl_plotting.py
+++ b/bluesky/callbacks/mpl_plotting.py
@@ -131,11 +131,11 @@ class LivePlot(QtAwareCallback):
             if fig is not None:
                 if ax is not None:
                     raise ValueError("Values were given for both `fig` and `ax`. "
-                                    "Only one can be used; prefer ax.")
+                                     "Only one can be used; prefer ax.")
                 warnings.warn("The `fig` keyword arugment of LivePlot is "
-                            "deprecated and will be removed in the future. "
-                            "Instead, use the new keyword argument `ax` to "
-                            "provide specific Axes to plot on.")
+                              "deprecated and will be removed in the future. "
+                              "Instead, use the new keyword argument `ax` to "
+                              "provide specific Axes to plot on.")
                 ax = fig.gca()
             if ax is None:
                 fig, ax = plt.subplots()
@@ -275,6 +275,7 @@ class LiveScatter(QtAwareCallback):
         super().__init__(use_teleporter=kwargs.pop('use_teleporter', None))
         self.__setup_lock = threading.Lock()
         self.__setup_event = threading.Event()
+
         def setup():
             # Run this code in start() so that it runs on the correct thread.
             nonlocal x, y, I, xlim, ylim, clim, cmap, ax, kwargs
@@ -290,7 +291,7 @@ class LiveScatter(QtAwareCallback):
             ax.cla()
             self.x = x
             self.y = y
-            self.I = I
+            self.I = I  # noqa: E741
             ax.set_xlabel(x)
             ax.set_ylabel(y)
             ax.set_aspect('equal')
@@ -333,7 +334,7 @@ class LiveScatter(QtAwareCallback):
     def event(self, doc):
         x = doc['data'][self.x]
         y = doc['data'][self.y]
-        I = doc['data'][self.I]
+        I = doc['data'][self.I]  # noqa: E741
         self.update(x, y, I)
         super().event(doc)
 
@@ -433,6 +434,7 @@ class LiveGrid(QtAwareCallback):
         super().__init__(**kwargs)
         self.__setup_lock = threading.Lock()
         self.__setup_event = threading.Event()
+
         def setup():
             # Run this code in start() so that it runs on the correct thread.
             nonlocal raster_shape, I, clim, cmap, xlabel, ylabel, extent
@@ -446,7 +448,7 @@ class LiveGrid(QtAwareCallback):
             if ax is None:
                 fig, ax = plt.subplots()
             ax.cla()
-            self.I = I
+            self.I = I  # noqa: E741
             ax.set_xlabel(xlabel)
             ax.set_ylabel(ylabel)
             ax.set_aspect(aspect)
@@ -521,7 +523,7 @@ class LiveGrid(QtAwareCallback):
         if self.snaking[1] and (pos[0] % 2):
             pos[1] = self.raster_shape[1] - pos[1] - 1
         pos = tuple(pos)
-        I = doc['data'][self.I]
+        I = doc['data'][self.I]  # noqa: E741
         self.update(pos, I)
         super().event(doc)
 

--- a/bluesky/callbacks/olog.py
+++ b/bluesky/callbacks/olog.py
@@ -158,7 +158,7 @@ class OlogCallback(CallbackBase):
         from pyOlog import SimpleOlogClient
         self.client = SimpleOlogClient()
         # Check at init time we are in an IPython session.
-        from IPython import get_ipython
+        from IPython import get_ipython  # noqa: F401
 
     def start(self, doc):
         from IPython import get_ipython

--- a/bluesky/callbacks/stream.py
+++ b/bluesky/callbacks/stream.py
@@ -1,4 +1,3 @@
-import logging
 import time as ttime
 from collections.abc import Iterable
 from collections import ChainMap
@@ -118,7 +117,7 @@ class LiveDispatcher(CallbackBase):
         # If we haven't described this configuration
         # Send a new document to our subscribers
         if (stream_name not in self._descriptors or
-            desc_id not in self._descriptors[stream_name]):
+                desc_id not in self._descriptors[stream_name]):
             # Create a new description document for the output of the stream
             data_keys = dict()
             # Parse the event document creating a new description. If the key

--- a/bluesky/callbacks/zmq.py
+++ b/bluesky/callbacks/zmq.py
@@ -146,7 +146,7 @@ class Proxy:
                 out_port = backend.bind_to_random_port("tcp://*")
             else:
                 backend.bind("tcp://*:%d" % out_port)
-        except:
+        except BaseException:
             # Clean up whichever components we have defined so far.
             try:
                 frontend.close()

--- a/bluesky/commandline/zmq_proxy.py
+++ b/bluesky/commandline/zmq_proxy.py
@@ -55,10 +55,12 @@ def main():
         logger.setLevel('INFO')
         if args.verbose > 2:
             logger.setLevel('DEBUG')
+        # Set daemon to kill all threads upon IPython exit
         threading.Thread(target=start_dispatcher,
                          args=('localhost', out_port, args.logfile),
-                         daemon=True).start()  # Set daemon to all ipython exit
-        #                                        kill all threads
+                         # Set daemon to all ipython exit kill all threads
+                         daemon=True).start()
+
     print("Connecting...")
     proxy = Proxy(in_port, out_port)
     print("Receiving on port %d; publishing to port %d." % (in_port, out_port))

--- a/bluesky/commandline/zmq_proxy.py
+++ b/bluesky/commandline/zmq_proxy.py
@@ -32,7 +32,7 @@ def start_dispatcher(host, port, logfile):
             logger.info("%s: %r", name, doc)
         else:
             logger.debug("%s: %r", name, doc)
-    dispatcher.subscribe(log_writer) # Subscribe log writer
+    dispatcher.subscribe(log_writer)  # Subscribe log writer
     dispatcher.start()
 
 
@@ -58,7 +58,7 @@ def main():
         threading.Thread(target=start_dispatcher,
                          args=('localhost', out_port, args.logfile),
                          daemon=True).start()  # Set daemon to all ipython exit
-                                               # kill all threads
+        #                                        kill all threads
     print("Connecting...")
     proxy = Proxy(in_port, out_port)
     print("Receiving on port %d; publishing to port %d." % (in_port, out_port))

--- a/bluesky/commandline/zmq_proxy.py
+++ b/bluesky/commandline/zmq_proxy.py
@@ -58,7 +58,6 @@ def main():
         # Set daemon to kill all threads upon IPython exit
         threading.Thread(target=start_dispatcher,
                          args=('localhost', out_port, args.logfile),
-                         # Set daemon to all ipython exit kill all threads
                          daemon=True).start()
 
     print("Connecting...")

--- a/bluesky/examples.py
+++ b/bluesky/examples.py
@@ -1,9 +1,11 @@
 import warnings
+import time as ttime
+import numpy as np
 from .utils import Msg
 
 
 try:
-    import ophyd.sim
+    import ophyd.sim  # noqa: F401
 except ImportError:
     raise ImportError("""
 The simulated hardware objects in the bluesky.examples module have been
@@ -13,7 +15,7 @@ else:
 The simulated hardware objects in the bluesky.examples module have been
 moved to ophyd.sim. Update imports to suppress this warning.
     """, stacklevel=2)
-    from ophyd.sim import *
+    from ophyd.sim import *  # noqa: F403, F401
 
 
 # These are very old, raw implementations of 'plans' the pre-date the

--- a/bluesky/log.py
+++ b/bluesky/log.py
@@ -2,7 +2,6 @@
 # Apache 2.0. See other_licenses/ in the repository directory.
 import logging
 import sys
-import warnings
 
 try:
     import colorama
@@ -14,7 +13,7 @@ try:
 except ImportError:
     curses = None
 
-__all__ = ('color_logs', 'config_bluesky_logging', 'get_handler',
+__all__ = ('config_bluesky_logging', 'get_handler',
            'LogFormatter', 'set_handler')
 
 

--- a/bluesky/magics.py
+++ b/bluesky/magics.py
@@ -23,6 +23,7 @@ try:
 except ImportError:
     from toolz import partition
 
+
 # This is temporarily here to allow for warnings to be printed
 # we changed positioners to a property but since we never instantiate
 # the class we need to add this
@@ -55,6 +56,7 @@ class MetaclassForClassProperties(MetaHasTraits, type):
 
     _positioners = []
     _detectors = []
+
 
 @magics_class
 class BlueskyMagics(Magics, metaclass=MetaclassForClassProperties):
@@ -125,7 +127,6 @@ class BlueskyMagics(Magics, metaclass=MetaclassForClassProperties):
         self._ensure_idle()
         return None
 
-
     @line_magic
     def ct(self, line):
         # If the deprecated BlueskyMagics.detectors list is non-empty, it has
@@ -164,9 +165,7 @@ class BlueskyMagics(Magics, metaclass=MetaclassForClassProperties):
         self._ensure_idle()
         return None
 
-
     FMT_PREC = 6
-
 
     @line_magic
     def wa(self, line):
@@ -203,7 +202,7 @@ class BlueskyMagics(Magics, metaclass=MetaclassForClassProperties):
                     devices = devices_dict[label]
                     all_children = [(k, getattr(obj, k))
                                     for _, obj in devices
-                                        for k in getattr(obj, 'read_attrs', [])]
+                                    for k in getattr(obj, 'read_attrs', [])]
                 except KeyError:
                     print('<no matches for this label>')
                     continue
@@ -212,12 +211,13 @@ class BlueskyMagics(Magics, metaclass=MetaclassForClassProperties):
                                if is_positioner(dev)]
                 if positioners:
                     _print_positioners(positioners, precision=self.FMT_PREC,
-                                        prefix=" "*2)
+                                       prefix=" "*2)
                     print()  # blank line
                 # Just display the top-level devices in the namespace (no
                 # children).
                 _print_devices(devices, prefix=" "*2)
                 print()  # blank line
+
 
 def _print_devices(devices, prefix=""):
     cols = ["Local variable name", "Ophyd name (to be recorded as metadata)"]
@@ -225,8 +225,10 @@ def _print_devices(devices, prefix=""):
     for name, obj in devices:
         print(prefix + "{:38} {:38s}".format(name, str(obj.name)))
 
+
 def is_positioner(dev):
     return hasattr(dev, 'position')
+
 
 def _print_positioners(positioners, sort=True, precision=6, prefix=""):
     '''
@@ -344,7 +346,6 @@ def get_labeled_devices(user_ns=None, maxdepth=6):
                             maxdepth=maxdepth-1).items():
                         items = [('.'.join([key, ot[0]]), ot[1]) for ot in v]
                         obj_list[c_key].extend(items)
-
 
     # Convert from defaultdict to normal dict before returning.
     return {k: sorted(v) for k, v in obj_list.items()}

--- a/bluesky/plan_patterns.py
+++ b/bluesky/plan_patterns.py
@@ -49,7 +49,7 @@ def spiral(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, nth, *,
         dr_aspect = 1
     else:
         dr_aspect = dr_y / dr
-   
+
     half_x = x_range / 2
     half_y = y_range / (2 * dr_aspect)
 
@@ -67,7 +67,7 @@ def spiral(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, nth, *,
             angle = i_angle * angle_step
             x = radius * np.cos(angle)
             y = radius * np.sin(angle) * dr_aspect
-            if ((abs(x - (y / dr_aspect) / tilt_tan) <= half_x) and 
+            if ((abs(x - (y / dr_aspect) / tilt_tan) <= half_x) and
                     (abs(y / dr_aspect) <= half_y)):
                 x_points.append(x_start + x)
                 y_points.append(y_start + y)
@@ -245,7 +245,7 @@ def spiral_fermat(x_motor, y_motor, x_start, y_start, x_range, y_range, dr,
         dr_aspect = 1
     else:
         dr_aspect = dr_y / dr
-    
+
     phi = 137.508 * np.pi / 180.
 
     half_x = x_range / 2

--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -510,7 +510,7 @@ def finalize_wrapper(plan, final_plan, *, pause_for_debug=False):
     except GeneratorExit:
         cleanup = False
         raise
-    except:
+    except BaseException:
         if pause_for_debug:
             yield from pause()
         raise
@@ -1063,10 +1063,10 @@ def relative_set_wrapper(plan, devices=None):
         eligible = (devices is None) or (msg.obj in devices)
         seen = msg.obj in initial_positions
         if (msg.command == 'set') and eligible and not seen:
-                return (pchain(
-                    __read_and_stash_a_motor(
-                        msg.obj, initial_positions, coupled_parents),
-                    single_gen(msg)), None)
+            return (pchain(
+                __read_and_stash_a_motor(
+                    msg.obj, initial_positions, coupled_parents),
+                single_gen(msg)), None)
         else:
             return None, None
 
@@ -1330,5 +1330,6 @@ def set_run_key_wrapper(plan, run):
         return msg
 
     return (yield from msg_mutator(plan, _set_run_key))
+
 
 set_run_key_decorator = make_decorator(set_run_key_wrapper)

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1,7 +1,6 @@
 import asyncio
 from datetime import datetime
 import sys
-import logging
 from warnings import warn
 from inspect import Parameter, Signature
 from itertools import count
@@ -17,7 +16,6 @@ from .bundlers import RunBundler
 import concurrent
 
 from event_model import DocumentNames, schema_validators
-import jsonschema
 from .log import logger, msg_logger, state_logger, ComposableLogAdapter
 from super_state_machine.machines import StateMachine
 from super_state_machine.extras import PropertyMachine
@@ -120,7 +118,7 @@ class LoggingPropertyMachine(PropertyMachine):
                 'RE': self}
 
         state_logger.info("Change state on %r from %r -> %r",
-                           obj, old_value, value, extra=tags)
+                          obj, old_value, value, extra=tags)
         if obj.state_hook is not None:
             obj.state_hook(value, old_value)
 

--- a/bluesky/simulators.py
+++ b/bluesky/simulators.py
@@ -73,7 +73,6 @@ def summarize_plan(plan):
         ...
 
 
-
 print_summary = summarize_plan  # back-compat
 
 

--- a/bluesky/suspenders.py
+++ b/bluesky/suspenders.py
@@ -530,9 +530,9 @@ class SuspendOutBand(_SuspendBandBase):
 class SuspendWhenChanged(SuspenderBase):
     """
     Suspend when the monitored value deviates from the expected.
-    
+
     Only resume if allowed AND when monitored equals expected.
-    
+
     Notes
     -----
 
@@ -540,25 +540,25 @@ class SuspendWhenChanged(SuspenderBase):
 
     USE CASE:
 
-    :class:`~SuspendWhenChanged()` is useful when ``signal`` is an EPICS enumeration 
+    :class:`~SuspendWhenChanged()` is useful when ``signal`` is an EPICS enumeration
     (`"mbbo" <https://wiki-ext.aps.anl.gov/epics/index.php/RRM_3-14_Multi-Bit_Binary_Output>`_)
-    used with a multi-instrument facility.  
-    Choices predefined in the mbbo record are the 
+    used with a multi-instrument facility.
+    Choices predefined in the mbbo record are the
     names of instruments allowed to control any shared hardware.
-    
+
     * The ``signal``, set by instrument staff outside of bluesky,
       names which instrument is allowed to control the hardware.
-    * Other instruments not matching ``signal`` are expected **not** to 
+    * Other instruments not matching ``signal`` are expected **not** to
       control the hardware (they could use simulators instead or not operate
       the shared hardware).
-    
-    Since a decision of hardware *vs.* simulators is made at the 
-    time a bluesky session starts and ophyd objects are first created, the 
-    session needs to be aware immediately if the ``signal`` is changed.  
+
+    Since a decision of hardware *vs.* simulators is made at the
+    time a bluesky session starts and ophyd objects are first created, the
+    session needs to be aware immediately if the ``signal`` is changed.
     The default value of ``allow_resume=False`` defends this decision.
-    If there is a mechanism engineered to toggle ophyd signals between 
+    If there is a mechanism engineered to toggle ophyd signals between
     hardware and simulators, one might consider ``allow_resume=True``.
-    
+
 
     Parameters
     ----------
@@ -569,13 +569,13 @@ class SuspendWhenChanged(SuspenderBase):
 
     expected_value : str, float, or int
         RunEngine operations will be suspended when signal deviates
-        from this value.  If `None` (default), set to value of 
+        from this value.  If `None` (default), set to value of
         ``signal`` when object is created.
 
     allow_resume : bool
         Should RunEngine be allowed to resume once ``signal.value == expected``
         again?  Default value of ``False`` is expected for intended use case.
-    
+
     sleep : float, optional
         How long to wait in seconds after the resume condition is met
         before marking the event as done.  Defaults to ``0``.
@@ -619,31 +619,31 @@ class SuspendWhenChanged(SuspenderBase):
             # FVST
             # ...
         }
-    
+
     NOTE: **Always** make the zero choice (``ZRST``) in the mbbo record to be 'none'.
-    This allows the instrument staff to designate that *no* instrument is allowed 
+    This allows the instrument staff to designate that *no* instrument is allowed
     to control the shared hardware.  Start the names of the allowed instruments
     with ``ONST``.
-    
+
     It is convenient for the multi-instrument facility to make this definition
     in EPICS rather than in a specific bluesky session.  The EPICS value could be
     useful in other contexts of instrument control beyond the realm of bluesky.
     """
-    
-    def __init__(self, signal, *, 
-                expected_value=None,
-                allow_resume=False,
-                sleep=0, pre_plan=None, post_plan=None, tripped_message='',
-                **kwargs):
-        
+
+    def __init__(self, signal, *,
+                 expected_value=None,
+                 allow_resume=False,
+                 sleep=0, pre_plan=None, post_plan=None, tripped_message='',
+                 **kwargs):
+
         self.expected_value = expected_value or signal.value
         self.allow_resume = allow_resume
-        super().__init__(signal, 
-            sleep=sleep, 
-            pre_plan=pre_plan, 
-            post_plan=post_plan, 
-            tripped_message=tripped_message,
-            **kwargs)
+        super().__init__(signal,
+                         sleep=sleep,
+                         pre_plan=pre_plan,
+                         post_plan=post_plan,
+                         tripped_message=tripped_message,
+                         **kwargs)
 
     def _should_suspend(self, value):
         return value != self.expected_value
@@ -663,6 +663,6 @@ class SuspendWhenChanged(SuspenderBase):
         if not self.allow_resume:
             just += '.  "RE.abort()" and then restart session to use new configuration.'
         return ': '.join(
-            s 
+            s
             for s in (just, self._tripped_message)
             if s)

--- a/bluesky/tests/interactive/best_effort_cb.py
+++ b/bluesky/tests/interactive/best_effort_cb.py
@@ -1,11 +1,9 @@
-#%matplotlib qt5
+# %matplotlib qt5
 import matplotlib.pyplot as plt
-plt.ion()
 import numpy as np
+import shutil
+
 from bluesky.utils import install_qt_kicker
-install_qt_kicker()
-
-
 from bluesky.plans import (relative_outer_product_scan,
                            relative_inner_product_scan,
                            outer_product_scan,
@@ -13,31 +11,32 @@ from bluesky.plans import (relative_outer_product_scan,
                            scan_nd)
 from bluesky.plan_stubs import mov
 
-from ophyd.sim import det4, motor1, motor2, motor3
+from ophyd.sim import det4, motor1, motor2
 from bluesky import RunEngine
 from bluesky.callbacks.best_effort import BestEffortCallback
 
 from databroker.tests.utils import temp_config
 from databroker import Broker
 
+plt.ion()
+install_qt_kicker()
 
 # db setup
 config = temp_config()
 tempdir = config['metadatastore']['config']['directory']
 
+
 def cleanup():
     shutil.rmtree(tempdir)
 
-db = Broker.from_config(config)
 
+db = Broker.from_config(config)
 
 RE = RunEngine({})
 # subscribe BEC
 bec = BestEffortCallback()
 RE.subscribe(bec)
 RE.subscribe(db.insert)
-
-
 
 # move motor to a reproducible location
 RE(mov(motor1, 0))
@@ -54,9 +53,8 @@ RE(relative_inner_product_scan([det4], 10, motor1, -1, 0, motor2, -2,
                                0))
 RE(inner_product_scan([det4], 10, motor1, -1, 0, motor2, -2, 0))
 
-
 # do it manually
-from cycler import cycler
+from cycler import cycler  # noqa: E402
 
 
 mot1_cycl = cycler(motor1, np.linspace(-1, 0, 10))
@@ -64,33 +62,32 @@ mot2_cycl = cycler(motor2, np.linspace(-2, 0, 10))
 
 
 # inner product
-inner_hints = {'fields' : [det4.name],
-               'dimensions' : [ ([motor1.name, motor2.name],'primary')]}
+inner_hints = {'fields': [det4.name],
+               'dimensions': [([motor1.name, motor2.name], 'primary')]}
 RE(scan_nd([det4], mot1_cycl+mot2_cycl), hints=inner_hints)
 
 # outer product
-outer_hints = {'fields' : [det4.name],
-               'dimensions' : [([motor2.name],'primary'),
-                               ([motor1.name], 'primary')]}
+outer_hints = {'fields': [det4.name],
+               'dimensions': [([motor2.name], 'primary'),
+                              ([motor1.name], 'primary')]}
 md = {'shape': (20, 20),
-      #'extents': ([-1, 0], [-1, 0]),
-      'hints' : outer_hints
-     }
+      # 'extents': ([-1, 0], [-1, 0]),
+      'hints': outer_hints
+      }
 
 RE(scan_nd([det4], mot1_cycl*mot2_cycl), **md)
 
 # make 40 points just to test
 mot2_cycl = cycler(motor2, np.linspace(-1, 0, 20))
 # now try rectilinear gridding
-outer_hints = {'fields' : [det4.name],
-               'dimensions' : [([motor2.name],'primary'),
-                               ([motor1.name], 'primary')],
-               'gridding' : 'rectilinear'
-              }
+outer_hints = {'fields': [det4.name],
+               'dimensions': [([motor2.name], 'primary'),
+                              ([motor1.name], 'primary')],
+               'gridding': 'rectilinear'
+               }
 md = {'shape': (10, 20),
       'extents': ([-1, 0], [-1, 0]),
-      'hints' : outer_hints,
-     }
+      'hints': outer_hints,
+      }
 
 RE(scan_nd([det4], mot1_cycl*mot2_cycl), **md)
-

--- a/bluesky/tests/test_bec.py
+++ b/bluesky/tests/test_bec.py
@@ -1,7 +1,6 @@
 import ast
 import pytest
 import jsonschema
-import re
 import time as ttime
 from datetime import datetime
 from bluesky.plans import scan, grid_scan

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -27,6 +27,7 @@ from unittest.mock import MagicMock
 from itertools import permutations
 import time
 
+
 # copied from examples.py to avoid import
 def stepscan(det, motor):
     yield Msg('open_run')

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -1,10 +1,4 @@
 import pytest
-with pytest.warns(UserWarning):
-    from bluesky.examples import (simple_scan, sleepy, wait_one,
-                                  wait_multiple, conditional_pause,
-                                  checkpoint_forever, simple_scan_saving,
-                                  stepscan, fly_gen, conditional_break,
-                                  )
 from bluesky.callbacks.mpl_plotting import LivePlot
 from bluesky import (Msg, IllegalMessageSequence,
                      RunEngineInterrupted, FailedStatus)
@@ -13,11 +7,16 @@ import os
 import signal
 import asyncio
 import time as ttime
-import numpy as np
-from numpy.testing import assert_array_equal
 import time
 import threading
 from functools import partial
+
+with pytest.warns(UserWarning):
+    from bluesky.examples import (simple_scan, sleepy, wait_one,
+                                  wait_multiple, conditional_pause,
+                                  checkpoint_forever, simple_scan_saving,
+                                  stepscan, fly_gen, conditional_break,
+                                  )
 
 
 def test_msgs(RE, hw):
@@ -620,11 +619,11 @@ def test_failed_status_object(RE):
     ff = failer()
     with pytest.raises(FailedStatus):
         RE([Msg('set', ff, None, group='a'),
-                  Msg('wait', None, group='a')])
+            Msg('wait', None, group='a')])
 
     with pytest.raises(FailedStatus):
         RE([Msg('trigger', ff, group='a'),
-                  Msg('wait', None, group='a')])
+            Msg('wait', None, group='a')])
 
 
 def test_rewindable_by_default(RE):

--- a/bluesky/tests/test_generators.py
+++ b/bluesky/tests/test_generators.py
@@ -388,7 +388,7 @@ def test_insert_before():
         else:
             return None, None
 
-    ret = EchoRE(plan_mutator(target(), insert_before))
+    EchoRE(plan_mutator(target(), insert_before))
 
 
 def test_insert_after():
@@ -410,7 +410,7 @@ def test_insert_after():
         else:
             return None, None
 
-    ret = EchoRE(plan_mutator(target(), insert_after))
+    EchoRE(plan_mutator(target(), insert_after))
 
 
 def test_base_exception():

--- a/bluesky/tests/test_legacy_plans.py
+++ b/bluesky/tests/test_legacy_plans.py
@@ -1,5 +1,5 @@
-import pytest
 import bluesky.plans as bp
+
 
 def test_legacy_plan_names():
     assert bp.outer_product_scan is bp.grid_scan

--- a/bluesky/tests/test_metadata.py
+++ b/bluesky/tests/test_metadata.py
@@ -1,8 +1,10 @@
 import bluesky
 import ophyd
 
+
 def test_blueskyversion(RE):
     assert RE.md['versions'].get('bluesky') == bluesky.__version__
+
 
 def test_ophydversion(RE):
     assert RE.md['versions'].get('ophyd') == ophyd.__version__

--- a/bluesky/tests/test_multi_runs.py
+++ b/bluesky/tests/test_multi_runs.py
@@ -1,5 +1,3 @@
-from bluesky import preprocessors as bpp
-from bluesky import plans as bp
 from bluesky import plan_stubs as bps
 from bluesky.preprocessors import set_run_key_wrapper as srkw
 import bluesky.preprocessors as bsp
@@ -106,6 +104,7 @@ def test_multirun_run_key_type(RE, hw):
     def plan4():
         yield from srkw(empty_plan(), "run_name")
     RE(plan4(), dc.insert)
+
     def plan5():
         yield from srkw(empty_plan(), run="run_name")
     RE(plan5(), dc.insert)

--- a/bluesky/tests/test_olog_cb.py
+++ b/bluesky/tests/test_olog_cb.py
@@ -25,20 +25,21 @@ def test_trivial_template(RE):
     RE.subscribe(logbook_cb_factory(f, long_template='hello'), 'start')
     RE([Msg('open_run', plan_args={}), Msg('close_run')])
 
+
 def test_template_dispatch(RE):
     disp = {'a': 'A', 'b': 'B'}
     text.clear()
     RE.subscribe(logbook_cb_factory(f, desc_dispatch=disp), 'start')
     RE([Msg('open_run', plan_name='a', plan_args={}),
-              Msg('close_run')])
+        Msg('close_run')])
     RE([Msg('open_run', plan_name='b', plan_args={}),
-              Msg('close_run')])
+        Msg('close_run')])
     assert text[0] == 'A'
     assert text[1] == 'B'
 
     # smoke test the long_dispatch
     RE.subscribe(logbook_cb_factory(f, long_dispatch=disp), 'start')
     RE([Msg('open_run', plan_name='a', plan_args={}),
-              Msg('close_run')])
+        Msg('close_run')])
     RE([Msg('open_run', plan_name='b', plan_args={}),
-              Msg('close_run')])
+        Msg('close_run')])

--- a/bluesky/tests/test_progress_bar.py
+++ b/bluesky/tests/test_progress_bar.py
@@ -1,8 +1,6 @@
 from bluesky.utils import ProgressBar, ProgressBarManager
 from bluesky.plan_stubs import mv
 from bluesky.tests import requires_ophyd
-from bluesky import RunEngine
-from collections import OrderedDict
 import time
 
 
@@ -83,6 +81,7 @@ def test_tuple_progress():
     st.done = True
     pbar.update(0, name='foo')
 
+
 def test_mv_progress(RE, hw):
     motor1 = hw.motor1
     motor2 = hw.motor2
@@ -104,6 +103,7 @@ def test_mv_progress(RE, hw):
 def test_draw_before_update():
     class Status:
         done = False
+
         def watch(self, func):
             ...
 

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -166,7 +166,7 @@ def test_flyer_with_collect_asset_documents(RE):
     from ophyd.sim import det, new_trivial_flyer, trivial_flyer
     from bluesky.preprocessors import fly_during_wrapper
     assert hasattr(new_trivial_flyer, 'collect_asset_docs')
-    assert hasattr(trivial_flyer, 'collec_asset_docs') is False
+    assert not hasattr(trivial_flyer, 'collec_asset_docs')
     RE(fly_during_wrapper(count([det], num=5), [new_trivial_flyer, trivial_flyer]))
 
 

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -14,8 +14,7 @@ from bluesky.run_engine import (RunEngineStateMachine,
                                 NoReplayAllowed, FailedStatus,
                                 RunEngineInterrupted,
                                 RequestStop,
-                                RequestAbort,
-                                PlanHalt)
+                                RequestAbort)
 from bluesky import Msg
 from functools import partial
 from bluesky.tests.utils import MsgCollector, DocCollector
@@ -167,7 +166,7 @@ def test_flyer_with_collect_asset_documents(RE):
     from ophyd.sim import det, new_trivial_flyer, trivial_flyer
     from bluesky.preprocessors import fly_during_wrapper
     assert hasattr(new_trivial_flyer, 'collect_asset_docs')
-    assert hasattr(trivial_flyer, 'collec_asset_docs') == False
+    assert hasattr(trivial_flyer, 'collec_asset_docs') is False
     RE(fly_during_wrapper(count([det], num=5), [new_trivial_flyer, trivial_flyer]))
 
 
@@ -530,6 +529,7 @@ def test_unrewindable_det_suspend(RE, plan, motor, det, msg_seq):
     from bluesky.utils import ts_msg_hook
     msgs = []
     loop = RE.loop
+
     def collector(msg):
         ts_msg_hook(msg)
         msgs.append(msg)

--- a/bluesky/tests/test_scans.py
+++ b/bluesky/tests/test_scans.py
@@ -8,7 +8,6 @@ import numpy.testing
 import pytest
 
 
-
 def test_scan_num(RE, hw):
     RE(bp.scan([hw.det], hw.motor1, -1, 1, num=1))
     RE(bp.scan([hw.det], hw.motor1, -1, 1, num=1.0))
@@ -63,8 +62,8 @@ def approx_multi_traj_checker(RE, scan, expected_data, *, decimal=2):
 
 def test_outer_product_ascan(RE, hw):
     scan = bp.grid_scan([hw.det],
-                                 hw.motor1, 1, 3, 3,
-                                 hw.motor2, 10, 20, 2, False)
+                        hw.motor1, 1, 3, 3,
+                        hw.motor2, 10, 20, 2, False)
     # Note: motor1 is the first motor specified, and so it is the "slow"
     # axis, matching the numpy convention.
     expected_data = [
@@ -82,8 +81,8 @@ def test_outer_product_ascan(RE, hw):
 
 def test_outer_product_ascan_snaked(RE, hw):
     scan = bp.grid_scan([hw.det],
-                                 hw.motor1, 1, 3, 3,
-                                 hw.motor2, 10, 20, 2, True)
+                        hw.motor1, 1, 3, 3,
+                        hw.motor2, 10, 20, 2, True)
     # Note: motor1 is the first motor specified, and so it is the "slow"
     # axis, matching the numpy convention.
     expected_data = [
@@ -117,8 +116,8 @@ def test_inner_product_ascan(RE, hw):
 
 def test_outer_product_dscan(RE, hw):
     scan = bp.rel_grid_scan([hw.det],
-                                          hw.motor1, 1, 3, 3,
-                                          hw.motor2, 10, 20, 2, False)
+                            hw.motor1, 1, 3, 3,
+                            hw.motor2, 10, 20, 2, False)
     # Note: motor1 is the first motor specified, and so it is the "slow"
     # axis, matching the numpy convention.
     hw.motor1.set(5)
@@ -138,8 +137,8 @@ def test_outer_product_dscan(RE, hw):
 
 def test_outer_product_dscan_snaked(RE, hw):
     scan = bp.rel_grid_scan([hw.det],
-                                          hw.motor1, 1, 3, 3,
-                                          hw.motor2, 10, 20, 2, True)
+                            hw.motor1, 1, 3, 3,
+                            hw.motor2, 10, 20, 2, True)
     # Note: motor1 is the first motor specified, and so it is the "slow"
     # axis, matching the numpy convention.
     hw.motor1.set(5)
@@ -468,7 +467,7 @@ def test_tune_centroid(RE, hw):
 
     RE(scan1, {'event': [col, counter1]})
     RE(scan2, {'event': counter2})
-    #assert counter1.value > counter2.value
+    # assert counter1.value > counter2.value
     assert actual_traj[0] == 0
 
     actual_traj = []
@@ -566,10 +565,10 @@ def test_rel_spiral(RE, hw):
     motor1.set(start_x)
     motor2.set(start_y)
     scan = bp.rel_spiral([det],
-                              motor1, motor2,
-                              1.0, 1.0,
-                              0.1, 1.0,
-                              tilt=0.0)
+                         motor1, motor2,
+                         1.0, 1.0,
+                         0.1, 1.0,
+                         tilt=0.0)
 
     approx_multi_traj_checker(RE, scan,
                               _get_spiral_data(start_x, start_y),
@@ -648,10 +647,10 @@ def test_relative_fermat_spiral(RE, hw):
     motor1.set(start_x)
     motor2.set(start_y)
     scan = bp.rel_spiral_fermat([det],
-                                     motor1, motor2,
-                                     1.0, 1.0,
-                                     0.1, 1.0,
-                                     tilt=0.0)
+                                motor1, motor2,
+                                1.0, 1.0,
+                                0.1, 1.0,
+                                tilt=0.0)
 
     approx_multi_traj_checker(RE, scan,
                               _get_fermat_data(start_x, start_y),
@@ -672,7 +671,7 @@ def test_x2x_scan(RE, hw):
         d.update({'motor1_setpoint': d['motor1']})
         d.update({'motor2_setpoint': d['motor2']})
 
-    scan = bp.x2x_scan([hw.det], hw.motor1, hw.motor2, y_start, y_stop, y_num )
+    scan = bp.x2x_scan([hw.det], hw.motor1, hw.motor2, y_start, y_stop, y_num)
 
     multi_traj_checker(RE, scan, expected_traj)
 

--- a/bluesky/tests/test_scientific.py
+++ b/bluesky/tests/test_scientific.py
@@ -1,21 +1,22 @@
 import numpy as np
 from bluesky.plans import scan
-from ophyd.sim import motor, noisy_det, det, SynGauss
+from ophyd.sim import motor, det, SynGauss
 from bluesky.callbacks.fitting import PeakStats
+from scipy.special import erf
+from lmfit import Model
 
 
 def get_ps(x, y, shift=0.5):
     """ peak status calculation from CHX algorithm.
     """
     ps = {}
-    x=np.array(x)
-    y=np.array(y)
+    x = np.array(x)
+    y = np.array(y)
 
-    PEAK=x[np.argmax(y)]
-    PEAK_y=np.max(y)
-    COM=np.sum(x * y) / np.sum(y)
+    COM = np.sum(x * y) / np.sum(y)
     ps['com'] = COM
-    ### from Maksim: assume this is a peak profile:
+
+    # from Maksim: assume this is a peak profile:
     def is_positive(num):
         return True if num > 0 else False
 
@@ -30,8 +31,8 @@ def get_ps(x, y, shift=0.5):
             list_of_roots.append(x[i - 1] + (x[i] - x[i - 1]) / (abs(ym[i]) + abs(ym[i - 1])) * abs(ym[i - 1]))
             positive = not positive
     if len(list_of_roots) >= 2:
-        FWHM=abs(list_of_roots[-1] - list_of_roots[0])
-        CEN=list_of_roots[0]+0.5*(list_of_roots[1]-list_of_roots[0])
+        FWHM = abs(list_of_roots[-1] - list_of_roots[0])
+        CEN = list_of_roots[0]+0.5*(list_of_roots[1]-list_of_roots[0])
 
         ps['fwhm'] = FWHM
         ps['cen'] = CEN
@@ -39,15 +40,17 @@ def get_ps(x, y, shift=0.5):
     else:    # ok, maybe it's a step function..
         print('no peak...trying step function...')
         ym = ym + shift
-        def err_func(x, x0, k=2, A=1,  base=0 ):     #### erf fit from Yugang
-            return base - A * erf(k*(x-x0))
-        mod = Model(  err_func )
-        ### estimate starting values:
-        x0=np.mean(x)
-        #k=0.1*(np.max(x)-np.min(x))
-        pars  = mod.make_params( x0=x0, k=2,  A = 1., base = 0. )
-        result = mod.fit(ym, pars, x = x )
-        CEN=result.best_values['x0']
+
+        def err_func(x, x0, k=2, A=1,  base=0):  # erf fit from Yugang
+            return base - A * erf(k * (x - x0))
+
+        mod = Model(err_func)
+        # estimate starting values:
+        x0 = np.mean(x)
+        # k=0.1*(np.max(x)-np.min(x))
+        pars = mod.make_params(x0=x0, k=2, A=1., base=0.)
+        result = mod.fit(ym, pars, x=x)
+        CEN = result.best_values['x0']
         FWHM = result.best_values['k']
         ps['fwhm'] = FWHM
         ps['cen'] = CEN
@@ -66,7 +69,7 @@ def test_peak_statistics(RE):
 
     np.allclose(ps.cen, 0, atol=1e-6)
     np.allclose(ps.com, 0, atol=1e-6)
-    fwhm_gauss = 2*np.sqrt(2*np.log(2)) # theoretical value with std=1
+    fwhm_gauss = 2*np.sqrt(2*np.log(2))  # theoretical value with std=1
     np.allclose(ps.fwhm, fwhm_gauss, atol=1e-2)
 
 
@@ -75,7 +78,7 @@ def test_peak_statistics_compare_chx(RE):
     """
     s = np.random.RandomState(1)
     noisy_det_fix = SynGauss('noisy_det_fix', motor, 'motor', center=0, Imax=1,
-                              noise='uniform', sigma=1, noise_multiplier=0.1, random_state=s)
+                             noise='uniform', sigma=1, noise_multiplier=0.1, random_state=s)
     x = 'motor'
     y = 'noisy_det_fix'
     ps = PeakStats(x, y)

--- a/bluesky/tests/test_simulators.py
+++ b/bluesky/tests/test_simulators.py
@@ -27,9 +27,9 @@ def test_old_module_name(hw):
     with pytest.warns(UserWarning):
         list(print_summary_wrapper(scan([det], motor, -1, 1, 10)))
     with pytest.warns(UserWarning):
-        plan = grid_scan([det], motor1, -5, 5, 10, motor2, -7, 7, 15,
-                                  True)
+        plan = grid_scan([det], motor1, -5, 5, 10, motor2, -7, 7, 15, True)
         plot_raster_path(plan, 'motor1', 'motor2', probe_size=.3)
+
 
 def test_check_limits(hw):
     det = hw.det
@@ -55,6 +55,7 @@ def test_check_limits(hw):
     motor.limits = (2, 2)
     with pytest.warns(UserWarning):
         check_limits(scan([det], motor, -1, 1, 3))
+
 
 def test_plot_raster_path(hw):
     det = hw.det

--- a/bluesky/tests/test_snaking.py
+++ b/bluesky/tests/test_snaking.py
@@ -2,9 +2,10 @@ from bluesky.utils import snake_cyclers
 from cycler import cycler
 
 
-x = cycler('x', [1,2,3])
-y = cycler('y', [1,2])
-z = cycler('z', [1,2,3])
+x = cycler('x', [1, 2, 3])
+y = cycler('y', [1, 2])
+z = cycler('z', [1, 2, 3])
+
 
 def test_snake_no_snaking():
     actual = list(snake_cyclers([z, y, x], [False, False, False]))
@@ -29,6 +30,7 @@ def test_snake_no_snaking():
         {'x': 3, 'y': 2, 'z': 3}]
     assert actual == expected
 
+
 def test_snake_all_snaking():
     actual = list(snake_cyclers([z, y, x], [False, True, True]))
     expected = [
@@ -51,6 +53,7 @@ def test_snake_all_snaking():
         {'x': 2, 'y': 2, 'z': 3},
         {'x': 1, 'y': 2, 'z': 3}]
     assert actual == expected
+
 
 def test_snake_some_snaking():
     actual = list(snake_cyclers([z, y, x], [False, True, False]))

--- a/bluesky/tests/test_supplemental_data.py
+++ b/bluesky/tests/test_supplemental_data.py
@@ -161,6 +161,7 @@ def test_uid_passthrough(RE, hw):
     sd.monitors = [hw.rand]
     sd.flyers = [hw.flyer1]
     hw.flyer1.loop = RE.loop
+
     def mycount2():
         uid = yield from sd(count([]))
         assert uid is not None

--- a/bluesky/tests/test_suspenders.py
+++ b/bluesky/tests/test_suspenders.py
@@ -16,6 +16,7 @@ from bluesky.run_engine import RunEngineInterrupted
 import threading
 import time
 
+
 @pytest.mark.parametrize(
     'klass,sc_args,start_val,fail_val,resume_val,wait_time',
     [(SuspendBoolHigh, (), 0, 1, 0, .2),
@@ -27,7 +28,6 @@ import time
      (SuspendOutBand, (.5, 1.5), 0, 1, 0, .2)])  # deprecated
 def test_suspender(klass, sc_args, start_val, fail_val,
                    resume_val, wait_time, RE, hw):
-    loop = RE._loop
     sig = hw.bool_sig
     my_suspender = klass(sig,
                          *sc_args, sleep=wait_time)
@@ -191,7 +191,6 @@ def test_unresumable_suspend_fail(RE):
 
 def test_suspender_plans(RE, hw):
     'Tests that the suspenders can be installed via Msg'
-    loop = RE._loop
     sig = hw.bool_sig
     my_suspender = SuspendBoolHigh(sig, sleep=0.2)
 

--- a/bluesky/tests/test_transformer.py
+++ b/bluesky/tests/test_transformer.py
@@ -1,6 +1,7 @@
 import pytest
 from bluesky.utils import register_transform
 
+
 @pytest.fixture
 def transform_cell():
     IPython = pytest.importorskip('IPython')
@@ -14,6 +15,7 @@ def transform_cell():
 
 def test_register_transform_smoke(transform_cell):
     assert True
+
 
 @pytest.mark.parametrize('cell',
                          ['a < b\n',

--- a/bluesky/tests/test_zmq.py
+++ b/bluesky/tests/test_zmq.py
@@ -65,12 +65,12 @@ def test_zmq(RE, hw):
         local_accumulator.append((name, doc))
 
     # Check that numpy stuff is sanitized by putting some in the start doc.
-    # md = {'stuff': {'nested': np.array([1, 2, 3])},
-    #       'scalar_stuff': np.float64(3),
-    #       'array_stuff': np.ones((3, 3))}
+    md = {'stuff': {'nested': np.array([1, 2, 3])},
+          'scalar_stuff': np.float64(3),
+          'array_stuff': np.ones((3, 3))}
 
     # RE([Msg('open_run', **md), Msg('close_run')], local_cb)
-    RE(count([hw.det]), local_cb)
+    RE(count([hw.det]), local_cb, **md)
     time.sleep(1)
 
     # Get the two documents from the queue (or timeout --- test will fail)
@@ -308,12 +308,12 @@ def test_zmq_prefix(RE, hw):
         local_accumulator.append((name, doc))
 
     # Check that numpy stuff is sanitized by putting some in the start doc.
-    # md = {'stuff': {'nested': np.array([1, 2, 3])},
-    #       'scalar_stuff': np.float64(3),
-    #       'array_stuff': np.ones((3, 3))}
+    md = {'stuff': {'nested': np.array([1, 2, 3])},
+          'scalar_stuff': np.float64(3),
+          'array_stuff': np.ones((3, 3))}
 
     # RE([Msg('open_run', **md), Msg('close_run')], local_cb)
-    RE(count([hw.det]), local_cb)
+    RE(count([hw.det]), local_cb, **md)
     time.sleep(1)
 
     # Get the two documents from the queue (or timeout --- test will fail)

--- a/bluesky/tests/test_zmq.py
+++ b/bluesky/tests/test_zmq.py
@@ -10,7 +10,7 @@ import pytest
 from bluesky import Msg
 from bluesky.callbacks.zmq import Proxy, Publisher, RemoteDispatcher
 from bluesky.plans import count
-
+from event_model import sanitize_doc
 
 def test_proxy_script():
     p = run(['bluesky-0MQ-proxy', '-h'])
@@ -83,7 +83,9 @@ def test_zmq(RE, hw):
     dispatcher_proc.terminate()
     proxy_proc.join()
     dispatcher_proc.join()
-    assert remote_accumulator == local_accumulator
+    ra = sanitize_doc(remote_accumulator)
+    la = sanitize_doc(local_accumulator)
+    assert ra == la
 
 
 def test_zmq_components():
@@ -189,7 +191,9 @@ def test_zmq_no_RE(RE):
     dispatcher_proc.terminate()
     proxy_proc.join()
     dispatcher_proc.join()
-    assert remote_accumulator == local_accumulator
+    ra = sanitize_doc(remote_accumulator)
+    la = sanitize_doc(local_accumulator)
+    assert ra == la
 
 
 def test_zmq_no_RE_newserializer(RE):
@@ -256,7 +260,9 @@ def test_zmq_no_RE_newserializer(RE):
     dispatcher_proc.terminate()
     proxy_proc.join()
     dispatcher_proc.join()
-    assert remote_accumulator == local_accumulator
+    ra = sanitize_doc(remote_accumulator)
+    la = sanitize_doc(local_accumulator)
+    assert ra == la
 
 
 def test_zmq_prefix(RE, hw):
@@ -326,4 +332,6 @@ def test_zmq_prefix(RE, hw):
     dispatcher_proc.terminate()
     proxy_proc.join()
     dispatcher_proc.join()
-    assert remote_accumulator == local_accumulator
+    ra = sanitize_doc(remote_accumulator)
+    la = sanitize_doc(local_accumulator)
+    assert ra == la

--- a/bluesky/tests/test_zmq.py
+++ b/bluesky/tests/test_zmq.py
@@ -4,8 +4,6 @@ import signal
 from subprocess import run
 import threading
 import time
-
-import numpy as np
 import pytest
 
 from bluesky import Msg
@@ -67,9 +65,9 @@ def test_zmq(RE, hw):
         local_accumulator.append((name, doc))
 
     # Check that numpy stuff is sanitized by putting some in the start doc.
-    md = {'stuff': {'nested': np.array([1, 2, 3])},
-          'scalar_stuff': np.float64(3),
-          'array_stuff': np.ones((3, 3))}
+    # md = {'stuff': {'nested': np.array([1, 2, 3])},
+    #       'scalar_stuff': np.float64(3),
+    #       'array_stuff': np.ones((3, 3))}
 
     # RE([Msg('open_run', **md), Msg('close_run')], local_cb)
     RE(count([hw.det]), local_cb)
@@ -90,7 +88,6 @@ def test_zmq(RE, hw):
 def test_zmq_components():
     # The test `test_zmq` runs Proxy and RemoteDispatcher in a separate
     # process, which coverage misses.
-    pid = os.getpid()
 
     def delayed_sigint(delay):
         time.sleep(delay)
@@ -196,6 +193,7 @@ def test_zmq_no_RE(RE):
 
 def test_zmq_no_RE_newserializer(RE):
     cloudpickle = pytest.importorskip('cloudpickle')
+
     # COMPONENT 1
     # Run a 0MQ proxy on a separate process.
     def start_proxy():
@@ -207,14 +205,12 @@ def test_zmq_no_RE_newserializer(RE):
 
     # COMPONENT 2
     # Run a Publisher and a RunEngine in this main process.
-
     p = Publisher('127.0.0.1:5567', serializer=cloudpickle.dumps)  # noqa
 
     # COMPONENT 3
     # Run a RemoteDispatcher on another separate process. Pass the documents
     # it receives over a Queue to this process, so we can count them for our
     # test.
-
     def make_and_start_dispatcher(queue):
         def put_in_queue(name, doc):
             print('putting ', name, 'in queue')
@@ -274,12 +270,10 @@ def test_zmq_prefix(RE, hw):
 
     # COMPONENT 2
     # Run a Publisher and a RunEngine in this main process.
-
     p = Publisher('127.0.0.1:5567', prefix=b'sb')  # noqa
     p2 = Publisher('127.0.0.1:5567', prefix=b'not_sb')  # noqa
     RE.subscribe(p)
     RE.subscribe(p2)
-
 
     # COMPONENT 3
     # Run a RemoteDispatcher on another separate process. Pass the documents
@@ -314,9 +308,9 @@ def test_zmq_prefix(RE, hw):
         local_accumulator.append((name, doc))
 
     # Check that numpy stuff is sanitized by putting some in the start doc.
-    md = {'stuff': {'nested': np.array([1, 2, 3])},
-          'scalar_stuff': np.float64(3),
-          'array_stuff': np.ones((3, 3))}
+    # md = {'stuff': {'nested': np.array([1, 2, 3])},
+    #       'scalar_stuff': np.float64(3),
+    #       'array_stuff': np.ones((3, 3))}
 
     # RE([Msg('open_run', **md), Msg('close_run')], local_cb)
     RE(count([hw.det]), local_cb)

--- a/bluesky/tests/test_zmq.py
+++ b/bluesky/tests/test_zmq.py
@@ -12,6 +12,7 @@ from bluesky.callbacks.zmq import Proxy, Publisher, RemoteDispatcher
 from bluesky.plans import count
 from event_model import sanitize_doc
 
+
 def test_proxy_script():
     p = run(['bluesky-0MQ-proxy', '-h'])
     assert p.returncode == 0

--- a/bluesky/tests/test_zmq.py
+++ b/bluesky/tests/test_zmq.py
@@ -4,6 +4,7 @@ import signal
 from subprocess import run
 import threading
 import time
+import numpy as np
 import pytest
 
 from bluesky import Msg

--- a/bluesky/tests/utils.py
+++ b/bluesky/tests/utils.py
@@ -1,5 +1,3 @@
-from functools import wraps
-import time
 from collections import defaultdict
 import contextlib
 import tempfile

--- a/fuzz/fuzz.py
+++ b/fuzz/fuzz.py
@@ -337,7 +337,7 @@ def run_fuzz():
           set([msg.command for msg in message_objects]))
 
     num_message = 100
-    # INT = 10
+    # num_SIGINT = 10
     num_scans = 50
     num_shuffled_scans = 50
     random.shuffle(message_objects)

--- a/fuzz/fuzz.py
+++ b/fuzz/fuzz.py
@@ -337,7 +337,7 @@ def run_fuzz():
           set([msg.command for msg in message_objects]))
 
     num_message = 100
-    num_SIGINT = 10
+    # INT = 10
     num_scans = 50
     num_shuffled_scans = 50
     random.shuffle(message_objects)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ coverage
 databroker
 doct
 doctr
+flake8
 ipython
 ipywidgets
 jinja2
@@ -23,6 +24,7 @@ pytest-faulthandler
 pyyaml
 pyzmq
 requests
+scipy
 sphinx
 sphinx_rtd_theme
 streamz


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The changes in this PR include the following:

- `flake8` is added to CI tests;

- the code is manually modified to comply with `flake8`.

## Description
<!--- Describe your changes in detail -->

`flake8` configuration is defined in `.flake8` file in the root of the Bluesky project. `flake8` is configured to allow the maximum line length of 115 characters. This is the maximum line length currently selected in scientific cookiecutter. `flake8` is also set to ignore the examples in `doc/source/examples`, since those examples are included in the document text and are formatted primarily to optimize visual perception. To comply with `flake8`, the examples would have to be modified to include additional blank lines, which is undesirable.

Changes to the code include:

- addition of missing imports and removing unused imports. Unused imports that were supposed to stay (in `__init__.py` files were marked with `noqa`);

- rearrangement of import order;

- removal of unused local variables;

- replacement of bare `except` with `except BaseException`;

- removal of `color_logs` from `__all__` in `bluesky/log.py`;

- manual changes to code formatting to comply with `flake8` requirements.

The most problematic files: `bluesky/tests/interactive/best_effort_cb.py` and `bluesky/tests/test_scientific.py`.
