### PR TITLE
MNT: clarify how suspenders get evaluated

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1152,7 +1152,9 @@ class RunEngine:
                 print(f"Justification for this suspension:\n{justification}")
 
             # add starting the suspender logic to the stack
-            self._plan_stack.append(single_gen(Msg('_start_suspender', None, pre_plan, post_plan, justification, fut)))
+            self._plan_stack.append(
+                single_gen(Msg('_start_suspender', None, pre_plan, post_plan, justification, fut))
+            )
             self._response_stack.append(None)
 
             # The event loop is still running. The pre_plan will be processed,

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -464,7 +464,7 @@ class RunEngine:
             'clear_checkpoint': self._clear_checkpoint,
             'rewindable': self._rewindable,
             'pause': self._pause,
-            'resume': self._resume,
+            '_resume_from_suspender': self._resume,
             'collect': self._collect,
             'kickoff': self._kickoff,
             'complete': self._complete,
@@ -1182,7 +1182,7 @@ class RunEngine:
                 self._response_stack.append(None)
 
             # tell the devices they are ready to go again
-            self._plan_stack.append(single_gen(Msg('resume', None, )))
+            self._plan_stack.append(single_gen(Msg('_resume_from_suspender', None, )))
             self._response_stack.append(None)
 
             # add the wait on the future to the stack

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1149,9 +1149,11 @@ class RunEngine:
                     self._task.cancel()
 
             if justification is not None:
-                print("Justification for this suspension:\n%s" % justification)
+                print(f"Justification for this suspension:\n{justification}")
             for current_run in self._run_bundlers.values():
-                current_run.record_interruption('resume')
+                current_run.record_interruption(
+                    justification if justification is not None else "suspended"
+                )
             # During suspend, all motors should be stopped. Call stop() on
             # every object we ever set().
             self._stop_movable_objects(success=True)

--- a/bluesky/tests/test_examples.py
+++ b/bluesky/tests/test_examples.py
@@ -283,11 +283,13 @@ def test_suspend(RE, hw):
     ]
     assert RE.state == 'idle'
 
-    def local_suspend():
-        RE.request_suspend(ev.wait)
-
     def resume_cb():
         RE.loop.call_soon_threadsafe(ev.set)
+
+    def local_suspend():
+        RE.request_suspend(ev.wait)
+        # wait a second and then resume
+        threading.Timer(1, resume_cb).start()
 
     out = []
 
@@ -295,8 +297,6 @@ def test_suspend(RE, hw):
         out.append(ev)
     # trigger the suspend right after the check point
     threading.Timer(.1, local_suspend).start()
-    # wait a second and then resume
-    threading.Timer(1, resume_cb).start()
     # grab the start time
     start = ttime.time()
     # run, this will not return until it is done

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -493,14 +493,14 @@ def _make_unrewindable_suspender_marker():
                  motor,
                  UnReplayableSynGauss('det', motor, 'motor', center=0, Imax=1),
                  ['set', 'trigger', 'sleep',
-                  'rewindable', 'wait_for', 'resume', 'rewindable',
+                  'rewindable', 'wait_for', "_resume_from_suspender", 'rewindable',
                   'set', 'trigger']))
 
     inps.append((test_plan,
                  motor,
                  SynGauss('det', motor, 'motor', center=0, Imax=1),
                  ['set', 'trigger', 'sleep',
-                  'rewindable', 'wait_for', 'resume', 'rewindable',
+                  'rewindable', 'wait_for', "_resume_from_suspender", 'rewindable',
                   'set',
                   'trigger', 'sleep', 'set', 'trigger']))
 

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -493,14 +493,20 @@ def _make_unrewindable_suspender_marker():
                  motor,
                  UnReplayableSynGauss('det', motor, 'motor', center=0, Imax=1),
                  ['set', 'trigger', 'sleep',
-                  'rewindable', 'wait_for', "_resume_from_suspender", 'rewindable',
+                  "_start_suspender",
+                  'rewindable',
+                  'wait_for', "_resume_from_suspender",
+                  'rewindable',
                   'set', 'trigger']))
 
     inps.append((test_plan,
                  motor,
                  SynGauss('det', motor, 'motor', center=0, Imax=1),
                  ['set', 'trigger', 'sleep',
-                  'rewindable', 'wait_for', "_resume_from_suspender", 'rewindable',
+                  "_start_suspender",
+                  'rewindable',
+                  'wait_for', "_resume_from_suspender",
+                  'rewindable',
                   'set',
                   'trigger', 'sleep', 'set', 'trigger']))
 

--- a/bluesky/tests/test_suspenders.py
+++ b/bluesky/tests/test_suspenders.py
@@ -84,39 +84,89 @@ def test_pretripped(RE, hw):
     RE(scan)
 
     assert len(msg_lst) == 2
