### PR TITLE
Read-only property `RunEngine.deferred_pause_requested`

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -736,6 +736,11 @@ class RunEngine:
 
     async def _request_pause_coro(self, defer=False):
         # We are pausing. Cancel any deferred pause previously requested.
+        if not self.state.can_pause:
+            raise TransitionError(
+                f"Run Engine is in '{self.state}' state and can not be paused."
+            )
+
         if defer:
             self._deferred_pause_requested = True
             print("Deferred pause acknowledged. Continuing to checkpoint.")

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -125,7 +125,7 @@ class RunEngineStateMachine(StateMachine):
             'panicked': []
         }
         named_checkers = [
-            ('can_pause', 'paused'),
+            ('can_pause', 'pausing'),
         ]
 
 

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -326,6 +326,22 @@ class RunEngine:
     def state(self):
         return self._state
 
+    @property
+    def deferred_pause_requested(self):
+        """
+        The property returns ``True`` if deferred pause was requested, but
+        not processed. The deferred pause is processed at the next checkpoint.
+        If the pause is requested after the last checkpoint, the plan runs
+        to completion and this property returns ``True`` until the next
+        plan is started.
+
+        Returns
+        -------
+        boolean
+            Indicates if deferred pause was requested, but not processed.
+        """
+        return self._deferred_pause_requested
+
     def __init__(self, md=None, *, loop=None, preprocessors=None,
                  context_managers=None, md_validator=None,
                  scan_id_source=default_scan_id_source,

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -331,9 +331,9 @@ class RunEngine:
         """
         The property returns ``True`` if deferred pause was requested, but
         not processed. The deferred pause is processed at the next checkpoint.
-        If the pause is requested after the last checkpoint, the plan runs
+        If the pause is requested past the last checkpoint, the plan runs
         to completion and this property returns ``True`` until the next
-        plan is started.
+        plan is started. Starting the next plan clears deferred pause request.
 
         Returns
         -------

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -1166,6 +1166,7 @@ def test_prompt_stop(RE, cancel_func):
                                          lambda RE: RE.abort(),
                                          lambda RE: RE.halt(),
                                          lambda RE: RE.request_pause(),
+                                         lambda RE: RE.request_pause(defer=True),
                                          lambda RE: RE.resume()])
 def test_bad_from_idle_transitions(RE, change_func):
     with pytest.raises(TransitionError):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changes:

- Implement read-only property `RunEngine.deferred_pause_requested` which returns the value of private variable `RunEngine._deferred_pause_requested`.

- Raise `TransitionError` exception if `RunEngine.request_pause()` is called when Run Engine in a state different from `idle`. The exception is raised if the parameter `defer` is `True` or `False`.

- Updated `can_pause` named checker of `RunEngineStateMachine` so that it returns `True` if transition to `pausing` state is allowed. Obviously, the name checker was not updated when additional transitional states were added. The name checker was not anywhere in the code, so the change is unlikely to affect operation of the Run Engine.

## Motivation and Context

The `RunEngine.deferred_pause_requested` property may be useful for Queue Server, where the state of Run Engine is monitored from a separate thread.

## How Has This Been Tested?
The unit tests are implemented for each new feature. 
