### PR TITLE
Tolerate garbage on zmq

### DIFF
--- a/bluesky/callbacks/zmq.py
+++ b/bluesky/callbacks/zmq.py
@@ -6,6 +6,12 @@ import warnings
 from ..run_engine import Dispatcher, DocumentNames
 
 
+class Bluesky0MQDecodeError(Exception):
+    """Custom exception class for things that go wrong reading message from wire."""
+
+    ...
+
+
 class Publisher:
     """
     A callback that publishes documents to a 0MQ proxy.
@@ -217,7 +223,7 @@ class RemoteDispatcher(Dispatcher):
     """
     def __init__(self, address, *, prefix=b'',
                  loop=None, zmq=None, zmq_asyncio=None,
-                 deserializer=pickle.loads):
+                 deserializer=pickle.loads, strict=False):
         if isinstance(prefix, str):
             raise ValueError("prefix must be bytes, not string")
         if b' ' in prefix:
@@ -243,27 +249,64 @@ class RemoteDispatcher(Dispatcher):
         self._socket.setsockopt_string(zmq.SUBSCRIBE, "")
         self._task = None
         self.closed = False
-
+        self._strict = strict
         super().__init__()
 
     async def _poll(self):
         our_prefix = self._prefix  # local var to save an attribute lookup
         while True:
             message = await self._socket.recv()
-            prefix, name, doc = message.split(b' ', 2)
-            name = name.decode()
+            try:
+                prefix, name, doc = message.split(b' ', 2)
+            except ValueError as e:
+                if self._strict:
+                    raise Bluesky0MQDecodeError from e
+                else:
+                    print(f"The message {message} could not be split into "
+                          "three parts by b' '.  Dropping message on floor "
+                          "an continuing"
+                          f"\n\n{e}")
+                    continue
+
+            try:
+                name = name.decode()
+            except UnicodeDecodeError as e:
+                if self._strict:
+                    raise Bluesky0MQDecodeError from e
+                else:
+                    print(f"the name {name} can not be decoded as utf-8. "
+                          "Dropping message on the floor and continuing. "
+                          f"\n\n{e}")
+                    continue
             if (not our_prefix) or prefix == our_prefix:
-                doc = self._deserializer(doc)
+                try:
+                    doc = self._deserializer(doc)
+                except Exception as e:
+                    if self._strict:
+                        raise Bluesky0MQDecodeError from e
+                    else:
+                        if len(doc) > 1024:
+                            msg_doc = doc[:1024] + b'--SNIPPED--'
+                        else:
+                            msg_doc = doc
+                        print(f"Failed to deserialize the {name} document "
+                              f"{msg_doc} using {self._deserializer}. "
+                              "Dropping on floor and continuing"
+                              f"\n\n{e}")
+                        continue
                 self.loop.call_soon(self.process, DocumentNames[name], doc)
 
     def start(self):
         if self.closed:
             raise RuntimeError("This RemoteDispatcher has already been "
                                "started and interrupted. Create a fresh "
-                               "instance with {}".format(repr(self)))
+                               f"instance with {self!r}")
         try:
             self._task = self.loop.create_task(self._poll())
-            self.loop.run_forever()
+            self.loop.run_until_complete(self._task)
+            task_exception = self._task.exception()
+            if task_exception is not None:
+                raise task_exception
         except BaseException:
             self.stop()
             raise
@@ -271,6 +314,4 @@ class RemoteDispatcher(Dispatcher):
     def stop(self):
         if self._task is not None:
             self._task.cancel()
-            self.loop.stop()
-        self._task = None
         self.closed = True

--- a/bluesky/callbacks/zmq.py
+++ b/bluesky/callbacks/zmq.py
@@ -278,7 +278,7 @@ class RemoteDispatcher(Dispatcher):
                 else:
                     print(f"The message {message} could not be split into "
                           "three parts by b' '.  Dropping message on floor "
-                          "an continuing"
+                          "and continuing"
                           f"\n\n{e}")
                     continue
 
@@ -288,7 +288,7 @@ class RemoteDispatcher(Dispatcher):
                 if self._strict:
                     raise Bluesky0MQDecodeError from e
                 else:
-                    print(f"the name {name} can not be decoded as utf-8. "
+                    print(f"The name {name} can not be decoded as utf-8. "
                           "Dropping message on the floor and continuing. "
                           f"\n\n{e}")
                     continue

--- a/bluesky/callbacks/zmq.py
+++ b/bluesky/callbacks/zmq.py
@@ -1,3 +1,17 @@
+"""
+The key classes needed to use 0MQ for multiprocess document communication.
+
+`Publisher` : subscribe this to the RE to emit the documents.  Expects a server to
+have a SUBSCRIBE port open to PUB to.
+
+`RemoteDispatcher` : subscribe callbacks to this class in a remote process.  Expects
+a server to have a PUB port open to SUBSCRIBE to.
+
+`Proxy` : server that binds ports for Pubslisher to push to and the Dispatcher
+to listen to.  Typically this is started with the cli tool ``bluesky-zmq-proxy``
+
+"""
+
 import asyncio
 import copy
 import pickle


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds a number of try-except blocks to the 0mq RemoteDispatcher to not silently fail when un-expected messages come across the socket.


<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This fixes failures of the xpdan servers at XPD/PDF that we believe are caused by the network scanners pushing random byte strings into the zmq proxy.  The proxy is OK with this, but the subscribed clients are not.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This can be tested by starting up the proxy, starting a dispatcher as

```python
from bluesky.callbacks.zmq import RemoteDispatcher
RemoteDispatcher('localhost:5578').start()
```

and in another terminal

```python
import zmq

url = 'tcp://localhost:5577'
context = zmq.Context()
socket = context.socket(zmq.PUB)
socket.connect(url)

socket.send(b' \x80abc ')
socket.send(b' start ')
socket.send(b' start abc')
socket.send(b'')
```

<!--
## Screenshots (if appropriate):
-->
