### PR TITLE
ENH: add extra dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,13 @@ with open('README.md', encoding='utf-8') as readme_file:
 
 extras_require = {
     "ipython": ["ipython"],
-    "qserver": ["pyzmq"],
+    "zmq": ["pyzmq"],
     "common": ["ophyd", "databroker"],
-    "tools": ["doct", "lmfit"],
-    "plotting": ["matplotlib"]
+    "tools": ["doct", "lmfit", "tifffile", "historydict"],
+    "streamz": ["streamz"],
+    "plotting": ["matplotlib"],
+    "cmd": ["colorama"],
+    "olog": ["jinja2"],
 }
 
 extras_require['all'] = sorted(set(sum(extras_require.values(), [])))

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,16 @@ with open('requirements.txt') as f:
 with open('README.md', encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
+extras_require = {
+    "ipython": ["ipython"],
+    "qserver": ["pyzmq"],
+    "common": ["ophyd", "databroker"],
+    "tools": ["doct", "lmfit"],
+    "plotting": ["matplotlib"]
+}
+
+extras_require['all'] = sorted(set(sum(extras_require.values(), [])))
+
 setuptools.setup(
     name='bluesky',
     version=versioneer.get_version(),
@@ -43,6 +53,7 @@ setuptools.setup(
     package_data={"bluesky": ["py.typed"]},
     python_requires='>={}'.format('.'.join(str(n) for n in min_version)),
     install_requires=requirements,
+    extras_require=extras_require,
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
Adds all of the extra dependencies used in the conda-forge recipe to setuptools.

I've grouped them arbitrarily here based on my simple understanding. Other grouping suggestions would be appreciated :smile:.

Closes #1408.

## Description

Add `extras_require`. Can install with bracket syntax using pip. For example, from source:

```bash
$ python -m pip install -e .[all]
```

Here are the dependencies in full (as resolved on my machine):
```bash
$ pipdeptree --freeze
bluesky==1.6.4.post262+ge8a7f495
  cycler==0.11.0
  event-model==1.17.2
    jsonschema==4.4.0
      attrs==21.4.0
      pyrsistent==0.18.1
    numpy==1.22.2
  historydict==1.2.3
  msgpack==1.0.3
  msgpack-numpy==0.4.7.1
    msgpack==1.0.3
    numpy==1.22.2
  numpy==1.22.2
  super-state-machine==2.0.2
    six==1.16.0
  toolz==0.11.2
  tqdm==4.63.0
  zict==2.1.0
    HeapDict==1.0.1
colorama==0.4.4
databroker==1.2.5
  bluesky-live==0.0.8
    dask==2022.2.1
      cloudpickle==2.0.0
      fsspec==2022.2.0
      packaging==21.3
        pyparsing==3.0.7
      partd==1.2.0
        locket==0.2.1
        toolz==0.11.2
      PyYAML==6.0
      toolz==0.11.2
    entrypoints==0.4
    event-model==1.17.2
      jsonschema==4.4.0
        attrs==21.4.0
        pyrsistent==0.18.1
      numpy==1.22.2
    numpy==1.22.2
    pandas==1.4.1
      numpy==1.22.2
      python-dateutil==2.8.2
        six==1.16.0
      pytz==2021.3
    xarray==2022.3.0
      numpy==1.22.2
      packaging==21.3
        pyparsing==3.0.7
      pandas==1.4.1
        numpy==1.22.2
        python-dateutil==2.8.2
          six==1.16.0
        pytz==2021.3
  boltons==21.0.0
  cachetools==5.0.0
  dask==2022.2.1
    cloudpickle==2.0.0
    fsspec==2022.2.0
    packaging==21.3
      pyparsing==3.0.7
    partd==1.2.0
      locket==0.2.1
      toolz==0.11.2
    PyYAML==6.0
    toolz==0.11.2
  doct==1.0.5
    humanize==4.0.0
    prettytable==3.2.0
      wcwidth==0.2.5
    six==1.16.0
  event-model==1.17.2
    jsonschema==4.4.0
      attrs==21.4.0
      pyrsistent==0.18.1
    numpy==1.22.2
  humanize==4.0.0
  intake==0.6.4
    appdirs==1.4.4
    dask==2022.2.1
      cloudpickle==2.0.0
      fsspec==2022.2.0
      packaging==21.3
        pyparsing==3.0.7
      partd==1.2.0
        locket==0.2.1
        toolz==0.11.2
      PyYAML==6.0
      toolz==0.11.2
    entrypoints==0.4
    fsspec==2022.2.0
    Jinja2==3.0.3
      MarkupSafe==2.1.0
    PyYAML==6.0
  Jinja2==3.0.3
    MarkupSafe==2.1.0
  jsonschema==4.4.0
    attrs==21.4.0
    pyrsistent==0.18.1
  mongoquery==1.4.0
    six==1.16.0
  msgpack==1.0.3
  msgpack-numpy==0.4.7.1
    msgpack==1.0.3
    numpy==1.22.2
  numpy==1.22.2
  pandas==1.4.1
    numpy==1.22.2
    python-dateutil==2.8.2
      six==1.16.0
    pytz==2021.3
  PIMS==0.5
    numpy==1.22.2
    six==1.16.0
    slicerator==1.0.0
      six==1.16.0
  pymongo==4.0.2
  pytz==2021.3
  PyYAML==6.0
  requests==2.27.1
    certifi==2021.10.8
    charset-normalizer==2.0.12
    idna==3.3
    urllib3==1.26.8
  six==1.16.0
  suitcase-mongo==0.3.1
    event-model==1.17.2
      jsonschema==4.4.0
        attrs==21.4.0
        pyrsistent==0.18.1
      numpy==1.22.2
    pymongo==4.0.2
  suitcase-msgpack==0.3.0
    event-model==1.17.2
      jsonschema==4.4.0
        attrs==21.4.0
        pyrsistent==0.18.1
      numpy==1.22.2
    msgpack==1.0.3
    msgpack-numpy==0.4.7.1
      msgpack==1.0.3
      numpy==1.22.2
    suitcase-utils==0.5.4
  tifffile==2022.2.9
    numpy==1.22.2
  toolz==0.11.2
  tzlocal==4.1
    pytz-deprecation-shim==0.1.0.post0
      tzdata==2021.5
  xarray==2022.3.0
    numpy==1.22.2
    packaging==21.3
      pyparsing==3.0.7
    pandas==1.4.1
      numpy==1.22.2
      python-dateutil==2.8.2
        six==1.16.0
      pytz==2021.3
  zarr==2.11.0
    asciitree==0.3.3
    fasteners==0.17.3
    numcodecs==0.9.1
      numpy==1.22.2
    numpy==1.22.2
ipython==8.1.1
  backcall==0.2.0
  decorator==5.1.1
  jedi==0.18.1
    parso==0.8.3
  matplotlib-inline==0.1.3
    traitlets==5.1.1
  pexpect==4.8.0
    ptyprocess==0.7.0
  pickleshare==0.7.5
  prompt-toolkit==3.0.28
    wcwidth==0.2.5
  Pygments==2.11.2
  setuptools==60.9.3
  stack-data==0.2.0
    asttokens==2.0.5
      six==1.16.0
    executing==0.8.3
    pure-eval==0.2.2
  traitlets==5.1.1
lmfit==1.0.3
  asteval==0.9.26
  numpy==1.22.2
  scipy==1.8.0
    numpy==1.22.2
  uncertainties==3.1.6
    future==0.18.2
matplotlib==3.5.1
  cycler==0.11.0
  fonttools==4.29.1
  kiwisolver==1.3.2
  numpy==1.22.2
  packaging==21.3
    pyparsing==3.0.7
  Pillow==9.0.1
  pyparsing==3.0.7
  python-dateutil==2.8.2
    six==1.16.0
ophyd==1.6.3
  networkx==2.7.1
  numpy==1.22.2
  Pint==0.18
    packaging==21.3
      pyparsing==3.0.7
pyzmq==22.3.0
streamz==0.6.3
  setuptools==60.9.3
  six==1.16.0
  toolz==0.11.2
  tornado==6.1
  zict==2.1.0
    HeapDict==1.0.1
```