### PR TITLE
DOC: remove extra arguments from rel_spiral docstring

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -1682,10 +1682,6 @@ def rel_spiral(detectors, x_motor, y_motor, x_range, y_range, dr, nth,
         any 'settable' object (motor, temp controller, etc.)
     y_motor : object
         any 'settable' object (motor, temp controller, etc.)
-    x_start : float
-        x center
-    y_start : float
-        y center
     x_range : float
         x width of spiral
     y_range : float


### PR DESCRIPTION
`x_start` and `y_start` are not legal arguments to `rel_spiral`