### PR TITLE
FIX: logging for CLI version ZMQ Proxy

### DIFF
--- a/bluesky/commandline/zmq_proxy.py
+++ b/bluesky/commandline/zmq_proxy.py
@@ -5,7 +5,6 @@ import threading
 from bluesky.callbacks.zmq import Proxy, RemoteDispatcher
 from bluesky.log import set_handler
 
-
 logger = logging.getLogger('bluesky')
 
 
@@ -51,10 +50,13 @@ def main():
     args = parser.parse_args()
     in_port = args.in_port[0]
     out_port = args.out_port[0]
+
     if args.verbose:
-        logger.setLevel('INFO')
-        if args.verbose > 2:
-            logger.setLevel('DEBUG')
+        from bluesky.log import config_bluesky_logging
+        if args.verbose <= 2:  # called with -v or -vv
+            config_bluesky_logging(level='INFO')
+        else:  # called with -vvv
+            config_bluesky_logging(level='DEBUG')
         # Set daemon to kill all threads upon IPython exit
         threading.Thread(target=start_dispatcher,
                          args=('localhost', out_port, args.logfile),

--- a/bluesky/commandline/zmq_proxy.py
+++ b/bluesky/commandline/zmq_proxy.py
@@ -46,20 +46,22 @@ def main():
                         help=("Show 'start' and 'stop' documents. "
                               "(Use -vvv to show all documents.)"))
     parser.add_argument('--logfile', type=str,
-                        help="Write logfile")
+                        help="Redirect logging output to a file on disk.")
     args = parser.parse_args()
     in_port = args.in_port[0]
     out_port = args.out_port[0]
 
     if args.verbose:
         from bluesky.log import config_bluesky_logging
-        if args.verbose <= 2:  # called with -v or -vv
-            config_bluesky_logging(level='INFO')
-        else:  # called with -vvv
-            config_bluesky_logging(level='DEBUG')
+        # "INFO" if called with '-v' or '-vv', "DEBUG" if called with '-vvv'
+        level = "INFO" if args.verbose <= 2 else 'DEBUG'
+        if args.logfile:
+            config_bluesky_logging(level=level, file=args.logfile)
+        else:
+            config_bluesky_logging(level=level)
         # Set daemon to kill all threads upon IPython exit
         threading.Thread(target=start_dispatcher,
-                         args=('localhost', out_port, args.logfile),
+                         args=('localhost', out_port, None),
                          daemon=True).start()
 
     print("Connecting...")


### PR DESCRIPTION
Minor changes that fix the issue of missing logging output for CLI ZMQ proxy. Addresses the issue https://github.com/bluesky/bluesky/issues/1438.

Logging output functionality may be manually verified by starting ZMQ proxy in a terminal as
```
bluesky-0MQ-proxy 5577 5578 -v
```
or
```
bluesky-0MQ-proxy 5577 5578 -vvv
```
and running the following code in IPython session another terminal:
```
from bluesky import RunEngine
from bluesky.plans import count
from ophyd.sim import det
from bluesky.callbacks.zmq import Publisher
publisher = Publisher('localhost:5577') 

RE = RunEngine()
RE.subscribe(publisher)  
RE(count([det])) 
```
The logging output in the terminal running proxy should display the contents of 'start' and 'stop' documents if the proxy was started with `-v` and all documents ('start', 'stop', 'descriptor' and 'event') if the proxy was started with `-vvv`.

If the proxy is started as
```
bluesky-0MQ-proxy 5577 5578
```
then no logging output will be printed.

Instead of sending to stdout, logging data could be saved to a file on disk:
```
bluesky-0MQ-proxy 5577 5578 -v --logfile log_file.txt
```
