### PR TITLE
ENH: don't call stage unless stageable

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -14,6 +14,7 @@ import weakref
 from dataclasses import dataclass
 import typing
 from .bundlers import RunBundler
+from . import protocols as bs_protocols
 
 import concurrent
 
@@ -2316,7 +2317,7 @@ class RunEngine:
         """
         _, obj, args, kwargs, _ = msg
         # If an object has no 'stage' method, assume there is nothing to do.
-        if not hasattr(obj, 'stage'):
+        if not isinstance(obj, bs_protocols.Stageable):
             return []
         result = obj.stage()
         self._staged.add(obj)  # add first in case of failure below
@@ -2332,7 +2333,7 @@ class RunEngine:
         """
         _, obj, args, kwargs, _ = msg
         # If an object has no 'unstage' method, assume there is nothing to do.
-        if not hasattr(obj, 'unstage'):
+        if not isinstance(obj, bs_protocols.Stageable):
             return []
         result = obj.unstage()
         # use `discard()` to ignore objects that are not in the staged set.

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -339,6 +339,26 @@ def test_stage_and_unstage_are_optional_methods(RE):
     RE([Msg('stage', dummy), Msg('unstage', dummy)])
 
 
+def test_need_both_stage_and_unstage_for_stagable(RE):
+    class StageOnly(object):
+
+        def stage(self):
+            raise Exception
+
+    class UnstageOnly(object):
+
+        def unstage(self):
+            raise Exception
+
+    stage_only = StageOnly()
+    unstage_only = UnstageOnly()
+    RE([Msg("stage", stage_only),
+        Msg("stage", unstage_only),
+        Msg("unstage", stage_only),
+        Msg("unstage", unstage_only)]
+        )
+
+
 def test_pause_resume_devices(RE):
     paused = {}
     resumed = {}

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -356,7 +356,7 @@ def test_need_both_stage_and_unstage_for_stagable(RE):
         Msg("stage", unstage_only),
         Msg("unstage", stage_only),
         Msg("unstage", unstage_only)]
-        )
+       )
 
 
 def test_pause_resume_devices(RE):


### PR DESCRIPTION
Some of the device objects we are passing into bluesky happen to have an attribute `stage` that has nothing to do with Bluesky's concept of `Stageable`. Since we already have protocols, we can use them to make the run engine smart enough to not attempt calling `stage` on our objects.

There are other places in the run engine where protocols could be used, but I'm going to ignore those in favor of solving the problem in front of us now.

As always, feel free to reject or propose alternative solutions. If the answer is "please don't ever pass anything with attribute `stage` this is expected behavior" we can work with that.

## Description

Replace `hasattr(obj, 'stage')` with `isinstance(obj, bs_protocols.Stageable)`.

## Motivation and Context

See https://gitlab.com/yaq/yaqd-attune/-/issues/6

## How Has This Been Tested?

Tests written.