### PR TITLE
Use databroker.temp instead of sqlite databroker.

### DIFF
--- a/bluesky/tests/conftest.py
+++ b/bluesky/tests/conftest.py
@@ -58,9 +58,8 @@ class NumpySeqHandler:
 def db(request):
     """Return a data broker
     """
-    from databroker.tests.utils import build_sqlite_backed_broker
-    db = build_sqlite_backed_broker(request)
-    db.reg.register_handler('NPY_SEQ', NumpySeqHandler)
+    from databroker import temp
+    db = temp()
     return db
 
 

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -22,7 +22,6 @@ from event_model import compose_run, DocumentNames
 import pytest
 import numpy as np
 import matplotlib.pyplot as plt
-from sqlite3 import InterfaceError
 from io import StringIO
 from unittest.mock import MagicMock
 from itertools import permutations

--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -445,8 +445,8 @@ def test_live_scatter(RE, hw):
                     xlim=(-3, 3), ylim=(-5, 5)))
 
 
-@pytest.mark.xfail(raises=InterfaceError,
-                   reason='something funny going on with 3.5, 3.6 and sqlite')
+@pytest.mark.xfail(raises=NotImplementedError,
+                   reason='This tests an API databroker has removed, and needs updating.')
 def test_broker_base(RE, hw, db):
     class BrokerChecker(BrokerCallbackBase):
         def __init__(self, field, *, db=None):


### PR DESCRIPTION
In the test suite, we currently reach into databroker's test fixtures and make a databroker using its deprecated sqlite backend. In this PR, we use `databroker.temp()` instead, which currently generates a msgpack-backed catalog.