### PR TITLE
Add github action for autorelease via CI

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,31 @@
+# This workflows will upload a Python Package using flit when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install wheel twine setuptools
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,7 +24,9 @@ jobs:
         pip install wheel twine setuptools
     - name: Build and publish
       env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_USERNAME: __token__
+        # The PYPI_PASSWORD must be a pypi token with the "pypi-" prefix with sufficient permissions to upload this package
+        # https://pypi.org/help/#apitoken
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python setup.py sdist bdist_wheel


### PR DESCRIPTION
## Description
Adds a github action which builds and uploads sdist and wheel to pypi.

With this applied, a release can be initiated using the github release in the web ui (or api, eg the `gh` cli).

I do _not_ think pushing a tag alone triggers this, but have not actually tested that.

This does require someone with proper permissions adding Secrets via github settings for PYPI_USERNAME and PYPI_PASSWORD (I use a pypi token with limited scope for such things).

Since bluesky is pure python, universal wheel (well, py3 only, but noarch, no abi specified) should work, and matches what is uploaded currently (though this could be modified should that change).

## Motivation and Context
This follows on from some conversations in the slack with @danielballan with an eye towards making releasing more automated.

That said, this does a real minimum of `setup.py sdist bdist_wheel` and `twine upload`.

## How Has This Been Tested?
I used this with another python repository.
That said, I do not actually know if more is done for bluesky releases. If it is, it can be added. In particular, the repo I used this with did not use versioneer (and I have limited experience with it, though it looks like it pulls the version from the tag itself, which should work, I expect)