### PR TITLE
Fix LiveScatter bug by storing x and y limits as attributes

### DIFF
--- a/bluesky/callbacks/mpl_plotting.py
+++ b/bluesky/callbacks/mpl_plotting.py
@@ -358,12 +358,12 @@ class LiveScatter(QtAwareCallback):
         self.sc.set_array(np.asarray(self._Idata))
 
         if self.xlim is None:
-            minx, maxx = np.minimum(x, self._minx), np.maximum(x, self._maxx)
-            self.ax.set_xlim(minx, maxx)
+            self._minx, self._maxx = np.minimum(x, self._minx), np.maximum(x, self._maxx)
+            self.ax.set_xlim(self._minx, self._maxx)
 
         if self.ylim is None:
-            miny, maxy = np.minimum(y, self._miny), np.maximum(y, self._maxy)
-            self.ax.set_ylim(miny, maxy)
+            self._miny, self._maxy = np.minimum(y, self._miny), np.maximum(y, self._maxy)
+            self.ax.set_ylim(self._miny, self._maxy)
 
         if self.clim is None:
             clim = np.nanmin(self._Idata), np.nanmax(self._Idata)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If no axis limits are given, the value of x and y min and max are updated using an attribute of the instance instead of a local variable. This ensures they update correctly as new data is added. 

## Motivation and Context
LiveScatter was not correctly updating axis limits when they were not pre-defined. 

## How Has This Been Tested?
The current unit tests lock the axes, but adding a test here seemed irrelevant considering this is a visual question.
I ran this script to satisfy my curiosity.  If we need a test like `test_live_scatter_axlim` that adds data to the plot then gets the ax limits we could do that, but it seems like a test that just reproduces code. 

```python
  cb = LiveScatter("m1", "m2", "det")
  cb.start({})
  points = [(0, 0, 0), (-5, -5, 10), (1, 1, -2), (5, 5, -5)]
  for point in points:
      x, y, z = point
      doc = {"data": {"m1": x, "m2": y, "det": z}}
      cb.event(doc)
      input("Waiting")
```

<!--
## Screenshots (if appropriate):
-->
