### PR TITLE
FIX/API: do not create a DefaultDuringTask on import

### DIFF
--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -1507,9 +1507,6 @@ class DefaultDuringTask(DuringTask):
                 blocking_event.wait()
 
 
-default_during_task = DefaultDuringTask()
-
-
 def _rearrange_into_parallel_dicts(readings):
     data = {}
     timestamps = {}


### PR DESCRIPTION
Doing the init at import time is breaking xi-cam (which is a Qt
application and does many of its imports in a background thread).

This was here for back-compatibility to replace a function by the same
name, but because we went with a `block` method rather than a
`__call__` method if anyone was relying on this they are already
broken so remove with no attempt to shim it back.

