### PR TITLE
added gui_mode attribute to solve #1353

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -342,6 +342,7 @@ class RunEngine:
         self.waiting_hook = None
         self.record_interruptions = False
         self.pause_msg = PAUSE_MSG
+        self.gui_mode = False
 
         if during_task is None:
             during_task = DefaultDuringTask()
@@ -419,6 +420,17 @@ class RunEngine:
         self.unsubscribe_lossless = self.dispatcher.unsubscribe
         self._subscribe_lossless = self.dispatcher.subscribe
         self._unsubscribe_lossless = self.dispatcher.unsubscribe
+
+    def set_gui_mode(self, val):
+        '''
+        Allow the RunEngine to know if it is running on the console (default) or as part of a GUI, if GUI then we want to
+        suppress the RunInterruptedException that is called when the RunEngine is paused because GUI applications have
+        other visual widgets that indicate next steps where as on the console the user must be explicitly told what those
+        options are.
+        :param val:
+        :return:
+        '''
+        self.gui_mode = val
 
     @property
     def commands(self):
@@ -795,7 +807,8 @@ class RunEngine:
         self._resume_task(init_func=_build_task)
 
         if self._interrupted:
-            raise RunEngineInterrupted(self.pause_msg) from None
+            if(not self.gui_mode):
+                raise RunEngineInterrupted(self.pause_msg) from None
 
         return tuple(self._run_start_uids)
 
@@ -832,7 +845,8 @@ class RunEngine:
                 obj.resume()
         self._resume_task()
         if self._interrupted:
-            raise RunEngineInterrupted(self.pause_msg) from None
+            if(not self.gui_mode):
+                raise RunEngineInterrupted(self.pause_msg) from None
         return tuple(self._run_start_uids)
 
     def _rewind(self):


### PR DESCRIPTION
added gui_mode attribute, False by default which will still raise RunEngineInterrupted and if set to True  for GUI applications it will skip the raise

<!--- Provide a general summary of your changes in the Title above -->

## Description
added:
 - self.gui_mode boolean attribute
 - set_gui_mode() function to set the attribute
 - if statement now check self.gui_mode before raise of RunEngineInterrupted

## Motivation and Context
see issue #1353 

## How Has This Been Tested?
I tested this on my own Qt GUI application (pyStxm) and it does not affect any other aspects of RunEngine that I can see


