### PR TITLE
Plan Decorator

### DIFF
--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -1336,7 +1336,7 @@ def set_run_key_wrapper(plan, run):
 set_run_key_decorator = make_decorator(set_run_key_wrapper)
 
 
-class Plan:
+class plan_wrapper:
     def __init__(self, gen_instance):
         self.gen_instance = gen_instance
         self.pulled = False
@@ -1353,17 +1353,21 @@ class Plan:
         return f"<bluesky plan: {self.gen_instance.__name__}>"
 
 
-class PlanFunction:
+class plan_decorator:
     def __init__(self, gen_func):
         self.gen_func = gen_func
         update_wrapper(self, gen_func)
 
     def __call__(self, *args, **kwargs):
-        return Plan(self.gen_func(*args, **kwargs))
+        return plan_wrapper(self.gen_func(*args, **kwargs))
 
     def __repr__(self):
         return f"<uninitialized bluesky plan: {self.gen_func.__name__}>"
 
 
 def isplanfunction(obj):
-    return isinstance(obj, PlanFunction)
+    return isinstance(obj, plan_decorator)
+
+
+def isplan(obj):
+    return isinstance(obj, plan_wrapper)

--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -1339,6 +1339,7 @@ set_run_key_decorator = make_decorator(set_run_key_wrapper)
 class plan_wrapper:
     def __init__(self, gen_instance):
         self.gen_instance = gen_instance
+        self._plan = True
         self.pulled = False
 
     def __iter__(self):
@@ -1356,6 +1357,7 @@ class plan_wrapper:
 class plan_decorator:
     def __init__(self, gen_func):
         self.gen_func = gen_func
+        self._plan_function = True
         update_wrapper(self, gen_func)
 
     def __call__(self, *args, **kwargs):
@@ -1366,8 +1368,8 @@ class plan_decorator:
 
 
 def isplanfunction(obj):
-    return isinstance(obj, plan_decorator)
+    return getattr(obj, "_plan_function", False)
 
 
 def isplan(obj):
-    return isinstance(obj, plan_wrapper)
+    return getattr(obj, "_plan", False)

--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -8,7 +8,7 @@ from .utils import (normalize_subs_input, root_ancestor,
                     Msg, ensure_generator, single_gen,
                     short_uid as _short_uid, make_decorator,
                     RunEngineControlException, merge_axis)
-from functools import wraps
+from functools import wraps, update_wrapper
 import warnings
 from .plan_stubs import (open_run, close_run, mv, pause, trigger_and_read)
 
@@ -1353,8 +1353,17 @@ class Plan:
         return f"<bluesky plan: {self.gen_instance.__name__}>"
 
 
-def plan(gen_func):
-    @wraps(gen_func)
-    def inner_plan(*args, **kwargs):
-        return Plan(gen_func(*args, **kwargs))
-    return inner_plan
+class PlanFunction:
+    def __init__(self, gen_func):
+        self.gen_func = gen_func
+        update_wrapper(self, gen_func)
+
+    def __call__(self, *args, **kwargs):
+        return Plan(self.gen_func(*args, **kwargs))
+
+    def __repr__(self):
+        return f"<uninitialized bluesky plan: {self.gen_func.__name__}>"
+
+
+def isplanfunction(obj):
+    return isinstance(obj, PlanFunction)

--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -1347,11 +1347,10 @@ class Plan:
 
     def __del__(self):
         if not self.pulled:
-            warnings.warn(f"The generator {self!r} was not used. \
-            Did you forget `yield from`?")
+            warnings.warn(f"{self!r} was not used. Did you forget `yield from`?")
 
     def __repr__(self):
-        return repr(self.gen_instance)
+        return f"<bluesky plan: {self.gen_instance.__name__}>"
 
 
 def plan(gen_func):

--- a/bluesky/tests/test_generators.py
+++ b/bluesky/tests/test_generators.py
@@ -8,7 +8,7 @@ from bluesky import Msg
 from bluesky.preprocessors import (msg_mutator, stub_wrapper,
                                    plan_mutator, pchain, single_gen as
                                    single_message_gen,
-                                   finalize_wrapper)
+                                   finalize_wrapper, plan)
 
 from bluesky.utils import ensure_generator
 
@@ -462,3 +462,18 @@ def test_stub_wrapper():
     stub_plan = list(stub_wrapper(plan()))
     assert len(stub_plan) == 1
     assert stub_plan[0].command == 'read'