-    assert ['wait_for', 'checkpoint'] == [m[0] for m in msg_lst]
+    assert ["wait_for", "checkpoint"] == [m[0] for m in msg_lst]
 
 
-@pytest.mark.parametrize('pre_plan,post_plan,expected_list',
-                         [([Msg('null')], None,
-                           ['checkpoint', 'sleep', 'rewindable', 'null',
-                            'wait_for', "_resume_from_suspender", 'rewindable', 'sleep']),
-                          (None, [Msg('null')],
-                           ['checkpoint', 'sleep', 'rewindable',
-                            'wait_for', "_resume_from_suspender", 'null', 'rewindable',
-                            'sleep']),
-                          ([Msg('null')], [Msg('null')],
-                           ['checkpoint', 'sleep', 'rewindable', 'null',
-                            'wait_for', "_resume_from_suspender", 'null', 'rewindable',
-                            'sleep']),
-                          (lambda: [Msg('null')], lambda: [Msg('null')],
-                           ['checkpoint', 'sleep', 'rewindable', 'null',
-                            'wait_for', "_resume_from_suspender", 'null', 'rewindable',
-                            'sleep'])])
+@pytest.mark.parametrize(
+    "pre_plan,post_plan,expected_list",
+    [
+        (
+            [Msg("null")],
+            None,
+            [
+                "checkpoint",
+                "sleep",
+                "_start_suspender",
+                "rewindable",
+                "null",
+                "wait_for",
+                "_resume_from_suspender",
+                "rewindable",
+                "sleep",
+            ],
+        ),
+        (
+            None,
+            [Msg("null")],
+            [
+                "checkpoint",
+                "sleep",
+                "_start_suspender",
+                "rewindable",
+                "wait_for",
+                "_resume_from_suspender",
+                "null",
+                "rewindable",
+                "sleep",
+            ],
+        ),
+        (
+            [Msg("null")],
+            [Msg("null")],
+            [
+                "checkpoint",
+                "sleep",
+                "_start_suspender",
+                "rewindable",
+                "null",
+                "wait_for",
+                "_resume_from_suspender",
+                "null",
+                "rewindable",
+                "sleep",
+            ],
+        ),
+        (
+            lambda: [Msg("null")],
+            lambda: [Msg("null")],
+            [
+                "checkpoint",
+                "sleep",
+                "_start_suspender",
+                "rewindable",
+                "null",
+                "wait_for",
+                "_resume_from_suspender",
+                "null",
+                "rewindable",
+                "sleep",
+            ],
+        ),
+    ],
+)
 def test_pre_suspend_plan(RE, pre_plan, post_plan, expected_list, hw):
     sig = hw.bool_sig
-    scan = [Msg('checkpoint'), Msg('sleep', None, .2)]
+    scan = [Msg("checkpoint"), Msg("sleep", None, 0.2)]
     msg_lst = []
     sig.put(0)
 
     def accum(msg):
         msg_lst.append(msg)
 
-    susp = SuspendBoolHigh(sig, pre_plan=pre_plan,
-                           post_plan=post_plan)
+    susp = SuspendBoolHigh(sig, pre_plan=pre_plan, post_plan=post_plan)
 
     RE.install_suspender(susp)
-    threading.Timer(.1, sig.put, (1,)).start()
+    threading.Timer(0.1, sig.put, (1,)).start()
     threading.Timer(1, sig.put, (0,)).start()
     RE.msg_hook = accum
     RE(scan)

--- a/bluesky/tests/test_suspenders.py
+++ b/bluesky/tests/test_suspenders.py
@@ -90,18 +90,18 @@ def test_pretripped(RE, hw):
 @pytest.mark.parametrize('pre_plan,post_plan,expected_list',
                          [([Msg('null')], None,
                            ['checkpoint', 'sleep', 'rewindable', 'null',
-                            'wait_for', 'resume', 'rewindable', 'sleep']),
+                            'wait_for', "_resume_from_suspender", 'rewindable', 'sleep']),
                           (None, [Msg('null')],
                            ['checkpoint', 'sleep', 'rewindable',
-                            'wait_for', 'resume', 'null', 'rewindable',
+                            'wait_for', "_resume_from_suspender", 'null', 'rewindable',
                             'sleep']),
                           ([Msg('null')], [Msg('null')],
                            ['checkpoint', 'sleep', 'rewindable', 'null',
-                            'wait_for', 'resume', 'null', 'rewindable',
+                            'wait_for', "_resume_from_suspender", 'null', 'rewindable',
                             'sleep']),
                           (lambda: [Msg('null')], lambda: [Msg('null')],
                            ['checkpoint', 'sleep', 'rewindable', 'null',
-                            'wait_for', 'resume', 'null', 'rewindable',
+                            'wait_for', "_resume_from_suspender", 'null', 'rewindable',
                             'sleep'])])
 def test_pre_suspend_plan(RE, pre_plan, post_plan, expected_list, hw):
     sig = hw.bool_sig

--- a/docs/source/api_changes.rst
+++ b/docs/source/api_changes.rst
@@ -2,6 +2,11 @@
  Release History
 =================
 
+v1.9.0 (2022-XX-YY)
+===================
+
+* the `"resume"` message which can only be used internally has been renamed to
+  `"_resume_from_suspender"`.
 
 v1.8.3 (2022-04-08)
 ===================


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

While looking at the #1501 and friends we had questions about if we needed to protect possible I/O with locks.  This refactors that code so that we do not need a lock.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Suspenders work by injecting (a bunch of ) plans onto the plan stack (why not just one you ask....that is a very good question...~for a later date~ the last commit in this PR).

Previously the sync function (called from the Suspenders classes from a background thread (in the case of ophyd the ophyd trampoline thread)) would create a task that would then muck about to add the plans to the plan stack, do any rewinding, set up the wait etc.  If we were to put any awaits in this coroutine than there is a chance that the `_run` task would get time again and we would end up in a possibly inconsistent state!

This refactor moves all of the work to modify the plan stack into a coroutine which is added to the plan stack in the prior co-routine and then does it the set up.  It will be safe to run any I/O related async calls in this new co-routine as it is being awaited in the `_run` loop!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Because there is an extra message some of the tests did have to be modified.  The test suite caught many bugs in the early drafts of this PR.
