### PR TITLE
PERF: remove a no-op loop

### DIFF
--- a/bluesky/bundlers.py
+++ b/bluesky/bundlers.py
@@ -432,8 +432,6 @@ class RunBundler:
         event_uid = new_uid()
         # Merge list of readings into single dict.
         readings = {k: v for d in self._read_cache for k, v in d.items()}
-        for key in readings:
-            readings[key]["value"] = readings[key]["value"]
         data, timestamps = _rearrange_into_parallel_dicts(readings)
         # Mark all externally-stored data as not filled so that consumers
         # know that the corresponding data are identifies, not dereferenced


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

While reviewing code with @jklynch we found this loop that looks like it is a no-op.  I suspect that this is part of a re-factor that didn't get cleaned out.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This should make the RE marginally faster by not doing un-needed work

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Should have no affect on the current test suite.

<!--
## Screenshots (if appropriate):
-->
