### PR TITLE
Machine learning callbacks

### DIFF
--- a/bluesky/callbacks/ml.py
+++ b/bluesky/callbacks/ml.py
@@ -9,6 +9,40 @@ logger = logging.getLogger(__name__)
 
 @make_class_safe(logger=logger)
 class AgentCallback(CallbackBase):
+    """
+    Callback for telling AI/ML agents about data, and generating reports.
+    This callback does not support fully adaptive planning;
+    however, can be used for streaming analysis, reports, or alerts.
+
+    Parameters
+    ----------
+    agents :
+        Each agent is required to have the methods ``tell`` and ``ask``
+    independent_key : str
+        Key for the independent variable (x) to send the agent. This will appear in doc["data"][independent_key].
+    dependent_key : str
+        Key for the dependent variable (y) to send the agent. This will appear in doc["data"][dependent_key].
+    report_on_event : bool
+        Call ``agent.report()`` on each event in the data stream. Default to True.
+    report_on_stop : bool
+        Call ``agent.report()`` at the stop document in the data stream. Default to True.
+    stream_name : str
+        Stream name contained in the descriptor document. Default to "primary".
+
+    Examples
+    --------
+    >>> class Agent:
+    >>>     self.positions = []
+    >>>     self.intensities = []
+    >>>     def tell(self, position, intensity):
+    >>>         self.positions.append(position)
+    >>>         self.intensities.append(intensity)
+    >>>     def report(self):
+    >>>         if self.intensities[-1] < 0: print(f"WARNING, negative intensity at {self.positions[-1]}.")
+    >>> agent = Agent()
+    >>> RE.subscribe(AgentCallback(agent, independent_key="position", dependent_key="intensity"))
+    """
+
     def __init__(
         self,
         *agents,
@@ -18,35 +52,6 @@ class AgentCallback(CallbackBase):
         report_on_stop: bool = True,
         stream_name: str = "primary",
     ):
-        """
-        Callback for telling AI/ML agents about data, and generating reports.
-        This callback does not support fully adaptive planning;
-        however, can be used for streaming analysis, reports, or alerts.
-
-
-        Parameters
-        ----------
-        agents :
-        independent_key : str
-        dependent_key : str
-        report_on_event : bool
-        report_on_stop : bool
-        stream_name : str
-
-        Examples
-        --------
-        >>> class Agent:
-        >>>     self.positions = []
-        >>>     self.intensities = []
-        >>>     def tell(self, position, intensity):
-        >>>         self.positions.append(position)
-        >>>         self.intensities.append(intensity)
-        >>>     def report(self):
-        >>>         if self.intensities[-1] < 0: print(f"WARNING, negative intensity at {self.positions[-1]}.")
-        >>> agent = Agent()
-        >>> RE.subscribe(AgentCallback(agent, independent_key="position", dependent_key="intensity"))
-        """
-
         super().__init__()
         self.agents = list()
         for agent in agents:

--- a/bluesky/callbacks/ml.py
+++ b/bluesky/callbacks/ml.py
@@ -1,0 +1,99 @@
+"""Callbacks for AI/ML agents"""
+
+from .core import CallbackBase, make_class_safe
+from warnings import warn
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@make_class_safe(logger=logger)
+class AgentCallback(CallbackBase):
+    def __init__(
+        self,
+        *agents,
+        independent_key: str,
+        dependent_key: str,
+        report_on_event: bool = True,
+        report_on_stop: bool = True,
+        stream_name: str = "primary",
+    ):
+        """
+        Callback for telling AI/ML agents about data, and generating reports.
+        This callback does not support fully adaptive planning;
+        however, can be used for streaming analysis, reports, or alerts.
+
+
+        Parameters
+        ----------
+        agents :
+        independent_key : str
+        dependent_key : str
+        report_on_event : bool
+        report_on_stop : bool
+        stream_name : str
+
+        Examples
+        --------
+        >>> class Agent:
+        >>>     self.positions = []
+        >>>     self.intensities = []
+        >>>     def tell(self, position, intensity):
+        >>>         self.positions.append(position)
+        >>>         self.intensities.append(intensity)
+        >>>     def report(self):
+        >>>         if self.intensities[-1] < 0: print(f"WARNING, negative intensity at {self.positions[-1]}.")
+        >>> agent = Agent()
+        >>> RE.subscribe(AgentCallback(agent, independent_key="position", dependent_key="intensity"))
+        """
+
+        super().__init__()
+        self.agents = list()
+        for agent in agents:
+            if self.agent_validation(agent):
+                self.agents.append(agent)
+            else:
+                warn(f"Agent did not pass validation and will not be included in the callback:\n{agent}")
+
+        self.independent_key = independent_key
+        self.dependent_key = dependent_key
+        self.report_on_event = report_on_event
+        self.report_on_stop = report_on_stop
+        self.stream = stream_name
+        self._descriptors = {}
+
+    @staticmethod
+    def agent_validation(agent):
+        passing = True
+        tell = getattr(agent, "tell", None)
+        if not callable(tell):
+            passing = False
+            warn("Agent missing callable tell method.")
+        report = getattr(agent, "report", None)
+        if not callable(report):
+            passing = False
+            warn("Agent missing callable report method.")
+        return passing
+
+    def descriptor(self, doc):
+        """Track descriptor documents to only send correct stream to agents"""
+        self._descriptors[doc["uid"]] = doc
+
+    def event(self, doc):
+        descriptor = self._descriptors[doc["descriptor"]]
+        if descriptor.get("name") != self.stream:
+            return
+
+        x = doc["data"][self.independent_key]
+        y = doc["data"][self.dependent_key]
+        for agent in self.agents:
+            agent.tell(x, y)
+
+        if self.report_on_event:
+            for agent in self.agents:
+                agent.report()
+
+    def stop(self, doc):
+        if self.report_on_stop:
+            for agent in self.agents:
+                agent.report()

