### PR TITLE
Unpin 'sphinx_rtd_theme'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ cover/*
 
 # Sphinx documentation
 docs/_build/
+docs/source/generated
 
 # PyBuilder
 target/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,7 +28,7 @@ requests
 scikit-image
 scipy
 sphinx
-sphinx_rtd_theme==0.5.2
+sphinx_rtd_theme
 streamz
 # These suitcases are test deps of databroker which we need to access
 # databroker fixtures.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The assumption about general issues with `sphinx_rtd_theme` turned out to be incorrect and the package does not need to be pinned to the previous version.

The issue was observed while building the documentation for `bluesky-queueserver` project, which is using custom CSS files for formatting the tables (e.g. https://blueskyproject.io/bluesky-queueserver/re_manager_api.html#environment-open). The issue was fixed in PR https://github.com/bluesky/bluesky-queueserver/pull/193  
