### PR TITLE
DOC: write down intended behavior of fraction

### DIFF
--- a/docs/source/hardware.rst
+++ b/docs/source/hardware.rst
@@ -63,6 +63,11 @@ conforms to the following definition
             parameters, depending on what the status object knows about its own
             progress.
 
+            The ``fraction`` argument accepts a single float representing fraction
+            remaining.
+            A fraction of zero indicates completion.
+            A fraction of one indicates progress has not started.
+
 Readable Device
 +++++++++++++++
 


### PR DESCRIPTION
Just want to write this down for my own future reference, if nothing else.
I haven't thought about it in detail, but perhaps tests or assertions would help enforce expectations here---something for a later PR.

## Description
Document intended behavior of `fraction` argument.

## Motivation and Context
See https://github.com/bluesky/ophyd/pull/1022.

## How Has This Been Tested?
Documentation.