### PR TITLE
[BUG] protocol should not require parent to be @property

### DIFF
--- a/bluesky/protocols.py
+++ b/bluesky/protocols.py
@@ -28,11 +28,7 @@ class Status(Protocol):
 @runtime_checkable
 class Readable(Protocol):
     name: str
-
-    @property
-    def parent(self) -> Optional[Any]:
-        """``None``, or a reference to a parent device."""
-        ...
+    parent: Optional[Any]
 
     def trigger(self) -> Status:
         """Return a ``Status`` that is marked done when the device is done triggering.
@@ -117,11 +113,7 @@ class Movable(Readable, Protocol):
 @runtime_checkable
 class Flyable(Protocol):
     name: str
-
-    @property
-    def parent(self) -> Optional[Any]:
-        """``None``, or a reference to a parent device."""
-        ...
+    parent: Optional[Any]
 
     def kickoff(self) -> Status:
         """Begin acculumating data.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The current implementation does not allow the `parent` attribute to be set, which means that a simple device that specifies `self.parent = None` fails to pass. I don't understand why `parent` should be implemented as an `@property` rather than a simple attribute. It's likely I'm missing details, review from @ksunden will be very important here.

While we're at it, why do we use `Any` here. Couldn't we say `Optional[Readable]`?

The hints dictionary is also currently implemented as an `@property`, we might want to change that as well.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I ran into this within https://github.com/bluesky/yaqc-bluesky/pull/59

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally, seems to behave the way I want.

<!--
## Screenshots (if appropriate):
-->
