### PR TITLE
ENH: fly will return uid

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1931,7 +1931,7 @@ def fly(flyers, *, md=None):
     :func:`bluesky.preprocessors.fly_during_wrapper`
     :func:`bluesky.preprocessors.fly_during_decorator`
     """
-    yield from bps.open_run(md)
+    uid = yield from bps.open_run(md)
     for flyer in flyers:
         yield from bps.kickoff(flyer, wait=True)
     for flyer in flyers:
@@ -1939,6 +1939,7 @@ def fly(flyers, *, md=None):
     for flyer in flyers:
         yield from bps.collect(flyer)
     yield from bps.close_run()
+    return uid
 
 
 def x2x_scan(detectors, motor1, motor2, start, stop, num, *,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR make fly function return uid instead of None
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/bluesky/bluesky/issues/1332
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In the context of bluesky tutorial  binder`Fly Basic` section  https://try.nsls2.bnl.gov
Script:
```
import bluesky.plans as bp
def custom_fly(flyer):
    uids = (yield from bp.fly(flyer))
    print('uid: ',uids)
    return [uids]

def get_data_using_uid(uids):
    for uid in uids:
        print(db[uid].table(db[uid].stream_names[0]))

def big_plan(flyer):
    uids = (yield from custom_fly(flyer))
    get_data_using_uid(uids)

RE(big_plan([ifly]))
```
Output:
```
uid:  d5466512-b070-438a-8643-39ec6fe58ee4
                                 time         x
seq_num                                        
1       2020-04-30 21:56:19.784460068  0.003487
2       2020-04-30 21:56:19.784499884  0.003527
3       2020-04-30 21:56:19.784512043  0.003539
4       2020-04-30 21:56:19.784520864  0.003548
5       2020-04-30 21:56:19.784529924  0.003557
('d5466512-b070-438a-8643-39ec6fe58ee4',)
```
<!--
## Screenshots (if appropriate):
-->
