### PR TITLE
List scan

### DIFF
--- a/bluesky/tests/test_plan_patterns.py
+++ b/bluesky/tests/test_plan_patterns.py
@@ -1,0 +1,203 @@
+import pytest
+import numpy as np
+import numpy.testing as npt
+import itertools
+from bluesky.plan_patterns import chunk_outer_product_args, outer_product
+
+
+@pytest.mark.parametrize("args, chunked_args", [
+    (("motor1", 1, 5, 10), [("motor1", 1, 5, 10, False)]),
+    (("motor1", 1, 5, 10, "motor2", 2, 10, 20),
+     [("motor1", 1, 5, 10, False), ("motor2", 2, 10, 20, False)]),
+    (("motor1", 1, 5, 10, "motor2", 2, 10, 20, "motor3", 3, 5, 15),
+     [("motor1", 1, 5, 10, False), ("motor2", 2, 10, 20, False), ("motor3", 3, 5, 15, False)])
+])
+def test_chunk_outer_product_args_1(hw, args, chunked_args):
+    """Check if the new pattern (Pattern 1) works"""
+
+    # Convert motor names to actual motors in the argument list using fixture 'hw'
+    args = tuple([getattr(hw, _) if isinstance(_, str) else _ for _ in args])
+    for n, a in enumerate(chunked_args):
+        chunked_args[n] = tuple([getattr(hw, _) if isinstance(_, str) else _ for _ in a])
+
+    assert list(chunk_outer_product_args(args)) == chunked_args, \
+        "Argument list was split into chunks incorrectly"
+
+
+@pytest.mark.parametrize("args, chunked_args", [
+    (("motor1", 1, 5, 10), [("motor1", 1, 5, 10, False)]),
+    (("motor1", 1, 5, 10, "motor2", 2, 10, 20, True),
+     [("motor1", 1, 5, 10, False), ("motor2", 2, 10, 20, True)]),
+    (("motor1", 1, 5, 10, "motor2", 2, 10, 20, True, "motor3", 3, 5, 15, False),
+     [("motor1", 1, 5, 10, False), ("motor2", 2, 10, 20, True), ("motor3", 3, 5, 15, False)])
+])
+def test_chunk_outer_product_args_2(hw, args, chunked_args):
+
+    # Convert motor names to actual motors in the argument list using fixture 'hw'
+    args = tuple([getattr(hw, _) if isinstance(_, str) else _ for _ in args])
+    for n, a in enumerate(chunked_args):
+        chunked_args[n] = tuple([getattr(hw, _) if isinstance(_, str) else _ for _ in a])
+
+    """Check if deprecated pattern (Pattern 2) is properly supported"""
+    assert list(chunk_outer_product_args(args)) == chunked_args, \
+        "Argument list was split into chunks incorrectly"
+
+
+@pytest.mark.parametrize("args, chunked_args", [
+    # Pattern 1
+    (("motor", 1, 7, 24,
+      "motor1", 1, 5, 10, False,
+      "motor2", 2, 10, 20, True,
+      "motor3", 3, 5, 15, False,
+      "jittery_motor1", 4, 6, 50, True,
+      "jittery_motor2", 6, 7, 30, False),
+     [("motor", 1, 7, 24, False),
+      ("motor1", 1, 5, 10, False),
+      ("motor2", 2, 10, 20, True),
+      ("motor3", 3, 5, 15, False),
+      ("jittery_motor1", 4, 6, 50, True),
+      ("jittery_motor2", 6, 7, 30, False)]),
+    # Pattern 2
+    (("motor", 1, 7, 24,
+      "motor1", 1, 5, 10,
+      "motor2", 2, 10, 20,
+      "motor3", 3, 5, 15,
+      "jittery_motor1", 4, 6, 50,
+      "jittery_motor2", 6, 7, 30,
+      "motor", 6, 7, 30),
+     [("motor", 1, 7, 24, False),
+      ("motor1", 1, 5, 10, False),
+      ("motor2", 2, 10, 20, False),
+      ("motor3", 3, 5, 15, False),
+      ("jittery_motor1", 4, 6, 50, False),
+      ("jittery_motor2", 6, 7, 30, False),
+      ("motor", 6, 7, 30, False)])
+    ])
+def test_chunk_outer_product_args_3(hw, args, chunked_args):
+    """Check the ambiguous case: function is called with 24 arguments,
+    the pattern can't be resolved just by counting arguments, so the
+    presence of boolean values is checked"""
+    assert list(chunk_outer_product_args(args)) == chunked_args, \
+        "Argument list was split into chunks incorrectly"
+
+
+def test_chunk_outer_product_args_failing(hw):
+
+    # Wrong number of arguments
+    args = (hw.motor, 1, 7, 24, True)
+    with pytest.raises(ValueError, match="Wrong number of positional arguments"):
+        list(chunk_outer_product_args(args))
+
+    args = (hw.motor, 1, 7, 24,
+            hw.motor1, 1, 5, 10, False,
+            hw.motor2, 2, 10, 20)
+    with pytest.raises(ValueError, match="Wrong number of positional arguments"):
+        list(chunk_outer_product_args(args))
+
+    args = (hw.motor, 1, 7, 24,
+            hw.motor1, 1, 5, 10, False,
+            hw.motor2, 2, 10, 20, 10)
+    with pytest.raises(ValueError, match="Wrong positional arguments"):
+        list(chunk_outer_product_args(args))
+
+    args = (hw.motor, 1, 7, 24,
+            hw.motor1, 1, 5, 10, 10,
+            hw.motor2, 2, 10, 20, False)
+    with pytest.raises(ValueError, match="Wrong positional arguments"):
+        list(chunk_outer_product_args(args))
+
+
+def _gen_outer_product(args):
+    """
+    Generate expected output for the `outer_product` function.
+    The output is generated using completely different method not based
+    on Cycler, so it is better suited for testing.
+
+    Parameters
+    ----------
+    args: list
+        same as input of the `outer_product` function
+
+    Returns
+    -------
+    Dictionary:
+        {'motor_name_1': list of positions,
+         'motor_name_2': list of positions, ...}
+    """
+
+    chunk_args = list(chunk_outer_product_args(args))
+
+    # The number of steps is the multiple of the number of steps along all axes
+    n_points = 1
+    for chunk in chunk_args:
+        n_points *= chunk[3]
+
+    positions = {}
+
+    n_passes = 1
+    for chunk in chunk_args:
+        motor, start, stop, num, snake = chunk
+
+        # The number of measurement during which the motor has to stay at the same position
+        n_steps = int(round(n_points / num / n_passes))
+
+        pts = []
+        for n in range(n_passes):
+            if (n % 2) and snake:  # Odd pass goes backward if the motor is snaked
+                v_start, v_stop = stop, start
+            else:
+                v_start, v_stop = start, stop
+            p = list(np.linspace(v_start, v_stop, num))
+            p = list(itertools.chain.from_iterable(itertools.repeat(_, n_steps) for _ in p))
+            pts += p
+
+        positions[motor.name] = pts
+
+        n_passes *= num
+
+    return positions
+
+
+@pytest.mark.parametrize("args", [
+    ("motor", 1, 2, 3,
+     "motor1", 4, 5, 6, True,
+     "motor2", 7, 8, 9, True),
+    ("motor", 1, 2, 3,
+     "motor1", 4, 5, 6, True,
+     "motor2", 7, 8, 9, False),
+    ("motor", 1, 2, 3,
+     "motor1", 4, 5, 6, False,
+     "motor2", 7, 8, 9, True),
+    ("motor", 1, 2, 3,
+     "motor1", 4, 5, 6, True,
+     "motor2", 7, 8, 9, False,
+     "motor3", 7, 8, 9, True)
+])
+def test_outer_product(hw, args):
+    """Basic test of the functionality"""
+
+    # Convert motor names to actual motors in the argument list using fixture 'hw'
+    args = [getattr(hw, _) if isinstance(_, str) else _ for _ in args]
+
+    full_cycler = outer_product(args=args)
+    event_list = list(full_cycler)
+
+    # The list of motors
+    chunk_args = list(chunk_outer_product_args(args))
+    motors = [_[0] for _ in chunk_args]
+    motor_names = [_.name for _ in motors]
+
+    positions = {k: [] for k in motor_names}
+    for event in event_list:
+        for m, mn in zip(motors, motor_names):
+            positions[mn].append(event[m])
+
+    positions_expected = _gen_outer_product(args)
+
+    assert set(positions.keys()) == set(positions_expected.keys()), \
+        "Different set of motors in dictionaries of actual and expected positions"
+
+    for name in positions_expected.keys():
+        npt.assert_array_almost_equal(
+            positions[name], positions_expected[name],
+            err_msg=f"Expected and actual positions for the motor '{name}' don't match")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The PR is addressing and attempts to resolve the issue https://github.com/bluesky/bluesky/issues/1189

