### PR TITLE
Add pyepics to tutorial dependencies.

### DIFF
--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -46,7 +46,7 @@ Before You Begin
 
   .. code-block:: bash
 
-     python3 -m pip install --upgrade bluesky ophyd databroker matplotlib pyqt5 ipython
+     python3 -m pip install --upgrade bluesky ophyd databroker matplotlib pyqt5 ipython pyepics
 
   Alternatively, if you are a conda user and you prefer conda packages, you can
   use:


### PR DESCRIPTION
Thanks to Will Smith from BESSY-II for pointing this out.

We could alternatively depend on caproto because it is easier to install
cross-platform, but since ophyd currently does not test against it,
that feels risky.