### PR TITLE
WIP: Add flush and flush upon gc/exit.

### DIFF
--- a/bluesky/tests/test_persistent_dict.py
+++ b/bluesky/tests/test_persistent_dict.py
@@ -1,5 +1,6 @@
 import collections.abc
 import gc
+import pytest
 
 import numpy
 from numpy.testing import assert_array_equal
@@ -23,6 +24,12 @@ def test_persistent_dict(tmp_path):
     expected = dict(d)
     actual.reload()  # Force load changes from disk
     recursive_assert_equal(actual, expected)
+
+    # Test element deletion
+    del d['b']
+    with pytest.raises(KeyError):
+        d['b']
+    assert 'b' not in d
 
     # Smoke test the accessor and the __repr__.
     assert d.directory == tmp_path

--- a/bluesky/tests/test_persistent_dict.py
+++ b/bluesky/tests/test_persistent_dict.py
@@ -19,8 +19,13 @@ def test_persistent_dict(tmp_path):
     recursive_assert_equal(actual, expected)
 
     # Update a value and check again.
-    actual['a'] = 2
-    expected = dict(actual)
+    d['a'] = 2
+    expected = dict(d)
+
+    # Force sync changes from d to actual
+    d.flush()
+    actual.reload()
+
     recursive_assert_equal(actual, expected)
 
     # Smoke test the accessor and the __repr__.

--- a/bluesky/tests/test_persistent_dict.py
+++ b/bluesky/tests/test_persistent_dict.py
@@ -19,8 +19,8 @@ def test_persistent_dict(tmp_path):
     recursive_assert_equal(actual, expected)
 
     # Update a value and check again.
-    d['a'] = 2
-    expected = dict(d)
+    actual['a'] = 2
+    expected = dict(actual)
     recursive_assert_equal(actual, expected)
 
     # Smoke test the accessor and the __repr__.

--- a/bluesky/tests/test_persistent_dict.py
+++ b/bluesky/tests/test_persistent_dict.py
@@ -21,11 +21,7 @@ def test_persistent_dict(tmp_path):
     # Update a value and check again.
     d['a'] = 2
     expected = dict(d)
-
-    # Force sync changes from d to actual
-    d.flush()
-    actual.reload()
-
+    actual.reload()  # Force load changes from disk
     recursive_assert_equal(actual, expected)
 
     # Smoke test the accessor and the __repr__.

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -800,8 +800,7 @@ class PersistentDict(zict.Func):
 
     def reload(self):
         """Force a reload from disk, overwriting current cache"""
-        self._cache.update(super().items())
-
+        self._cache = dict(super().items())
 
 
 SEARCH_PATH = []

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -773,6 +773,10 @@ class PersistentDict(zict.Func):
     def __getitem__(self, key):
         return self._cache[key]
 
+    def __delitem__(self, key):
+        del self._cache[key]
+        super().__delitem__(key)
+
     def __repr__(self):
         return f"<{self.__class__.__name__} {dict(self)!r}>"
 


### PR DESCRIPTION
**WIP -- does not quite work yet**

Fixes #1388.

_"Those who do not study history are doomed to repeat it."_

We had an identical issue on https://github.com/Nikea/historydict/pull/27 which, funnily enough, was _also_ reported by @ambarb and _also_ fixed by me, back in 2016.