### PR TITLE
FIX: allow ':' to be used in keynames and still format LiveTable

### DIFF
--- a/bluesky/callbacks/core.py
+++ b/bluesky/callbacks/core.py
@@ -357,10 +357,11 @@ class LiveTable(CallbackBase):
                         '|'
                         )
         self._data_formats = OrderedDict(
-            (k, self._FMTLOOKUP[f.dtype].format(k=k,
-                                                width=f.width-2*self._pad_len,
-                                                prec=f.prec, dtype=f.dtype,
-                                                pad=self._extra_pad))
+            (k, self._FMTLOOKUP[f.dtype].format(
+                k=f'h{str(hash(k))}',
+                width=f.width-2*self._pad_len,
+                prec=f.prec, dtype=f.dtype,
+                pad=self._extra_pad))
             for k, f in self._format_info.items())
 
         self._count = 0
@@ -386,7 +387,7 @@ class LiveTable(CallbackBase):
             fmt_time = str(datetime.fromtimestamp(doc['time']).time())
             data[self.ev_time_key] = fmt_time
             data['seq_num'] = doc['seq_num']
-            cols = [f.format(**{k: data[k]})
+            cols = [f.format(**{f'h{str(hash(k))}': data[k]})
                     # Show data[k] if k exists in this Event and is 'filled'.
                     # (The latter is only applicable if the data is
                     # externally-stored -- hence the fallback to `True`.)

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -294,6 +294,7 @@ def test_evil_table_names(RE):
 +------------+--------------+--------+--------+--------+--------+"""
     _compare_tables(fout, reference)
 
+
 def test_live_fit(RE, hw):
     try:
         import lmfit


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Internally hash the keys we use to format the LiveTable rows.  This ensure that the value of the data keys can not corrupt the formatting.  Opted to go with a hash (because this is completely internal) rather than trying to sanitize the input as it seemed simpler.



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

fixes a bug that @stashlukj  ran into when trying to use ``:' ` as signal names.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added another test of LiveTable.  Re-arranged the tests a bit.

<!--
## Screenshots (if appropriate):
-->
