### PR TITLE
Fix descriptors for flyers that do not implement read_configuration

### DIFF
--- a/bluesky/bundlers.py
+++ b/bluesky/bundlers.py
@@ -612,14 +612,15 @@ class RunBundler:
                 descriptor_uid = new_uid()
                 # if we have not yet read the configuration, do so
                 if collect_obj.name not in collect_obj_config:
+                    _config = collect_obj_config[collect_obj.name] = {
+                        "data": {},
+                        "timestamps": {},
+                        "data_keys": {}
+                    }
                     # but read_configuration is optional
                     if hasattr(collect_obj, "read_configuration"):
                         doc_logger.debug("reading configuration from %s", collect_obj)
-                        _config = collect_obj_config[collect_obj.name] = {
-                            "data": {},
-                            "timestamps": {},
-                            "data_keys": collect_obj.describe_configuration()
-                        }
+                        _config['data_keys'].update(collect_obj.describe_configuration())
                         for config_key, config in collect_obj.read_configuration().items():
                             _config["data"][config_key] = config["value"]
                             _config["timestamps"][config_key] = config["timestamp"]

--- a/bluesky/tests/test_scientific.py
+++ b/bluesky/tests/test_scientific.py
@@ -1,14 +1,15 @@
+import pytest
 import numpy as np
 from bluesky.plans import scan
 from ophyd.sim import motor, det, SynGauss
 from bluesky.callbacks.fitting import PeakStats
 from scipy.special import erf
-from lmfit import Model
 
 
 def get_ps(x, y, shift=0.5):
     """ peak status calculation from CHX algorithm.
     """
+    lmfit = pytest.importorskip('lmfit')
     ps = {}
     x = np.array(x)
     y = np.array(y)
@@ -44,7 +45,7 @@ def get_ps(x, y, shift=0.5):
         def err_func(x, x0, k=2, A=1,  base=0):  # erf fit from Yugang
             return base - A * erf(k * (x - x0))
 
-        mod = Model(err_func)
+        mod = lmfit.Model(err_func)
         # estimate starting values:
         x0 = np.mean(x)
         # k=0.1*(np.max(x)-np.min(x))

--- a/bluesky/tests/utils.py
+++ b/bluesky/tests/utils.py
@@ -43,6 +43,9 @@ class DocCollector:
         elif name == "descriptor":
             self.descriptor[doc["run_start"]].append(doc)
             self.event[doc["uid"]] = []
+        elif name == 'bulk_events':
+            for k, v in doc.items():
+                self.event[k].extend(v)
         else:
             self.event[doc["descriptor"]].append(doc)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix descriptors for flyers that do not implement read_configuration.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously if `read_configuration` was not defined we would not put an entry in the configuration key in the descriptor.  While the RE would run OK, this would case issues on data access with newer versions of databroker. 

I do not think we want to make a distinction between in the documents between "the device reported configuration and it was empty" from "the device did not report any configuration".

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added new test

<!--
## Screenshots (if appropriate):
-->
