### PR TITLE
FIX: add draw_idle to LiveGrid and LiveScatter

### DIFF
--- a/bluesky/callbacks/mpl_plotting.py
+++ b/bluesky/callbacks/mpl_plotting.py
@@ -24,6 +24,7 @@ def initialize_qt_teleporter():
     ------
     RuntimeError
         If called from any thread but the main thread
+
     """
     if threading.current_thread() is not threading.main_thread():
         raise RuntimeError(
@@ -364,6 +365,7 @@ class LiveScatter(QtAwareCallback):
         if self.clim is None:
             clim = np.nanmin(self._Idata), np.nanmax(self._Idata)
             self.sc.set_clim(*clim)
+        self.ax.figure.canvas.draw_idle()
 
 
 @make_class_safe(logger=logger)
@@ -533,6 +535,7 @@ class LiveGrid(QtAwareCallback):
             self.im.set_clim(np.nanmin(self._Idata), np.nanmax(self._Idata))
 
         self.im.set_array(self._Idata)
+        self.ax.figure.canvas.draw_idle()
 
 
 @make_class_safe(logger=logger)
@@ -655,6 +658,7 @@ def plot_peak_stats(peak_stats, ax=None):
     -------
     arts : dict
         dictionary of matplotlib Artist objects, for further styling
+
     """
     import matplotlib.pyplot as plt
     arts = {}


### PR DESCRIPTION
Previously we were relying on the qt kicker to trigger the re-draws,
move the logic into the callbacks instead.

This is both more robust (it is still safe for something external to
check the stale status and trigger e re-draw) and more-correct (the
callback object knows when it is back to a consistent state and should
be re-drawn).

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Issue of LiveGrid not updating reported via informal channels from CSX

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually.

```python
from bluesky import RunEngine
import bluesky.plans as bp
from bluesky.callbacks.best_effort import BestEffortCallback
from ophyd.sim import *
import matplotlib.pyplot as plt
plt.ion()

RE = RunEngine()
bec = BestEffortCallback()
RE.subscribe(bec)

motor.delay = 1
motor2.delay = .1

RE(bp.rel_grid_scan([det], motor, -5, 5, 25, motor2, -4, 4, 16))
```

<!--
## Screenshots (if appropriate):
-->
