### PR TITLE
Fix critical typo in Movable.

### DIFF
--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -1544,7 +1544,7 @@ class Movable(metaclass=abc.ABCMeta):
             'read',
             'describe',
             'read_configuration',
-            'describe_configuration'
+            'describe_configuration',
             'set',
             'stop',
         )


### PR DESCRIPTION
This fixes a critical typo in f69709890020241a9d7c500e175908cb87e7b07f
that was merged in https://github.com/bluesky/bluesky/pull/1334. The
typo failed many tests, so I do not think any additional tests are
needed. I think #1334 was merged by mistake.