+
+
+def test_plan_decorator_warns():
+    @plan
+    def test_plan():
+        yield Msg('open_run')
+        yield Msg('stage')
+        yield Msg('read')
+        yield Msg('unstage')
+        yield Msg('close_run')
+        raise Exception
+
+    with pytest.warns(Warning):
+        test_plan()
+    EchoRE(test_plan())

--- a/bluesky/tests/test_generators.py
+++ b/bluesky/tests/test_generators.py
@@ -492,18 +492,18 @@ def test_plan_decorator_warnings():
 def test_is_a_plan_function():
 
     @plan_decorator
-    def test_plan():
+    def decorated_plan():
         yield Msg("null")
 
-    def not_a_real_plan():
+    def undecorated_plan():
         yield Msg("null")
 
-    assert isplanfunction(test_plan)
-    assert not isplanfunction(not_a_real_plan)
+    assert isplanfunction(decorated_plan)
+    assert not isplanfunction(undecorated_plan)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        assert isplan(test_plan())
-    assert not isplan(test_plan)
-    assert not isplan(not_a_real_plan)
-    assert not isplan(not_a_real_plan())
+        assert isplan(decorated_plan())
+    assert not isplan(decorated_plan)
+    assert not isplan(undecorated_plan)
+    assert not isplan(undecorated_plan())

--- a/bluesky/tests/test_generators.py
+++ b/bluesky/tests/test_generators.py
@@ -2,14 +2,14 @@ import uuid
 import pytest
 from collections import deque
 from itertools import zip_longest
-
+import warnings
 from bluesky import Msg
 
 from bluesky.preprocessors import (msg_mutator, stub_wrapper,
                                    plan_mutator, pchain, single_gen as
                                    single_message_gen,
-                                   finalize_wrapper, PlanFunction,
-                                   isplanfunction)
+                                   finalize_wrapper, plan_decorator,
+                                   isplanfunction, isplan)
 
 from bluesky.utils import ensure_generator
 
@@ -466,7 +466,7 @@ def test_stub_wrapper():
 
 
 def test_plan_decorator_warnings():
-    @PlanFunction
+    @plan_decorator
     def test_plan():
         yield Msg('open_run')
         yield Msg('stage')
@@ -491,7 +491,7 @@ def test_plan_decorator_warnings():
 
 def test_is_a_plan_function():
 
-    @PlanFunction
+    @plan_decorator
     def test_plan():
         yield Msg("null")
 
@@ -500,3 +500,10 @@ def test_is_a_plan_function():
 
     assert isplanfunction(test_plan)
     assert not isplanfunction(not_a_real_plan)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        assert isplan(test_plan())
+    assert not isplan(test_plan)
+    assert not isplan(not_a_real_plan)
+    assert not isplan(not_a_real_plan())

--- a/bluesky/tests/test_generators.py
+++ b/bluesky/tests/test_generators.py
@@ -2,14 +2,12 @@ import uuid
 import pytest
 from collections import deque
 from itertools import zip_longest
-import warnings
 from bluesky import Msg
 
 from bluesky.preprocessors import (msg_mutator, stub_wrapper,
                                    plan_mutator, pchain, single_gen as
                                    single_message_gen,
-                                   finalize_wrapper, plan_decorator,
-                                   isplanfunction, isplan)
+                                   finalize_wrapper)
 
 from bluesky.utils import ensure_generator
 
@@ -463,47 +461,3 @@ def test_stub_wrapper():
     stub_plan = list(stub_wrapper(plan()))
     assert len(stub_plan) == 1
     assert stub_plan[0].command == 'read'
-
-
-def test_plan_decorator_warnings():
-    @plan_decorator
-    def test_plan():
-        yield Msg('open_run')
-        yield Msg('stage')
-        yield Msg('read')
-        yield Msg('unstage')
-        yield Msg('close_run')
-
-    def error_plan():
-        yield Msg("null")
-        test_plan()
-
-    def correct_plan():
-        yield Msg("null")
-        yield from test_plan()
-
-    with pytest.warns(Warning):
-        EchoRE(error_plan())
-
-    # does not warn
-    EchoRE(correct_plan())
-
-
-def test_is_a_plan_function():
-
-    @plan_decorator
-    def decorated_plan():
-        yield Msg("null")
-
-    def undecorated_plan():
-        yield Msg("null")
-
-    assert isplanfunction(decorated_plan)
-    assert not isplanfunction(undecorated_plan)
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        assert isplan(decorated_plan())
-    assert not isplan(decorated_plan)
-    assert not isplan(undecorated_plan)
-    assert not isplan(undecorated_plan())

