### PR TITLE
Minor refactor for internal consistency

### DIFF
--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -752,7 +752,8 @@ class PersistentDict(zict.Func):
             default=msgpack_numpy.encode,
             use_bin_type=True)
 
-    def _load(self, file):
+    @staticmethod
+    def _load(file):
         return msgpack.unpackb(
             file,
             object_hook=msgpack_numpy.decode,


### PR DESCRIPTION
I am not sure why I made `_dump` a `staticmethod` but not `_load`.
Neither of them use instance state; they are just included in the class
for organizational reasons.