### PR TITLE
DOC: shape cannot be None

### DIFF
--- a/doc/source/hardware.rst
+++ b/doc/source/hardware.rst
@@ -129,8 +129,8 @@ The interface of a readable device:
 
         * source (a descriptive string --- e.g., an EPICS Process Variable)
         * dtype: one of the JSON data types: {'number', 'string', 'array'}
-        * shape: ``None`` or a list of dimensions --- e.g., ``[5, 5]`` for a
-          5x5 array
+        * shape: list of integer dimensions --- e.g., ``[5, 5]`` for a
+          5x5 array. Use empty list ``[]`` to indicate a scalar.
 
         Optional additional fields (precision, units, etc.) are allowed.
         The optional field ``external`` should be used to provide information

--- a/doc/source/hardware.rst
+++ b/doc/source/hardware.rst
@@ -129,7 +129,7 @@ The interface of a readable device:
 
         * source (a descriptive string --- e.g., an EPICS Process Variable)
         * dtype: one of the JSON data types: {'number', 'string', 'array'}
-        * shape: list of integer dimensions --- e.g., ``[5, 5]`` for a
+        * shape: list of integers (dimension sizes) --- e.g., ``[5, 5]`` for a
           5x5 array. Use empty list ``[]`` to indicate a scalar.
 
         Optional additional fields (precision, units, etc.) are allowed.


### PR DESCRIPTION
This PR fixes an inconsistency between docs [1] and schema [2] by updating the docs.

closes #1374 
see also https://github.com/bluesky/event-model/pull/180

[1] http://nsls-ii.github.io/bluesky/hardware.html#ReadableDevice.describe
[2] https://github.com/bluesky/event-model/blob/f33e54ac88ca7fa8588acd41a1f7e41b7610c269/event_model/schemas/event_descriptor.json#L23-L28