### PR TITLE
BUG: done and success should not be class attributes of Status protocol

### DIFF
--- a/bluesky/protocols.py
+++ b/bluesky/protocols.py
@@ -11,8 +11,6 @@ Configuration = Dict[str, Dict[str, Any]]
 
 @runtime_checkable
 class Status(Protocol):
-    done: bool
-    success: bool
 
     def add_callback(self, callback: Callable[["Status"], NoReturn]) -> NoReturn:
         """Add a callback function to be called upon completion.
@@ -22,6 +20,14 @@ class Status(Protocol):
         If the Status object is done when the function is added, it should be
         called immediately.
         """
+        ...
+
+    @property
+    def done(self) -> bool:
+        ...
+
+    @property
+    def success(self) -> bool:
         ...
 
 

--- a/bluesky/protocols.py
+++ b/bluesky/protocols.py
@@ -11,7 +11,6 @@ Configuration = Dict[str, Dict[str, Any]]
 
 @runtime_checkable
 class Status(Protocol):
-
     def add_callback(self, callback: Callable[["Status"], NoReturn]) -> NoReturn:
         """Add a callback function to be called upon completion.
 
@@ -33,8 +32,6 @@ class Status(Protocol):
 
 @runtime_checkable
 class Readable(Protocol):
-    name: str
-
     @property
     def parent(self) -> Optional[Any]:
         """``None``, or a reference to a parent device."""
@@ -112,6 +109,10 @@ class Readable(Protocol):
         """Same API as ``describe``, but corresponding to the keys in ``read_configuration``."""
         ...
 
+    @property
+    def name(self) -> str:
+        ...
+
 
 @runtime_checkable
 class Movable(Readable, Protocol):
@@ -122,7 +123,9 @@ class Movable(Readable, Protocol):
 
 @runtime_checkable
 class Flyable(Protocol):
-    name: str
+    @property
+    def name(self) -> str:
+        ...
 
     @property
     def parent(self) -> Optional[Any]:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Working further, and having been schooled by @ksunden in #1466, I'm now on the exact opposite side of the problem. The current implementation of `Status` does not work with our existing classes because we _do_ use `@property`. Error given is "expected settable variable, got read-only attribute".

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Current behavior does not pass existing Status objects.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Passes on yaqc_bluesky after this change.

<!--
## Screenshots (if appropriate):
-->