--- a/bluesky/tests/test_cb_ml.py
+++ b/bluesky/tests/test_cb_ml.py
@@ -44,10 +44,10 @@ def test_bad_agent():
 
     with pytest.warns(UserWarning):
         # Wrong names for function calls
-        cb = AgentCallback(BadAgent(), independent_key="", dependent_key="")
+        AgentCallback(BadAgent(), independent_key="", dependent_key="")
     with pytest.warns(UserWarning):
         # Not callable attributes
-        cb = AgentCallback(WorseAgent(), independent_key="", dependent_key="")
+        AgentCallback(WorseAgent(), independent_key="", dependent_key="")
 
 
 def test_simple(RE, hw):

--- a/bluesky/tests/test_cb_ml.py
+++ b/bluesky/tests/test_cb_ml.py
@@ -1,0 +1,121 @@
+import pytest
+from bluesky.callbacks.ml import AgentCallback
+import pandas as pd
+from bluesky.plans import scan
+
+
+class DummyAgent:
+    """Simple agent reports a statistical summary of data"""
+
+    def __init__(self, verbose=True):
+        self.independents = []
+        self.dependents = []
+        self.last_summary = None
+        self.verbose = verbose
+        self.n_reports = 0
+
+    def tell(self, x, y):
+        self.independents.append(x)
+        self.dependents.append(y)
+        self.last_summary = pd.Series(self.dependents).describe()
+
+    def ask(self):
+        raise NotImplementedError
+
+    def report(self):
+        self.n_reports += 1
+        if self.verbose:
+            print(self.last_summary)
+        return self.last_summary
+
+
+def test_bad_agent():
+    class BadAgent:
+        def tells(self, x, y):
+            pass
+
+        def reporting(self):
+            pass
+
+    class WorseAgent:
+        def __init__(self):
+            self.tell = None
+            self.report = 4
+
+    with pytest.warns(UserWarning):
+        # Wrong names for function calls
+        cb = AgentCallback(BadAgent(), independent_key="", dependent_key="")
+    with pytest.warns(UserWarning):
+        # Not callable attributes
+        cb = AgentCallback(WorseAgent(), independent_key="", dependent_key="")
+
+
+def test_simple(RE, hw):
+    cb = AgentCallback(DummyAgent(), independent_key="motor", dependent_key="det")
+    RE.subscribe(cb)
+    RE(scan([hw.det], hw.motor, 1, 3, num=3))
+
+
+def test_multi_agent(RE, hw):
+    cb = AgentCallback(
+        DummyAgent(verbose=False), DummyAgent(verbose=False), independent_key="motor", dependent_key="det"
+    )
+    assert cb.agents[0] is not cb.agents[1]
+    RE.subscribe(cb)
+    RE(scan([hw.det], hw.motor, 1, 3, num=3))
+    assert (cb.agents[0].last_summary == cb.agents[1].last_summary).all()
+
+
+def test_closure(RE, hw):
+    agent = DummyAgent(verbose=False)
+    cb = AgentCallback(agent, independent_key="motor", dependent_key="det")
+    RE.subscribe(cb)
+    RE(scan([hw.det], hw.motor, 1, 3, num=3))
+    assert agent.last_summary.astype(bool).all()
+
+
+def test_report_on_event(RE, hw):
+    agent = DummyAgent(verbose=False)
+    cb = AgentCallback(agent, independent_key="motor", dependent_key="det", report_on_stop=False)
+    RE.subscribe(cb)
+    RE(scan([hw.det], hw.motor, 1, 3, num=3))
+    assert agent.n_reports == 3
+
+
+def test_report_on_stop(RE, hw):
+    agent = DummyAgent(verbose=False)
+    cb = AgentCallback(agent, independent_key="motor", dependent_key="det", report_on_event=False)
+    RE.subscribe(cb)
+    RE(scan([hw.det], hw.motor, 1, 3, num=3))
+    assert agent.n_reports == 1
+
+
+def test_no_reports(RE, hw):
+    agent = DummyAgent(verbose=False)
+    cb = AgentCallback(
+        agent, independent_key="motor", dependent_key="det", report_on_event=False, report_on_stop=False
+    )
+    RE.subscribe(cb)
+    RE(scan([hw.det], hw.motor, 1, 3, num=3))
+    assert agent.n_reports == 0
+    assert len(agent.dependents) > 0
+
+
+def test_stream_name(RE, hw):
+    agent = DummyAgent(verbose=True)
+    cb = AgentCallback(agent, independent_key="motor", dependent_key="det", stream_name="background")
+    RE.subscribe(cb)
+    RE(scan([hw.det], hw.motor, 1, 3, num=3))
+    assert agent.last_summary is None
+
+
+def test_class_safety(RE, hw):
+    class ErrorAgent:
+        def tell(self, x, y):
+            pass
+
+        def report(self):
+            raise RuntimeError
+
+    RE.subscribe(AgentCallback(ErrorAgent(), independent_key="motor", dependent_key="det"))
+    RE(scan([hw.det], hw.motor, 1, 3, num=3))

