### PR TITLE
forgotten argument dist to twine upload

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -30,4 +30,4 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python setup.py sdist bdist_wheel
-        twine upload
+        twine upload dist/*


### PR DESCRIPTION
Automatic release action failed. Note this is the first time we are actually trying to do an auto-release.

```
twine upload: error: the following arguments are required: dist
```

https://github.com/bluesky/bluesky/runs/3068462859?check_suite_focus=true#step:5:86