### PR TITLE
check limits should call objects' check_value() method

### DIFF
--- a/bluesky/simulators.py
+++ b/bluesky/simulators.py
@@ -88,28 +88,7 @@ def check_limits(plan):
     ----------
     plan : iterable
         Must yield `Msg` objects
-
-    Raises
-    ------
-    LimitsExceeded
     """
-    ignore = []
     for msg in plan:
         if msg.command == 'set':
-            if msg.obj in ignore:
-                continue  # we have already warned about this device
-            try:
-                low, high = msg.obj.limits
-            except AttributeError:
-                warn("Limits of {} are unknown and can't be checked.".format(msg.obj.name))
-                ignore.append(msg.obj)
-                continue
-            if low == high:
-                warn("Limits are not set on {}".format(msg.obj.name))
-                ignore.append(msg.obj)
-                continue
-            pos, = msg.args
-            if not (low < pos < high):
-                raise LimitsExceeded("This plan would put {} at {} "
-                                     "which is outside of its limits, {}."
-                                     "".format(msg.obj.name, pos, (low, high)))
+            msg.obj.check_value(msg.args[0])

--- a/bluesky/simulators.py
+++ b/bluesky/simulators.py
@@ -88,9 +88,9 @@ def check_limits(plan):
     ignore = []
     for msg in plan:
         if msg.command == 'set' and msg.obj not in ignore:
-            if hasattr(msg.obj, "limits"):
+            if hasattr(msg.obj, "check_value"):
                 msg.obj.check_value(msg.args[0])
             else:
-                warn("Limits of {} are unknown and can't be checked."
-                     .format(msg.obj.name))
+                warn(f"{msg.obj.name} has no check_value() method"
+                     f" to check if {msg.args[0]} is within its limits.")
                 ignore.append(msg.obj)

--- a/bluesky/simulators.py
+++ b/bluesky/simulators.py
@@ -76,10 +76,6 @@ def summarize_plan(plan):
 print_summary = summarize_plan  # back-compat
 
 
-class LimitsExceeded(Exception):
-    ...
-
-
 def check_limits(plan):
     """
     Check that a plan will not move devices outside of their limits.

--- a/bluesky/simulators.py
+++ b/bluesky/simulators.py
@@ -85,12 +85,12 @@ def check_limits(plan):
     plan : iterable
         Must yield `Msg` objects
     """
-    ignore = [] 
+    ignore = []
     for msg in plan:
         if msg.command == 'set' and msg.obj not in ignore:
             if hasattr(msg.obj, "limits"):
                 msg.obj.check_value(msg.args[0])
             else:
                 warn("Limits of {} are unknown and can't be checked."
-                     .format(msg.obj.name)) 
-                ignore.append(msg.obj) 
+                     .format(msg.obj.name))
+                ignore.append(msg.obj)

--- a/bluesky/simulators.py
+++ b/bluesky/simulators.py
@@ -89,6 +89,12 @@ def check_limits(plan):
     plan : iterable
         Must yield `Msg` objects
     """
+    ignore = [] 
     for msg in plan:
-        if msg.command == 'set':
-            msg.obj.check_value(msg.args[0])
+        if msg.command == 'set' and msg.obj not in ignore:
+            if hasattr(msg.obj, "limits"):
+                msg.obj.check_value(msg.args[0])
+            else:
+                warn("Limits of {} are unknown and can't be checked."
+                     .format(msg.obj.name)) 
+                ignore.append(msg.obj) 

--- a/bluesky/tests/test_simulators.py
+++ b/bluesky/tests/test_simulators.py
@@ -38,9 +38,10 @@ def test_check_limits(hw):
     # Use an assert to help us out if this changes in the future.
     assert not hasattr(motor, 'limits')
 
-    # check_limits should warn if it can't find limits
-    with pytest.warns(UserWarning):
-        check_limits(scan([det], motor, -1, 1, 3))
+    # # check_limits should warn if it can't find check_value
+    # TODO: Is there _any_ object to test?
+    # with pytest.warns(UserWarning):
+    #     check_limits(scan([det], motor, -1, 1, 3))
 
     # monkey-patch some limits
     motor.limits = (-2, 2)

--- a/bluesky/tests/test_simulators.py
+++ b/bluesky/tests/test_simulators.py
@@ -1,7 +1,7 @@
 from bluesky.plans import scan
 from bluesky.simulators import (print_summary, print_summary_wrapper,
                                 summarize_plan,
-                                check_limits, LimitsExceeded,
+                                check_limits,
                                 plot_raster_path)
 import pytest
 from bluesky.plans import grid_scan
@@ -47,14 +47,14 @@ def test_check_limits(hw):
     # check_limits should do nothing here
     check_limits(scan([det], motor, -1, 1, 3))
 
-    # check_limits should error if limits are exceeded
-    with pytest.raises(LimitsExceeded):
-        check_limits(scan([det], motor, -3, 3, 3))
+    # check_limits should error if limits are exceeded only if object raises
+    # this object does not raise
+    check_limits(scan([det], motor, -3, 3, 3))
 
-    # check_limits should warn if limits are equal
+    # check_limits should raise if limits are equal only if object raises
+    # this object does not raise
     motor.limits = (2, 2)
-    with pytest.warns(UserWarning):
-        check_limits(scan([det], motor, -1, 1, 3))
+    check_limits(scan([det], motor, -1, 1, 3))
 
 
 def test_plot_raster_path(hw):


### PR DESCRIPTION
Fixes #1411 which provides details.

## Description
Revise to call each object's `check_value(pos)` method.  Removed local check of `msg.obj.limits`.

Note that `check_limits()` cannot know if same limits are a problem.  Also it cannot know if limits are exceeded if the object does not raise.

## Motivation and Context
see #1411

## How Has This Been Tested?
Tested this code with the `hklpy.diffract.Diffractometer` class.  Other projects may also need to be tested with this code.
