### PR TITLE
Fix list_grid_scan md for plan pattern args

### DIFF
--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -287,8 +287,7 @@ def list_grid_scan(detectors, *args, snake_axes=False, per_step=None, md=None):
                          'per_step': repr(per_step)},
            'plan_name': 'list_grid_scan',
            'plan_pattern': 'outer_list_product',
-           'plan_pattern_args': dict(args=md_args).update(
-               {'snake_axes': snake_axes}),
+           'plan_pattern_args': dict(args=md_args, snake_axes=snake_axes),
            'plan_pattern_module': plan_patterns.__name__,
            'motors': tuple(motor_names),
            'hints': {},


### PR DESCRIPTION
Update function always returns None, thus the expected dictionary was not actually included

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Rework plan pattern args to not use `update`, as that does not return the dictionary it is updating.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran a list_grid_scan, ensured that the plan_pattern_args were not null.

<!--
## Screenshots (if appropriate):
-->
