### PR TITLE
DOC/MNT: add configure count time wrapper / decorator to docs

### DIFF
--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -9,7 +9,7 @@ from .utils import (normalize_subs_input, root_ancestor,
                     short_uid as _short_uid, make_decorator,
                     RunEngineControlException, merge_axis)
 from functools import wraps
-from .plan_stubs import (open_run, close_run, mv, pause, trigger_and_read)
+from .plan_stubs import (open_run, close_run, mv, pause, trigger_and_read, rd)
 
 
 def plan_mutator(plan, msg_proc):
@@ -448,7 +448,7 @@ def configure_count_time_wrapper(plan, time):
                 # TODO Do this with a 'read' Msg once reads can be
                 # marked as belonging to a different event stream (or no
                 # event stream.
-                original_times[obj] = obj.count_time.get()
+                original_times[obj] = rd(obj.count_time)
                 # TODO do this with configure
                 return pchain(mv(obj.count_time, time),
                               single_gen(msg)), None

--- a/doc/source/plans.rst
+++ b/doc/source/plans.rst
@@ -650,6 +650,8 @@ a generator instance. The corresponding functions named
     baseline_decorator
     baseline_wrapper
     contingency_wrapper
+    configure_count_time_wrapper
+    configure_count_time_decorator
     finalize_decorator
     finalize_wrapper
     fly_during_decorator


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

configure_count_time_wrapper and configure_count_time_decorator
have existed from 2017, but were not included in the built docs.

Also change to use rd internally.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is something that is frequently asked for and we already have the machinery extracted from the (now removed) spec API.  in ~2017 we generalized it but have not been using it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The wrapper already has tests in the test suite.

<!--
## Screenshots (if appropriate):
-->
