### PR TITLE
Declare matplotlib as optional dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 cycler
 event-model>=1.14.0
 historydict
+matplotlib
 msgpack
 msgpack-numpy
 numpy


### PR DESCRIPTION
Matplotlib is used by `BestEffortCallback` and other vis-callbacks. We need it as a dependency here. Relevant discussion started in https://github.com/bluesky/bluesky-queueserver/pull/35/files#r489571206 and then in the DAMA teams.
