### PR TITLE
Do not import set_handler from bluesky.log

### DIFF
--- a/bluesky/__init__.py
+++ b/bluesky/__init__.py
@@ -5,7 +5,6 @@ from .utils import FailedStatus  # noqa: F401
 
 from .run_engine import RunEngine  # noqa: F401
 from .preprocessors import SupplementalData  # noqa: F401
-from .log import set_handler  # noqa: F401
 
 from ._version import get_versions
 __version__ = get_versions()['version']


### PR DESCRIPTION
This PR address the problem of unexpected bluesky console logging first observed at BMM.

## Description
Removing the line 
```python
from .log import set_handler
```
from `bluesky/__init__.py` resolves the problem. It may be that `bluesky/log.py` should be completely removed.

## How Has This Been Tested?
This change was tested while running scans at SRX.

In addition `logging_tree` confirms that the unwanted logging handler is added by the specified import.
Before removing the import:
```
 o<--"bluesky"
   |   Level INFO
   |   Handler Stream <_io.TextIOWrapper name='<stdout>' mode='w' encoding='UTF-8'>
   |     Formatter <bluesky.log.LogFormatter object at 0x7fd456e20b38>
   |   Handler TimedRotatingFile '/home/xf05id1/.cache/bluesky/log/bluesky.log' when='W0' interval=604800 backupCount=10
   |     Level INFO
   |     Formatter fmt='[%(levelname)1.1s %(asctime)s.%(msecs)03d %(name)s  %(module)s:%(lineno)d] %(message)s' datefmt=None
```
After removing the import:
```
  o<--"bluesky"
   |   Level INFO
   |   Handler TimedRotatingFile '/home/xf05id1/.cache/bluesky/log/bluesky.log' when='W0' interval=604800 backupCount=10
   |     Level INFO
   |     Formatter fmt='[%(levelname)1.1s %(asctime)s.%(msecs)03d %(name)s  %(module)s:%(lineno)d] %(message)s' datefmt=None
```
