### PR TITLE
TST: Set tests in test_callbacks.py that timeout to xfail

### DIFF
--- a/bluesky/tests/test_callbacks.py
+++ b/bluesky/tests/test_callbacks.py
@@ -147,6 +147,8 @@ def test_table_warns():
                              'data_keys': {'field': {'dtype': 'array'}}})
 
 
+@pytest.mark.xfail(raises=TimeoutError,
+                   reason="count([hw.img]) has been timing out stochastically")
 def test_table_external(RE, hw, db):
     RE.subscribe(db.insert)
     RE(count([hw.img]), LiveTable(['img']))
@@ -447,6 +449,8 @@ def test_live_scatter(RE, hw):
 
 @pytest.mark.xfail(raises=InterfaceError,
                    reason='something funny going on with 3.5, 3.6 and sqlite')
+@pytest.mark.xfail(raises=TimeoutError,
+                   reason='count([hw.img]) has been timing out stochastically')
 def test_broker_base(RE, hw, db):
     class BrokerChecker(BrokerCallbackBase):
         def __init__(self, field, *, db=None):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As noted by #1459 there are two tests in test_callbacks.py that fail randomly with timeout errors. This sets them both to xfail on a timeout error, until they can be properly debugged. The failing tests are test_table_external and test_broker_base, and both have been marked with xfail.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's really annoying that half the time you see a failure, it's just the same two tests randomly failing. Not useful! Eventually, somebody should look at hw.img in detail to see what's going on.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
xfails as expected.
