### PR TITLE
MNT: making 3.9 support official

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         ophyd-version: ["master", "latest"]
       fail-fast: false
     steps:

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,8 @@ setuptools.setup(
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Already use Bluesky with Python 3.9, but don't currently test against it or officially document that support. I hope this doesn't make tests any slower.