### PR TITLE
Give the RunEngine thread a useful name.

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -2430,7 +2430,7 @@ def _ensure_event_loop_running(loop):
     This is idempotent: if the loop is already running nothing will be done.
     """
     if not loop.is_running():
-        th = threading.Thread(target=loop.run_forever, daemon=True)
+        th = threading.Thread(target=loop.run_forever, daemon=True, name="bluesky-run-engine")
         th.start()
         _ensure_event_loop_running.loop_to_thread[loop] = th
     else:

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -1558,3 +1558,18 @@ def test_self_describe(RE):
         assert type(RE) is cls
 
     RE(inner())
+
+
+def test_thread_name(RE):
+    "The RunEngine event loop should be on a thread with a given name."
+    from ophyd.status import Status
+
+    class MockDevice:
+        name = "mock_device"
+
+        def trigger(self):
+            assert threading.current_thread().name == "bluesky-run-engine"
+            return Status()
+
+    d = MockDevice()
+    RE([Msg("trigger", d)])


### PR DESCRIPTION
Now `threading.current_thread()` will show a Thread with the name
bluesky-run-engine instead of something like Thread-1.