### PR TITLE
FIX: make sure bps.rd works with Signal (aka leaf) objects

### DIFF
--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -351,6 +351,7 @@ def rd(obj, *, default_value=0):
         )
         raise ValueError(msg)
     elif len(hints) == 0:
+        hint = None
         if hasattr(obj, "read_attrs"):
             if len(obj.read_attrs) != 1:
                 msg = (
@@ -362,9 +363,6 @@ def rd(obj, *, default_value=0):
                 )
 
                 raise ValueError(msg)
-
-            else:
-                hint = None
     # len(hints) == 1
     else:
         (hint,) = hints

--- a/bluesky/tests/test_plans.py
+++ b/bluesky/tests/test_plans.py
@@ -353,8 +353,10 @@ def test_rd_device(hw, RE, kind):
         nonlocal called
         direct_read = yield from bps.read(obj)
         rd_read = yield from bps.rd(obj)
+        sig_read = yield from bps.rd(obj.val)
 
         assert rd_read == direct_read["det"]["value"]
+        assert sig_read == rd_read
         called = True
 
     RE(tester(hw.det))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Simplify the logic in rd for Signal objects (objects without read_attrs)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes a UnboundLocal error when used, discovered by @mygsage at FXI at NSLS-II

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Extended existing test case to exercise this.

<!--
## Screenshots (if appropriate):
-->
