### PR TITLE
Fix persistent dict

### DIFF
--- a/bluesky/tests/test_persistent_dict.py
+++ b/bluesky/tests/test_persistent_dict.py
@@ -45,7 +45,86 @@ def test_persistent_dict_mutable_value(tmp_path):
     recursive_assert_equal(d, expected)
     # Check that the __repr__ reflects this.
     assert "{'a': [1]}" in repr(d)
-    d.flush()
+    # Check that contents are synced to disk at exit.
+    del d
+    gc.collect()
+    actual = PersistentDict(tmp_path)
+    recursive_assert_equal(actual, expected)
+
+
+def test_pop(tmp_path):
+    d = PersistentDict(tmp_path)
+    d['a'] = 1
+    d['b'] = 2
+    d.pop('b')
+    expected = {'a': 1}
+    # Check the in-memory version is updated
+    recursive_assert_equal(d, expected)
+    # Check that the __repr__ reflects this.
+    assert "{'a': 1}" in repr(d)
+    # Check that contents are synced to disk at exit.
+    del d
+    gc.collect()
+    actual = PersistentDict(tmp_path)
+    recursive_assert_equal(actual, expected)
+
+
+def test_popitem(tmp_path):
+    d = PersistentDict(tmp_path)
+    d['a'] = 1
+    d['b'] = 2
+    d.poptem()
+    expected = {'a': 1}
+    # Check the in-memory version is updated
+    recursive_assert_equal(d, expected)
+    # Check that the __repr__ reflects this.
+    assert "{'a': 1}" in repr(d)
+    # Check that contents are synced to disk at exit.
+    del d
+    gc.collect()
+    actual = PersistentDict(tmp_path)
+    recursive_assert_equal(actual, expected)
+
+
+def test_update(tmp_path):
+    d = PersistentDict(tmp_path)
+    d.update(a=1)
+    expected = {'a': 1}
+    # Check the in-memory version is updated
+    recursive_assert_equal(d, expected)
+    # Check that the __repr__ reflects this.
+    assert "{'a': 1}" in repr(d)
+    # Check that contents are synced to disk at exit.
+    del d
+    gc.collect()
+    actual = PersistentDict(tmp_path)
+    recursive_assert_equal(actual, expected)
+
+
+def test_setdefault(tmp_path):
+    d = PersistentDict(tmp_path)
+    d.setdefault('a', 1)
+    expected = {'a': 1}
+    # Check the in-memory version is updated
+    recursive_assert_equal(d, expected)
+    # Check that the __repr__ reflects this.
+    assert "{'a': 1}" in repr(d)
+    # Check that contents are synced to disk at exit.
+    del d
+    gc.collect()
+    actual = PersistentDict(tmp_path)
+    recursive_assert_equal(actual, expected)
+
+
+def test_clear(tmp_path):
+    d = PersistentDict(tmp_path)
+    d['a'] = 1
+    d.clear()
+    expected = {}
+    # Check the in-memory version is updated
+    recursive_assert_equal(d, expected)
+    # Check that the __repr__ reflects this.
+    assert "{}" in repr(d)
     # Check that contents are synced to disk at exit.
     del d
     gc.collect()

--- a/bluesky/tests/test_persistent_dict.py
+++ b/bluesky/tests/test_persistent_dict.py
@@ -73,7 +73,7 @@ def test_popitem(tmp_path):
     d = PersistentDict(tmp_path)
     d['a'] = 1
     d['b'] = 2
-    d.poptem()
+    d.popitem()
     expected = {'a': 1}
     # Check the in-memory version is updated
     recursive_assert_equal(d, expected)

--- a/bluesky/utils.py
+++ b/bluesky/utils.py
@@ -801,8 +801,9 @@ class PersistentDict(collections.abc.MutableMapping):
         yield from self._cache
 
     def popitem(self):
-        key, _value = self._cache.popitem()
+        key, value = self._cache.popitem()
         del self._func[key]
+        return key, value
 
     @staticmethod
     def _dump(obj):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Critical bug fix

## Motivation and Context
The `PersistentDict.update(..)` method writes updates to disk but does not update the in-memory cache. When the `PersistentDict` is finalized, the copy of disk is overwritten by the copy in the cache, so the update never takes effect at any point.

This bug occurred because methods of base class `zict.Func` were being called without updating our intermediate layer, `self._cache`. It seems to be the best way to avoid this kind of bug is to use composition instead of inheritance. `PersistentDict` now inherits from `collections.abc.MutableMapping`, and we can ensure that all updates flow through our code.

## How Has This Been Tested?

Unit tests added for each of the mutating methods (update, pop, popitem, setdefault, clear)

<!--
## Screenshots (if appropriate):
-->