--- a/bluesky/tests/test_generators.py
+++ b/bluesky/tests/test_generators.py
@@ -8,7 +8,8 @@ from bluesky import Msg
 from bluesky.preprocessors import (msg_mutator, stub_wrapper,
                                    plan_mutator, pchain, single_gen as
                                    single_message_gen,
-                                   finalize_wrapper, plan)
+                                   finalize_wrapper, PlanFunction,
+                                   isplanfunction)
 
 from bluesky.utils import ensure_generator
 
@@ -465,7 +466,7 @@ def test_stub_wrapper():
 
 
 def test_plan_decorator_warnings():
-    @plan
+    @PlanFunction
     def test_plan():
         yield Msg('open_run')
         yield Msg('stage')
@@ -484,5 +485,18 @@ def test_plan_decorator_warnings():
     with pytest.warns(Warning):
         EchoRE(error_plan())
 
-    # does not warn 
+    # does not warn
     EchoRE(correct_plan())
+
+
+def test_is_a_plan_function():
+
+    @PlanFunction
+    def test_plan():
+        yield Msg("null")
+
+    def not_a_real_plan():
+        yield Msg("null")
+
+    assert isplanfunction(test_plan)
+    assert not isplanfunction(not_a_real_plan)

--- a/bluesky/tests/test_generators.py
+++ b/bluesky/tests/test_generators.py
@@ -464,7 +464,7 @@ def test_stub_wrapper():
     assert stub_plan[0].command == 'read'
 
 
-def test_plan_decorator_warns():
+def test_plan_decorator_warnings():
     @plan
     def test_plan():
         yield Msg('open_run')
@@ -472,8 +472,17 @@ def test_plan_decorator_warns():
         yield Msg('read')
         yield Msg('unstage')
         yield Msg('close_run')
-        raise Exception
+
+    def error_plan():
+        yield Msg("null")
+        test_plan()
+
+    def correct_plan():
+        yield Msg("null")
+        yield from test_plan()
 
     with pytest.warns(Warning):
-        test_plan()
-    EchoRE(test_plan())
+        EchoRE(error_plan())
+
+    # does not warn 
+    EchoRE(correct_plan())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!--- Describe your changes in detail -->
This PR would add a plan decorator that can be used to wrap any plan in a simple plan class, that at the minimum, provides a warning when a plan is used without `yield from`. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Plan decorators have been discussed intermittently as a building-block to enable a few different features. The code this PR is built on was proposed by @danielballan in #1239 as a way to warn users if they have forgotten to `yield from` a plan, and implement a more useful `repr` for plans than the built in `<generator object my_plan at 0x7f3cc009cc80>` you usually see.

Plan decorators would also allow for better plan inspection capabilities, as we could differentiate between a _plan_ and a normal generator. In the future (i.e, not in this PR), different plan decorators could be defined for, e.g, adaptive plans, so that a summarizer could check what _kind_ of plan it is trying to summarize, and act appropriately.

More controversially, #1238 proposed plan decorators as a possible building block towards shortcutting the `RE(...)` syntax. This excites some, and scares others, and will not be explored in this PR.

## Current Implementation
This code is pulled whole-cloth from [Dan's code in #1239](https://github.com/bluesky/bluesky/issues/1239#issue-479177515 ), with only minor adjustments to the `repr` to make it more friendly. 

It does currently:
* Warn users if they neglect to `yield from` a plan in another plan.
* Change the `repr` to be `<bluesky plan: {plan_name}>`

It should (by the time we merge):
* Decorate all bluesky plans

It does not:
* Warn users if they neglect to call `RE(...)` on a plan
* Implement any of the "Plan Accessor" concept discussed in #1239
* Implement a dynamic `repr` that contains information about the generator state, as discussed in #1239

## Please Discuss
The big question is - how much functionality should we give this plan decorator? Right now it is very minimal. It is a building block that implements a useful warning, and will allow _future_ code to reason about whether or not it has a bluesky plan. Plan accessors would be a _major_ shift in how bluesky is able to be used, so I am _very reluctant_ to delve into them here, despite the strong previous support. My preference is to take the code that Dan wrote in 2019, and shepherd it into bluesky so that we can start using it.

However, I would very much welcome all feedback and discussion.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A test has been added to see if an improperly called plan warns correctly, and a properly called plan runs error-free.


