### PR TITLE
Include configuration in flyscan EventDescriptor

### DIFF
--- a/bluesky/bundlers.py
+++ b/bluesky/bundlers.py
@@ -396,8 +396,6 @@ class RunBundler:
                 config[name]["data"] = self._config_values_cache[obj]
                 config[name]["timestamps"] = self._config_ts_cache[obj]
                 config[name]["data_keys"] = self._config_desc_cache[obj]
-                if hasattr(obj, "hints"):
-                    hints[name] = obj.hints
             descriptor_uid = new_uid()
             doc = dict(
                 run_start=self._run_start_uid,

--- a/bluesky/bundlers.py
+++ b/bluesky/bundlers.py
@@ -396,6 +396,8 @@ class RunBundler:
                 config[name]["data"] = self._config_values_cache[obj]
                 config[name]["timestamps"] = self._config_ts_cache[obj]
                 config[name]["data_keys"] = self._config_desc_cache[obj]
+                if hasattr(obj, "hints"):
+                    hints[name] = obj.hints
             descriptor_uid = new_uid()
             doc = dict(
                 run_start=self._run_start_uid,

--- a/bluesky/bundlers.py
+++ b/bluesky/bundlers.py
@@ -594,7 +594,6 @@ class RunBundler:
                 descriptor_uid = new_uid()
                 stream_object_keys = {collect_obj.name: list(stream_data_keys)}
                 hints = {}
-                # is this if block an error?
                 if hasattr(collect_obj, "hints"):
                     hints.update({collect_obj.name: collect_obj.hints})
                 for obj_read in objs_read:

--- a/bluesky/bundlers.py
+++ b/bluesky/bundlers.py
@@ -596,9 +596,6 @@ class RunBundler:
                 hints = {}
                 if hasattr(collect_obj, "hints"):
                     hints.update({collect_obj.name: collect_obj.hints})
-                for obj_read in objs_read:
-                    if hasattr(obj_read, "hints"):
-                        hints[obj_read.name] = obj_read.hints
                 doc = dict(
                     run_start=self._run_start_uid,
                     time=ttime.time(),

--- a/bluesky/bundlers.py
+++ b/bluesky/bundlers.py
@@ -614,19 +614,20 @@ class RunBundler:
                                  extra={'doc_name': 'descriptor',
                                         'run_uid': self._run_start_uid,
                                         'data_keys': stream_data_keys.keys()})
-                self._descriptors[stream_name] = (objs_read, doc)
+                self._descriptors[stream_name] = (frz_stream_data_keys, doc)
                 self._sequence_counters[stream_name] = count(1)
             else:
                 objs_read, doc = self._descriptors[stream_name]
-            if d_objs != objs_read:
-                raise RuntimeError(
-                    "Mismatched objects read, "
-                    "expected {!s}, "
-                    "got {!s}".format(d_objs, objs_read)
-                )
+                # we only need to make this check when the else block is executed
+                if frz_stream_data_keys != objs_read:
+                    raise RuntimeError(
+                        "Mismatched objects read, "
+                        "expected {!s}, "
+                        "got {!s}".format(frz_stream_data_keys, objs_read)
+                    )
 
             descriptor_uid = doc["uid"]
-            local_descriptors[objs_read] = (stream_name, descriptor_uid)
+            local_descriptors[frz_stream_data_keys] = (stream_name, descriptor_uid)
 
             bulk_data[descriptor_uid] = []
 

--- a/bluesky/bundlers.py
+++ b/bluesky/bundlers.py
@@ -589,8 +589,6 @@ class RunBundler:
         #     {name_for_desc1: data_keys_for_desc1,
         #      name_for_desc2: data_keys_for_desc2, ...}
         for stream_name, stream_data_keys in collect_obj.describe_collect().items():
-            # is it necessary to use a frozenset here? can we just use stream_data_keys?
-            frz_stream_data_keys = frozenset(stream_data_keys)
             if stream_name not in self._descriptors:
                 # We do not have an Event Descriptor for this set.
                 descriptor_uid = new_uid()
@@ -614,20 +612,19 @@ class RunBundler:
                                  extra={'doc_name': 'descriptor',
                                         'run_uid': self._run_start_uid,
                                         'data_keys': stream_data_keys.keys()})
-                self._descriptors[stream_name] = (frz_stream_data_keys, doc)
+                self._descriptors[stream_name] = (stream_data_keys, doc)
                 self._sequence_counters[stream_name] = count(1)
             else:
                 objs_read, doc = self._descriptors[stream_name]
-                # we only need to make this check when the else block is executed
-                if frz_stream_data_keys != objs_read:
+                if stream_data_keys != objs_read:
                     raise RuntimeError(
                         "Mismatched objects read, "
                         "expected {!s}, "
-                        "got {!s}".format(frz_stream_data_keys, objs_read)
+                        "got {!s}".format(stream_data_keys, objs_read)
                     )
 
             descriptor_uid = doc["uid"]
-            local_descriptors[frz_stream_data_keys] = (stream_name, descriptor_uid)
+            local_descriptors[frozenset(stream_data_keys)] = (stream_name, descriptor_uid)
 
             bulk_data[descriptor_uid] = []
 

--- a/bluesky/bundlers.py
+++ b/bluesky/bundlers.py
@@ -379,7 +379,7 @@ class RunBundler:
                 "got {!s}".format(d_objs, objs_read)
             )
         if doc is None:
