### PR TITLE
Fix/bec use teleporter

### DIFF
--- a/bluesky/callbacks/mpl_plotting.py
+++ b/bluesky/callbacks/mpl_plotting.py
@@ -58,7 +58,8 @@ def _get_teleporter():
 
 
 class QtAwareCallback(CallbackBase):
-    def __init__(self, *args, use_teleporter=None, **kwargs):
+    def __init__(self, *args, **kwargs):
+        use_teleporter = kwargs.get('use_teleporter', None)
         if use_teleporter is None:
             import matplotlib
             use_teleporter = 'qt' in matplotlib.get_backend().lower()
@@ -66,7 +67,7 @@ class QtAwareCallback(CallbackBase):
             self.__teleporter = _get_teleporter()
         else:
             self.__teleporter = None
-        super().__init__(*args, **kwargs)
+        super().__init__()
 
     def __call__(self, name, doc, *, escape=False):
         if not escape and self.__teleporter is not None:
@@ -117,7 +118,7 @@ class LivePlot(QtAwareCallback):
     """
     def __init__(self, y, x=None, *, legend_keys=None, xlim=None, ylim=None,
                  ax=None, fig=None, epoch='run', **kwargs):
-        super().__init__(use_teleporter=kwargs.pop('use_teleporter', None))
+        super().__init__(**kwargs)
         self.__setup_lock = threading.Lock()
         self.__setup_event = threading.Event()
 
@@ -273,7 +274,7 @@ class LiveScatter(QtAwareCallback):
     """
     def __init__(self, x, y, I, *, xlim=None, ylim=None,  # noqa: E741
                  clim=None, cmap='viridis', ax=None, **kwargs):
-        super().__init__(use_teleporter=kwargs.pop('use_teleporter', None))
+        super().__init__(**kwargs)
         self.__setup_lock = threading.Lock()
         self.__setup_event = threading.Event()
 

--- a/bluesky/tests/test_bec.py
+++ b/bluesky/tests/test_bec.py
@@ -8,6 +8,7 @@ import bluesky.preprocessors as bpp
 import bluesky.plan_stubs as bps
 from bluesky.preprocessors import SupplementalData
 from bluesky.callbacks.best_effort import BestEffortCallback
+from bluesky.callbacks.mpl_plotting import initialize_qt_teleporter
 from bluesky.utils import new_uid
 from event_model import RunRouter
 
@@ -31,6 +32,14 @@ def test_simple(RE, hw):
     RE.subscribe(bec)
     RE(scan([hw.ab_det], hw.motor, 1, 5, 5))
 
+
+def test_use_teleporter(RE, hw):
+    det, motor = hw.ab_det, hw.motor
+    initialize_qt_teleporter()
+    bec = BestEffortCallback(use_teleporter=True)
+    RE.subscribe(bec)
+    RE(scan([det], motor, 1, 5, 5))
+    assert len(bec._live_plots) == 1
 
 def test_disable(RE, hw):
     det, motor = hw.ab_det, hw.motor


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allow for QtAwareCallback to get use_teleporter arg from kwargs.  There was no way to pass this in BestEffortCallback
## Description
<!--- Describe your changes in detail -->
get use_teleporter arg from kwargs. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This could be a local environment issue, but if use_teleporter is None, we get a segfault trying to check if 'qt' is in mpl backend.  When we know we're going to use the teleporter, it'd be nice to be able to pass this to BEC kwargs to QtAwareCallback
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
from ophyd.sim import motor1, det1
from bluesky import RunEngine
from bluesky.callbacks.mpl_plotting import initialize_qt_teleporter
from bluesky.callbacks.best_effort import BestEffortCallback
from Bluesky.plans import scan
RE = RunEngine({})
initialize_qt_teleporter()
bec = BestEffortCallback(). # Change BestEffortCallback(use_teleporter=True)
RE.subscribe(bec)
RE(bp.scan([det1], motor1, -10, 10, 21))
This caused segfault when use_teleporter is None.  The usual tk not finding main loop on main thread (again, this seems to be an environment issue for our NFS machines)
Now this produces live plot no problem.
<!--- Include details of your testing environment, and the tests you ran to -->
We are using the latest pcds_conda environment https://github.com/pcdshub/pcds-envs
<!--- see how your change affects other areas of the code, etc. -->
All changes should be benign, everything functions the same way if you don't pass in the use_teleporter arg.  I've also made sure the plotting utilities (LivePlot, etc...) still function as they should.
<!--
## Screenshots (if appropriate):
-->
