### PR TITLE
add hardware-interfaces page

### DIFF
--- a/docs/source/hardware-interfaces.rst
+++ b/docs/source/hardware-interfaces.rst
@@ -1,0 +1,34 @@
+.. _hardware_interface_packages:
+
+Hardware Interface Packages
+===========================
+
+The Bluesky library does not provide direct support for communicating with real hardware.
+Instead, we define a high-level abstraction: the :ref:`Bluesky Hardware Interface <hardware_interface>`.
+This allows different experimentalists to use different hardware control systems.
+
+The following packages provide support for real hardware communication from Bluesky:
+
+=============  ========================================================================
+Instrbuilder_  Lightweight package with a focus on SCPI_.
+Ophyd_         Primary hardware interface package for Bluesky with a focus on EPICS_.
+Ophyd-Tango_   Tango_ integration for Bluesky.
+yaqc-bluesky_  yaq_ integration for Bluesky.
+=============  ========================================================================
+
+Importantly, you may mix hardware interfaces from multiple different packages within the same RunEngine.
+Please note that the above packages are developed and maintained separately from Bluesky itself.
+
+Are you maintaining a Python Package which provides hardware communication functionality?
+The :ref:`Bluesky Hardware Interface <hardware_interface>` is a simple set of attributes and methods that can easily be added to your existing classes.
+Please consider supporting our interface specification to unlock the full capabilities of the Bluesky ecosystem for your supported hardware.
+Let us know if you add Bluesky support so we can add you to the above list.
+
+.. _Instrbuilder: https://lucask07.github.io/instrbuilder/build/html/
+.. _SCPI: https://en.wikipedia.org/wiki/Standard_Commands_for_Programmable_Instruments
+.. _Ophyd: https://blueskyproject.io/ophyd/
+.. _EPICS: https://epics-controls.org/
+.. _Ophyd-Tango: https://github.com/bluesky/ophyd-tango
+.. _Tango: https://www.tango-controls.org/
+.. _yaqc-bluesky: https://github.com/bluesky/yaqc-bluesky
+.. _yaq: https://yaq.fyi/

--- a/docs/source/hardware-interfaces.rst
+++ b/docs/source/hardware-interfaces.rst
@@ -9,12 +9,12 @@ This allows different experimentalists to use different hardware control systems
 
 The following packages provide support for real hardware communication from Bluesky:
 
-=============  ========================================================================
+=============  ================================================================================
+Ophyd_         EPICS_ integration for Bluesky. Reference implementation for hardware interface.
 Instrbuilder_  Lightweight package with a focus on SCPI_.
-Ophyd_         Primary hardware interface package for Bluesky with a focus on EPICS_.
-Ophyd-Tango_   Tango_ integration for Bluesky.
+Ophyd-Tango_   Tango_ integration for Bluesky. Incomplete and experimental early work.
 yaqc-bluesky_  yaq_ integration for Bluesky.
-=============  ========================================================================
+=============  ================================================================================
 
 Importantly, you may mix hardware interfaces from multiple different packages within the same RunEngine.
 Please note that the above packages are developed and maintained separately from Bluesky itself.

--- a/docs/source/hardware.rst
+++ b/docs/source/hardware.rst
@@ -1,6 +1,8 @@
 How Bluesky Interfaces with Hardware
 ====================================
 
+.. _hardware_interface:
+
 Overview
 --------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -56,6 +56,7 @@ Index
    magics
    from-pyepics-to-bluesky
    comparison-with-spec
+   hardware-interfaces
    appendix
 
 .. toctree::

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -1260,9 +1260,10 @@ Implementation
 developed in tandem with bluesky, implements this interface for devices that
 speak `EPICS <http://www.aps.anl.gov/epics/>`_. But bluesky is not tied to
 ophyd or EPICS specifically: any Python object may be used, so long as it
-provides the specified methods and attributes that bluesky expects. For
-example, an experimental implementation of the bluesky interface for LabView
-has been written. And the simulated hardware that we have been using in this
+provides the specified methods and attributes that bluesky expects.
+For example, an experimental implementation of the bluesky interface for LabView has been written.
+See :ref:`Hardware Interface Packages <hardware_interface_packages>` for more examples.
+And the simulated hardware that we have been using in this
 tutorial is all based on pure-Python constructs unconnected from hardware or
 any specific hardware control protocol.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add hardware interfaces page to docs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As discussed with @danielballan I am trying to update the docs to be more useful to small labs (and non-EPICS users in general). My next step is to flesh out `hardware.rst` to give much more concrete advice about how to implement Bluesky interfaces. In the long run I hope to reach out to some of the existing hardware support libraries and try to see if they would be willing to add Bluesky Hardware Interface compliance to their "device" classes.

I'm aware that some of these linked packages aren't polished, but I feel like if we're going to start building an ecosystem we have to start by at least advertising what we have.