### PR TITLE
Mention check_value() in bluesky interface docs

### DIFF
--- a/doc/source/hardware.rst
+++ b/doc/source/hardware.rst
@@ -227,7 +227,8 @@ Movable device objects must pass :func:`bluesky.utils.is_movable(obj)`.
     .. method:: set(*args, **kwargs)
 
         Return a ``Status`` that is marked done when the device is done
-        moving.
+        moving. This is the only *required* method that the Movable interace
+        adds to the  Readable one.
 
     .. method:: stop(success=True)
 

--- a/doc/source/hardware.rst
+++ b/doc/source/hardware.rst
@@ -215,14 +215,14 @@ The interface of a readable device:
         resumes after a pause.
 
 
-Settable (Movable) Device
-+++++++++++++++++++++++++
+Movable (or "Settable")  Device
++++++++++++++++++++++++++++++++
 
 The interface of a settable device extends the interface of a readable device
 with the following additional methods and attributes.
-Settable device objects must pass ``bluesky.utils.is_movable(obj)``.
+Movable device objects must pass ``bluesky.utils.is_movable(obj)``.
 
-.. class:: SettableDevice:
+.. class:: MovableDevice:
 
     .. method:: set(*args, **kwargs)
 

--- a/doc/source/hardware.rst
+++ b/doc/source/hardware.rst
@@ -269,7 +269,7 @@ Movable device objects must pass :func:`bluesky.utils.is_movable(obj)`.
 
 *For context on what we mean by "flyer", refer to the section on :doc:`async`.*
 
-The interace of a "flyable" device is separate from the interface of a readable
+The interface of a "flyable" device is separate from the interface of a readable
 or settable device, though there is some overlap.
 
 .. class:: FlyableDevice:

--- a/doc/source/hardware.rst
+++ b/doc/source/hardware.rst
@@ -218,9 +218,10 @@ The interface of a readable device:
 Movable (or "Settable")  Device
 +++++++++++++++++++++++++++++++
 
-The interface of a settable device extends the interface of a readable device
-with the following additional methods and attributes.
-Movable device objects must pass :func:`bluesky.utils.is_movable(obj)`.
+The interface of a movable device extends the interface of a readable device
+with the following additional methods and attributes. The utility function
+:func:`bluesky.utils.is_movable` can be used to check if an object meets the
+expected interface of a Movable.
 
 .. class:: MovableDevice:
 

--- a/doc/source/hardware.rst
+++ b/doc/source/hardware.rst
@@ -237,14 +237,27 @@ Settable device objects must pass ``bluesky.utils.is_movable(obj)``.
         and the device should stop "normally".
         When ``success`` is false, something has gone wrong and the device
         may wish to take defensive action to make itself safe.
+
         Optional: devices that cannot be stopped should not implement this
         method.
+
+    .. method:: check_value(*args, **kwargs)
+
+       This should accept the same arguments as ``set``. It should raise an
+       Exception if the argument represent an illegal setting --- e.g. a
+       position that would move a motor outside its limits or a temperature
+       controller outside of its settable range.
+
+       Optional: If this method is not present, simulators that check limits
+       such as :func:`bluesky.simulators.check_limits` may issue a warning but
+       should assume that all values are legal.
 
     .. attribute:: position
 
         A heuristic that describes the current position of a device as a
         single scalar, as opposed to the potentially multi-valued description
         provided by ``read()``.
+
         Optional: bluesky itself does not use the position attribute, but other
         parts of the ecosystem might.
         Developers are encouraged to implement this attribute where possible.

--- a/doc/source/hardware.rst
+++ b/doc/source/hardware.rst
@@ -220,7 +220,7 @@ Movable (or "Settable")  Device
 
 The interface of a settable device extends the interface of a readable device
 with the following additional methods and attributes.
-Movable device objects must pass ``bluesky.utils.is_movable(obj)``.
+Movable device objects must pass :func:`bluesky.utils.is_movable(obj)`.
 
 .. class:: MovableDevice:
 

--- a/doc/source/hardware.rst
+++ b/doc/source/hardware.rst
@@ -224,6 +224,11 @@ Settable device objects must pass ``bluesky.utils.is_movable(obj)``.
 
 .. class:: SettableDevice:
 
+    .. method:: set(*args, **kwargs)
+
+        Return a ``Status`` that is marked done when the device is done
+        moving.
+
     .. method:: stop(success=True)
 
         Safely stop a device that may or may not be in motion.
@@ -234,11 +239,6 @@ Settable device objects must pass ``bluesky.utils.is_movable(obj)``.
         may wish to take defensive action to make itself safe.
         Optional: devices that cannot be stopped should not implement this
         method.
-
-    .. method:: set(*args, **kwargs)
-
-        Return a ``Status`` that is marked done when the device is done
-        moving.
 
     .. attribute:: position
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

In #1412 we effectivley made ``check_value(...)`` an optional part of
the "bluesky interface" that movable devices should implement. This adds
it to the documentation on Movables and makes a couple other refinements
in the process.