### PR TITLE
Many motor BestEffortCallback

### DIFF
--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -487,9 +487,9 @@ class BestEffortCallback(QtAwareCallback):
                 tr
                 for tr in lp.ax.lines
                 if len(tr._x) != 2
-                   or len(tr._y) != 2
-                   or (len(tr._x) == 2
-                       and tr._x[0] != tr._x[1])
+                or len(tr._y) != 2
+                or (len(tr._x) == 2
+                    and tr._x[0] != tr._x[1])
             ]
             if len(lines) > num_lines:
                 keepers = lines[-num_lines:]

--- a/bluesky/tests/test_bec.py
+++ b/bluesky/tests/test_bec.py
@@ -298,13 +298,15 @@ def test_bec_peak_stats_derivative_and_stats(RE, hw):
 
 
 def test_many_motors(RE, hw):
-    """Ensure appropriate behavior for too many motors to plot. No figures, with a table"""
+    """Ensure appropriate behavior for too many motors to plot. No figures with warning, and a table."""
     dets = [hw.ab_det]
     motors = [hw.motor, hw.motor1, hw.motor2, hw.motor3]
     bec = BestEffortCallback()
     RE.subscribe(bec)
     movement = [(motor, 1, 5, 5) for motor in motors]
-    RE(grid_scan(dets, *[item for sublist in movement for item in sublist]))
+    with pytest.warns(None) as record:
+        RE(grid_scan(dets, *[item for sublist in movement for item in sublist]))
+    assert len(record) > 0
     assert not bec._live_plots
     assert not bec._live_grids
     assert not bec._live_scatters

--- a/bluesky/tests/test_bec.py
+++ b/bluesky/tests/test_bec.py
@@ -295,3 +295,17 @@ def test_bec_peak_stats_derivative_and_stats(RE, hw):
                                out_value)
         else:
             stats_value == out_value
+
+
+def test_many_motors(RE, hw):
+    """Ensure appropriate behavior for too many motors to plot. No figures, with a table"""
+    dets = [hw.ab_det]
+    motors = [hw.motor, hw.motor1, hw.motor2, hw.motor3]
+    bec = BestEffortCallback()
+    RE.subscribe(bec)
+    movement = [(motor, 1, 5, 5) for motor in motors]
+    RE(grid_scan(dets, *[item for sublist in movement for item in sublist]))
+    assert not bec._live_plots
+    assert not bec._live_grids
+    assert not bec._live_scatters
+    assert bec._table is not None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes #1508 

## Description
1. Add a unit test for the desired behavior. 
2. Refactor plotting set up from the processing of descriptor documents in BEC to a private function. This allows a premature return in the plotting to not stop the descriptor processing. 
3. Add a warning and explanation at the premature return. 
https://github.com/maffettone/bluesky/blob/145dea576cc992a4e7fefe63ad9655f1bb4d1bf4/bluesky/callbacks/best_effort.py#L199-L203

## Motivation and Context
The BEC prints no LiveTable, produces no Figures, and doesn't tell the user why.
This largely happens because of this return statement in the descriptor processing

## How Has This Been Tested?
An additional unit test was added `test_bec.test_many_motors` to ensure that no plot gets made with higher dimensional motors, a warning is issued that recommends adjusting the hints for BEC if plots are desired, and the full dimensionality makes it to the LiveTable. 

The changes pass all other tests in `test_bec` (python 3.7 environment). 

