### PR TITLE
TST: Use legal wait message

### DIFF
--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -1309,7 +1309,8 @@ def test_failures_kill_run(RE):
     dummy = Dummy()
 
     with pytest.raises(FailedStatus):
-        RE([Msg('set', dummy, 1), Msg('wait')])
+        RE([Msg('set', dummy, 1, group='test'),
+            Msg('wait', group='test')])
 
 
 def test_colliding_streams(RE, hw):


### PR DESCRIPTION
the `'wait'` message must be passed a group to wait for.

I think there is a race condition in if the status object does not fail fast enough from the background thread, the wait message gets processed.  The message was added in  0fab64ac8a8a8c5fa7a98158dd97190b774616f1 but without the group so attempting to process it fails.  This should remove at least one of the flaky tests on travis.