### PR TITLE
ENH: allow "movable" objects that match bluesky interface with instance attributes

### DIFF
--- a/bluesky/plan_patterns.py
+++ b/bluesky/plan_patterns.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     from toolz import partition
 
-from .utils import snake_cyclers, Movable
+from .utils import snake_cyclers, is_movable
 
 
 def spiral(x_motor, y_motor, x_start, y_start, x_range, y_range, dr, nth, *,
@@ -428,7 +428,7 @@ def classify_outer_product_args_pattern(args):
             raise ValueError(f"Unknown pattern '{pattern}'")
         for n, element in enumerate(args):
             # Check if the element is the motor
-            flag = isinstance(element, Movable)
+            flag = is_movable(element)
             # If the element is expected to be the motor, then flip the flag
             if n in pos_movable:
                 flag = not flag

--- a/bluesky/tests/test_utils.py
+++ b/bluesky/tests/test_utils.py
@@ -3,7 +3,7 @@ import pytest
 from functools import reduce
 import operator
 
-from bluesky.utils import ensure_generator, Msg, merge_cycler, Movable
+from bluesky.utils import ensure_generator, Msg, merge_cycler, is_movable
 from cycler import cycler
 
 
@@ -102,11 +102,11 @@ def test_cycler_merge_mixed(hw, children):
     assert mcyc.by_key() == cyc.by_key()
 
 
-def test_Movable(hw):
+def test_is_movable(hw):
 
     obj_list = [(10, False), (1.05, False), ("some_string", False),
                 (hw.det, False), (hw.motor, True)]
     for obj, result in obj_list:
-        assert isinstance(obj, Movable) == result, \
+        assert is_movable(obj) == result, \
             f"The object {obj} is incorrectly recognized "\
             f"as {'' if result else 'not '}movable"

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -1565,12 +1565,12 @@ def is_movable(obj):
 class Movable(metaclass=abc.ABCMeta):
     """
     Abstract base class for objects that satisfy the bluesky 'movable' interface.
-    
+
     Examples
     --------
-    
+
     .. code-block:: python
-    
+
         m = hw.motor
         # We need to detect if 'm' is a motor
         if isinstance(m, Movable):

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -1516,25 +1516,51 @@ def _rearrange_into_parallel_dicts(readings):
     return data, timestamps
 
 
+def is_movable(obj):
+    """Check if object satisfies bluesky 'movable' interface.
+
+    Parameters
+    ----------
+    obj : Object
+        Object to test.
+
+    Returns
+    -------
+    boolean
+        True if movable, False otherwise.
+    """
+    EXPECTED_ATTRS = (
+        'name',
+        'parent',
+        'read',
+        'describe',
+        'read_configuration',
+        'describe_configuration',
+        'set',
+        'stop',
+    )
+    return all(hasattr(obj, attr) for attr in EXPECTED_ATTRS)
+
+
 class Movable(metaclass=abc.ABCMeta):
     """
     Abstract base class for objects that satisfy the bluesky 'movable' interface.
-
     Examples
     --------
-
     .. code-block:: python
-
         m = hw.motor
         # We need to detect if 'm' is a motor
         if isinstance(m, Movable):
             print(f"The object {m.name} is a motor")
-
     """
     @classmethod
     def __subclasshook__(cls, C):
         # If the following condition is True, the object C is recognized
         # to have Movable interface (e.g. a motor)
+        msg = """The Movable abstract base class is deprecated and will be removed in a future
+                 version of bluesky. Please use bluesky.utils.is_movable(obj) to test if an object
+                 satisfies the movable interface."""
+        warnings.warn(msg, DeprecationWarning)
         EXPECTED_ATTRS = (
             'name',
             'parent',

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -1565,9 +1565,12 @@ def is_movable(obj):
 class Movable(metaclass=abc.ABCMeta):
     """
     Abstract base class for objects that satisfy the bluesky 'movable' interface.
+    
     Examples
     --------
+    
     .. code-block:: python
+    
         m = hw.motor
         # We need to detect if 'm' is a motor
         if isinstance(m, Movable):

--- a/doc/source/hardware.rst
+++ b/doc/source/hardware.rst
@@ -219,7 +219,8 @@ Settable (Movable) Device
 +++++++++++++++++++++++++
 
 The interface of a settable device extends the interface of a readable device
-with the following additional methods and attributes:
+with the following additional methods and attributes.
+Settable device objects must pass ``bluesky.utils.is_movable(obj)``.
 
 .. class:: SettableDevice:
 


### PR DESCRIPTION
This PR changes the way that bluesky checks if an argument is "movable". Before: `isinstance(obj, Movable)`, now: `is_movable(obj)`.

Current behavior requires all of the expected attributes to be implemented as class attributes. With this PR, bluesky now checks instance attributes. For example, a class that defines `name` as an instance attribute at init time would have failed in old state but now passes. All objects that passed before should still pass.

closes #1377 

As an example of where current state gets weird, try running the following cell in a new notebook on https://try.nsls2.bnl.gov/

```python
from bluesky.utils import Movable
from bluesky.plans import grid_scan
from bluesky import RunEngine

%run scripts/beamline_configuration.py
motor = motor_ph
det = ph

RE(grid_scan([det], motor, 0, 1, 11))  # fails
```