### PR TITLE
mark stop as optional for settable hardware

### DIFF
--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -1605,7 +1605,6 @@ def is_movable(obj):
         'read_configuration',
         'describe_configuration',
         'set',
-        'stop',
     )
     return all(hasattr(obj, attr) for attr in EXPECTED_ATTRS)
 

--- a/doc/source/hardware.rst
+++ b/doc/source/hardware.rst
@@ -224,9 +224,14 @@ Settable device objects must pass ``bluesky.utils.is_movable(obj)``.
 
 .. class:: SettableDevice:
 
-    .. method:: stop()
+    .. method:: stop(success=True)
 
         Safely stop a device that may or may not be in motion.
+	The argument ``success`` is a boolean.
+	When ``success`` is true, bluesky is stopping the device as planned
+	and the device should stop "normally".
+	When ``success`` is false, something has gone wrong and the device
+	may wish to take defensive action to make itself safe.
 	Optional: devices that cannot be stopped should not implement this
 	method.
 

--- a/doc/source/hardware.rst
+++ b/doc/source/hardware.rst
@@ -227,6 +227,8 @@ Settable device objects must pass ``bluesky.utils.is_movable(obj)``.
     .. method:: stop()
 
         Safely stop a device that may or may not be in motion.
+	Optional: devices that cannot be stopped should not implement this
+	method.
 
     .. method:: set(*args, **kwargs)
 


### PR DESCRIPTION
Currently bluesky requires objects to implement `stop` to pass the `is_moveable` check [1]. However if you look at RunEngine behavior it's clear that you expect devices that cannot be stopped to _not_ implement a stop method [2]. This PR attempts to clean up this discrepancy by making `stop` optional explicitly.

[1] https://github.com/bluesky/bluesky/blob/master/bluesky/utils.py#L1608
[2] https://github.com/bluesky/bluesky/blob/master/bluesky/run_engine.py#L1219-L1230
