### PR TITLE
replace deprecated tqdm._utils with tqdm.utils

### DIFF
--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -19,7 +19,8 @@ from functools import wraps, partial
 import threading
 import time
 from tqdm import tqdm
-from tqdm._utils import _environ_cols_wrapper, _term_move_up, _unicode
+from tqdm._utils import _term_move_up, _unicode
+from tqdm.utils import _screen_shape_wrapper
 import warnings
 
 import msgpack
@@ -1084,7 +1085,7 @@ class ProgressBar:
         self.meters = []
         self.status_objs = []
         # Determine terminal width.
-        self.ncols = _environ_cols_wrapper()(sys.stdout) or 79
+        self.ncols = _screen_shape_wrapper()(sys.stdout)[0] or 79
         self.fp = sys.stdout
         self.creation_time = time.time()
         self.delay_draw = delay_draw

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -19,8 +19,8 @@ from functools import wraps, partial
 import threading
 import time
 from tqdm import tqdm
-from tqdm._utils import _term_move_up, _unicode
-from tqdm.utils import _screen_shape_wrapper
+from tqdm._utils import _unicode
+from tqdm.utils import _screen_shape_wrapper, _term_move_up
 import warnings
 
 import msgpack

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -19,8 +19,7 @@ from functools import wraps, partial
 import threading
 import time
 from tqdm import tqdm
-from tqdm._utils import _unicode
-from tqdm.utils import _screen_shape_wrapper, _term_move_up
+from tqdm.utils import _screen_shape_wrapper, _term_move_up, _unicode
 import warnings
 
 import msgpack


### PR DESCRIPTION
This PR replaces `tqdm._utils` with `tqdm.utils`.

## Description
Made the following replacements:

  + replaced `tqdm._utils._environ_cols_wrapper` with `tqdm.utils._screen_shape_wrapper`
  + replaced `tqdm._utils._term_move_up` with `tqdm.utils._term_move_up`
  + replaced `tqdm._utils._unicode` with `tqdm.utils._unicode`

## Motivation and Context
`tqdm._utils` has been deprecated and will be removed in version 5.

## How Has This Been Tested?
The unit tests are passing in CI.