--- a/docs/source/callbacks.rst
+++ b/docs/source/callbacks.rst
@@ -1264,3 +1264,40 @@ LiveDispatcher API
 ++++++++++++++++++
 .. autoclass:: bluesky.callbacks.stream.LiveDispatcher
    :members:
+
+
+Callbacks for Machine Learning
+------------------------------
+It is often desirable to embed a machine learning model (agent) into the plan.
+Callbacks can be used for passive uses of machine learning, i.e. agents that do not actively change the plans.
+For active agents, see the ongoing developments at `bluesky-adaptive <https://blueskyproject.io/bluesky-adaptive/>`_.
+
+We make use of the ``tell``-``report``-``ask`` paradigm both here and in ``bluesky-adaptive``.
+
+- ``agent.tell(x, y)``: Tell the agent about some new data with the independent variable (x) and dependent variable (y).
+- ``agent.report()``: Generate a report using the agent internals. This can be something as simple as printing a
+  recent classification probability, or something more complex as a live plot that updates at each measurement with a
+  full dataset clustering.
+- ``agent.ask()``: Ask the agent what to measure next. **This is not used within callbacks.**
+
+
+The following will send the primary data stream two agents, which will treat the motor as an independent variable
+and the detector as a dependent variable. The agents will generate a report by default both on event and on stop;
+this frequency can be controlled through keyword arguments.
+
+.. code-block:: python
+
+    from bluesky.callbacks.ml import AgentCallback
+    cb = AgentCallback(clustering_agent, classification_agent,
+                       independent_key="motor", dependent_key="det")
+    RE.subscribe(cb)
+
+
+Where the functionality of the agent is embedded is entirely dependent on the use case. Given the examples above, a
+classification agent that relies on a loaded ML model would likely include a predict call every time it is given new
+data, retaining a cache of the independent variable, dependent variable, and classification probabilities.
+Whereas a clustering agent, would likely only want to train the model on the full cache when ``report`` is called.
+
+
+.. autoclass:: bluesky.callbacks.ml.AgentCallback
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Construct a generic callback that interfaces the document stream with a passive machine learning agent, using the `tell`-`report` interface. 

## Description
<!--- Describe your changes in detail -->
The callback:
- focuses on passive ML, that is, agents that respond to but do not guide experiments. 
- consumes an arbitrary number of agents which are each required to have a `tell` and `report` method. 
- will track a specific stream (default "primary"), and requires explicit specification of independent and dependent variables.
- does not use "hints" as in the best effort callback.
- calls `agent.tell()` on a per-event basis
- calls `agent.report()` on a per-event and/or a per-stop basis. 

The documentation for callbacks was extended to include a ML section. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This follows on from reviewer and user feedback regarding [this paper](https://arxiv.org/abs/2201.03550), 
and the paradigms outlined there and in [bluesky-adaptive](https://blueskyproject.io/bluesky-adaptive/) and its respective [tutorials](https://github.com/bluesky/tutorials/blob/main/Adaptive%20RL%20Sampling/Adaptive%20Sampling.ipynb).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A full set of unit tests has been developed along side of the callback to ensure expected functionality. 

<!--
## Screenshots (if appropriate):
-->