In the new API interface for `grid_scan` and `rel_grid_scan` functions, the optional `snake_axes` argument was added. The boolean value `True` or `False` of `snake_axes` enables or disables snaking along all axes (except the slowest). Alternatively, `snake_axes` can be a list (or iterable), which specifies the axes along which snaking is enabled.

```
# Default - snaking is disabled
grid_scan([hw.det], hw.motor, 1, 2, 5, hw.motor1, 7, 2, 10, hw.motor2, 3, 5, 4)

# Snaking is explicitely disabled
grid_scan([hw.det], hw.motor, 1, 2, 5, hw.motor1, 7, 2, 10, hw.motor2, 3, 5, 4, snake_axes=False)

# Snaking can also be disabled by providing empty list of motors
grid_scan([hw.det], hw.motor, 1, 2, 5, hw.motor1, 7, 2, 10, hw.motor2, 3, 5, 4, snake_axes=[])

# Snaking is enabled for all motors except the slowest hw.motor
grid_scan([hw.det], hw.motor, 1, 2, 5, hw.motor1, 7, 2, 10, hw.motor2, 3, 5, 4, snake_axes=True)

# Snaking is enabled only for hw.motor1
grid_scan([hw.det], hw.motor, 1, 2, 5, hw.motor1, 7, 2, 10, hw.motor2, 3, 5, 4, snake_axes=[hw.motor1])

# Snaking is enabled only for hw.motor1 and hw.motor2
grid_scan([hw.det], hw.motor, 1, 2, 5, hw.motor1, 7, 2, 10, hw.motor2, 3, 5, 4, snake_axes=[hw.motor1, hw.motor2])
```