-            # We don't not have an Event Descriptor for this set.
+            # We do not have an Event Descriptor for this set.
             data_keys = {}
             config = {}
             object_keys = {}

--- a/bluesky/bundlers.py
+++ b/bluesky/bundlers.py
@@ -594,7 +594,6 @@ class RunBundler:
             if stream_name not in self._descriptors:
                 # We do not have an Event Descriptor for this set.
                 descriptor_uid = new_uid()
-                stream_object_keys = {collect_obj.name: list(stream_data_keys)}
                 hints = {}
                 if hasattr(collect_obj, "hints"):
                     hints.update({collect_obj.name: collect_obj.hints})
@@ -606,7 +605,7 @@ class RunBundler:
                     name=stream_name,
                     configuration=collect_obj_configuration,
                     hints=hints,
-                    object_keys=stream_object_keys,
+                    object_keys={collect_obj.name: list(stream_data_keys)},
                 )
                 await self.emit(DocumentNames.descriptor, doc)
                 doc_logger.debug("[descriptor] document is emitted with name %r "

--- a/bluesky/bundlers.py
+++ b/bluesky/bundlers.py
@@ -589,9 +589,9 @@ class RunBundler:
         #     {name_for_desc1: data_keys_for_desc1,
         #      name_for_desc2: data_keys_for_desc2, ...}
         for stream_name, stream_data_keys in collect_obj.describe_collect().items():
-            d_objs = frozenset(stream_data_keys)
+            # is it necessary to use a frozenset here? can we just use stream_data_keys?
+            frz_stream_data_keys = frozenset(stream_data_keys)
             if stream_name not in self._descriptors:
-                objs_read = d_objs
                 # We do not have an Event Descriptor for this set.
                 descriptor_uid = new_uid()
                 stream_object_keys = {collect_obj.name: list(stream_data_keys)}

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -1426,18 +1426,32 @@ def test_flyer_descriptor(RE, hw):
         def read_configuration(self):
             return {
                 "data_key_1": {"value": ""},
-                "data_key_2": {"value": 0}
+                "data_key_2": {"value": 0},
+                "data_key_3": {"value": ""},
+                "data_key_4": {"value": 0}
             }
 
         def collect(self):
             yield {
                 "data": {
                     "data_key_1": "",
-                    "data_key_2": 0
+                    "data_key_2": 0,
                 },
                 "timestamps": {
                     "data_key_1": 0,
-                    "data_key_2": 0
+                    "data_key_2": 0,
+                },
+                "time": 0
+            }
+
+            yield {
+                "data": {
+                    "data_key_3": "",
+                    "data_key_4": 0
+                },
+                "timestamps": {
+                    "data_key_3": 0,
+                    "data_key_4": 0
                 },
                 "time": 0
             }
@@ -1457,7 +1471,22 @@ def test_flyer_descriptor(RE, hw):
                         "shape": [],
                         "source": "",
                     }
+                },
+                "secondary": {
+                    "data_key_3": {
+                        "dims": ("dim 1",),
+                        "dtype": "string",
+                        "shape": [],
+                        "source": "",
+                    },
+                    "data_key_4": {
+                        "dims": ("dim 1",),
+                        "dtype": "number",
+                        "shape": [],
+                        "source": "",
+                    }
                 }
