### PR TITLE
Account for change to expected signature in Status done callback

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1788,7 +1788,7 @@ class RunEngine:
 
         await current_run.kickoff(msg)
 
-        def done_callback():
+        def done_callback(status=None):
             self.log.debug(
                 "The object %r reports 'kickoff' is done " "with status %r",
                 msg.obj,
@@ -1840,7 +1840,7 @@ class RunEngine:
         p_event = asyncio.Event(loop=self.loop)
         pardon_failures = self._pardon_failures
 
-        def done_callback():
+        def done_callback(status=None):
             self.log.debug(
                 "The object %r reports 'complete' is done " "with status %r",
                 msg.obj,
@@ -1910,7 +1910,7 @@ class RunEngine:
         p_event = asyncio.Event(loop=self.loop)
         pardon_failures = self._pardon_failures
 
-        def done_callback():
+        def done_callback(status=None):
             self.log.debug("The object %r reports set is done "
                            "with status %r", msg.obj, ret.success)
             task = self._loop.call_soon_threadsafe(
@@ -1941,7 +1941,7 @@ class RunEngine:
         p_event = asyncio.Event(loop=self.loop)
         pardon_failures = self._pardon_failures
 
-        def done_callback():
+        def done_callback(status=None):
             self.log.debug("The object %r reports trigger is "
                            "done with status %r.", msg.obj, ret.success)
             task = self._loop.call_soon_threadsafe(

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -1309,7 +1309,7 @@ def test_failures_kill_run(RE):
     dummy = Dummy()
 
     with pytest.raises(FailedStatus):
-        RE([Msg('set', dummy, 1)])
+        RE([Msg('set', dummy, 1), Msg('wait')])
 
 
 def test_colliding_streams(RE, hw):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ msgpack-numpy
 numpy
 super_state_machine
 toolz
-tqdm
+tqdm>=4.44
 zict


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Accept an optional `status` kwarg in the callbacks defined inside of the RunEngine coroutines.

## Motivation and Context

There were so many warnings coming out, travis was giving up on us

## How Has This Been Tested?

Test suite locally.