The new API interface is consistent with already existing functions `list_grid_scan` and `rel_list_grid_scan` that accept `snake_axes` argument.

The implementations of `grid_scan` and `rel_grid_scan` are backward compatible. Old and new API should not be mixed. If they are mixed, then the settings in `snake_axes` override snaking settings in the `args` list. For example:

```
# Old style call that enables snaking for hw.motor1
grid_scan([hw.det], hw.motor, 1, 2, 5, hw.motor1, 7, 2, 10, True, hw.motor2, 3, 5, 4, False)

# Equivalent new style call
grid_scan([hw.det], hw.motor, 1, 2, 5, hw.motor1, 7, 2, 10, hw.motor2, 3, 5, 4, snake_axes=[hw.motor1])

# In the following call, snaking is disabled for all motors
grid_scan([hw.det], hw.motor, 1, 2, 5, hw.motor1, 7, 2, 10, True, hw.motor2, 3, 5, 4, False, snake_axes=False)

# In the following call, snaking is enabled for hw.motor2
grid_scan([hw.det], hw.motor, 1, 2, 5, hw.motor1, 7, 2, 10, True, hw.motor2, 3, 5, 4, False, snake_axes=[hw.motor2])
``` 
The description of the old style calls will be removed from documentation. It is assumed that only the new style calls are used in all new code.

## Description

The changed include adding code for processing of arguments in `grid_scan` and `rel_grid_scan`, modification of `chunk_outer_product_args` so that it is able to recognize two patterns of arguments (with/without snaking boolean flags). The tests were implemented for `grid_scan`, `rel_grid_scan`, `chunk_outer_product_args` and `outer_product` functions.

## Motivation and Context
Issue: https://github.com/bluesky/bluesky/issues/1189

## How Has This Been Tested?
The tests for `grid_scan` and `rel_grid_scan` are implemented. 
In addition, the tests for `chunk_outer_product_args` and `outer_product` were implemented.