+
             }
 
     flyers = [Flyer(), TrivialFlyer()]
@@ -1469,9 +1498,20 @@ def test_flyer_descriptor(RE, hw):
     )
 
     primary_descriptor = descriptors["primary"]
+    assert len(primary_descriptor["configuration"]) == 4
     assert primary_descriptor["configuration"]["data_key_1"]["value"] == ""
     assert primary_descriptor["configuration"]["data_key_2"]["value"] == 0
+    assert primary_descriptor["configuration"]["data_key_3"]["value"] == ""
+    assert primary_descriptor["configuration"]["data_key_4"]["value"] == 0
     assert "flyer" in primary_descriptor["object_keys"]
+
+    secondary_descriptor = descriptors["secondary"]
+    assert len(secondary_descriptor["configuration"]) == 4
+    assert secondary_descriptor["configuration"]["data_key_1"]["value"] == ""
+    assert secondary_descriptor["configuration"]["data_key_2"]["value"] == 0
+    assert secondary_descriptor["configuration"]["data_key_3"]["value"] == ""
+    assert secondary_descriptor["configuration"]["data_key_4"]["value"] == 0
+    assert "flyer" in secondary_descriptor["object_keys"]
 
     trivial_flyer_descriptor = descriptors["stream_name"]
     assert len(trivial_flyer_descriptor["configuration"]) == 0

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -1421,16 +1421,24 @@ def test_flyer_descriptor(RE, hw):
     from ophyd.sim import TrivialFlyer
 
     class Flyer(TrivialFlyer):
+        name = "flyer"
+
         def read_configuration(self):
             return {
                 "data_key_1": {"value": ""},
-                "data_key_2": {"value": 0},
+                "data_key_2": {"value": 0}
             }
 
         def collect(self):
             yield {
-                "data": {"data_key_1": "", "data_key_2": 0},
-                "timestamps": {"data_key_1": 0, "data_key_2": 0},
+                "data": {
+                    "data_key_1": "",
+                    "data_key_2": 0
+                },
+                "timestamps": {
+                    "data_key_1": 0,
+                    "data_key_2": 0
+                },
                 "time": 0
             }
 
@@ -1448,20 +1456,26 @@ def test_flyer_descriptor(RE, hw):
                         "dtype": "number",
                         "shape": [],
                         "source": "",
-                    },
+                    }
                 }
             }
 
-    flyers = [Flyer()]
-    collector = []
+    flyers = [Flyer(), TrivialFlyer()]
+    descriptors = dict()
 
-    RE(fly(flyers), {'descriptor': lambda name, doc: collector.append(doc)})
-    descriptor = collector.pop()
-    assert 'configuration' in descriptor
-    assert 'object_keys' in descriptor
+    RE(
+        fly(flyers),
+        {'descriptor': lambda name, doc: descriptors.update({doc["name"]: doc})}
+    )
 
-    assert descriptor["configuration"]["data_key_1"]["value"] == ""
-    assert descriptor["configuration"]["data_key_2"]["value"] == 0
+    primary_descriptor = descriptors["primary"]
+    assert primary_descriptor["configuration"]["data_key_1"]["value"] == ""
+    assert primary_descriptor["configuration"]["data_key_2"]["value"] == 0
+    assert "flyer" in primary_descriptor["object_keys"]
+
+    trivial_flyer_descriptor = descriptors["stream_name"]
+    assert len(trivial_flyer_descriptor["configuration"]) == 0
+    assert "trivial_flyer" in trivial_flyer_descriptor["object_keys"]
 
 
 def test_filled(RE, hw, db):

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -1423,6 +1423,7 @@ def test_flyer_descriptor(RE, hw):
     collector = []
     RE(fly(flyers), {'descriptor': lambda name, doc: collector.append(doc)})
     descriptor = collector.pop()
+    assert 'configuration' in descriptor
     assert 'object_keys' in descriptor
 
 


### PR DESCRIPTION
## Description
This PR modifies`RunBundler.collect` to call `read_configuration`, if it exists, on the `collect` message object and the results are included in *all* descriptors.

## Motivation and Context
This PR resolves #1337.

## How Has This Been Tested?
`test_flyer_descriptor()` in `test_run_engine.py` checks for the presence of key `configuration`.
