### PR TITLE
CI: test Python 3.7-3.10

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
         ophyd-version: ["master", "latest"]
       fail-fast: false
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,6 +24,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install cython as a build requirement for some dependencies for Python 3.10
+      if: matrix.python-version == '3.10'
+      shell: bash -l {0}
+      run: pip install Cython
+
     - name: Install
       shell: bash -l {0}
       run: source continuous_integration/scripts/install.sh

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         ophyd-version: ["master", "latest"]
       fail-fast: false
     steps:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add Python 3.10 to the test matrix, remove Python 3.6.

## Description
<!--- Describe your changes in detail -->
Python 3.10 is out: https://pythoninsider.blogspot.com/2021/10/python-3100-is-available.html?utm_source=feedburner&utm_medium=feed&utm_campaign=Feed%3A+PythonInsider+%28Python+Insider%29.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Need to test newer versions of Python once they are released.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To be tested in CI, but @tacaswell tested the bleeding edge of Python's repo locally (see #1474).

<!--
## Screenshots (if appropriate):
-->
