### PR TITLE
Readme and license updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,19 +1,21 @@
-Copyright (c) 2015, Brookhaven Science Associates, Brookhaven National
-Laboratory. All rights reserved.
+BSD 3-Clause License
+
+Copyright (c) 2015, Brookhaven National Lab
+All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-* Neither the name of the Brookhaven Science Associates, Brookhaven National
-  Laboratory nor the names of its contributors may be used to endorse or promote
-  products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2015, Brookhaven National Lab
+Copyright (c) 2015, Brookhaven National Laboratory
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ See [documentation](http://bluesky.github.io/bluesky).
 
 ## Conda Recipes
 
-Install the most recent build: `conda install bluesky -c nsls2force`
+Install the most recent build: `conda install bluesky -c nsls2forge`
 
 Find the tagged recipe [here](https://github.com/nsls-ii-forge/bluesky-feedstock)

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ See [documentation](http://bluesky.github.io/bluesky).
 
 ## Conda Recipes
 
-Install the most recent build: `conda install bluesky -c lightsource2-tag`
+Install the most recent build: `conda install bluesky -c nsls2force`
 
-Install the most recent development build: `conda install bluesky -c lightsource2-dev`
-
-Find the tagged recipe [here](https://github.com/NSLS-II/lightsource2-recipes/tree/master/recipes-tag/bluesky) and the dev recipe [here](https://github.com/NSLS-II/lightsource2-recipes/tree/master/recipes-dev/bluesky)
+Find the tagged recipe [here](https://github.com/nsls-ii-forge/bluesky-feedstock)

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ bluesky
 
 a Python data collection interface for experimental science
 
-See [documentation](http://nsls-ii.github.io/bluesky).
+See [documentation](http://bluesky.github.io/bluesky).
 
-[Report an issue with bluesky](https://github.com/NSLS-II/bluesky/issues/new)
+[Report an issue with bluesky](https://github.com/bluesky/bluesky/issues/new)
 
 ## Conda Recipes
 
-Install the most recent tagged build: `conda install bluesky -c lightsource2-tag`
+Install the most recent build: `conda install bluesky -c lightsource2-tag`
 
 Install the most recent development build: `conda install bluesky -c lightsource2-dev`
 


### PR DESCRIPTION
## Description
Updated links to point to current locations, and the LICENSE file to be more standard so that it is more easily recognized as the 3-clause BSD license.

## Motivation and Context
Make it easier to install the latest version from the current Conda channel, and make the licensing clearer in the GitHub UI.

## How Has This Been Tested?
LICENSE update won't be definite until merged, but verified recognition in other repositories. Checked new links and channels in the browser and on the command line.