### PR TITLE
FIX: make trigger and read careful

### DIFF
--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -914,17 +914,17 @@ def trigger_and_read(devices, name='primary'):
                     ret.update(reading)
             return ret
 
-        def happy_path():
+        def standard_path():
             yield from save()
 
-        def sad_path(exp):
+        def exception_path(exp):
             yield from drop()
             raise exp
 
         ret = yield from contingency_wrapper(
             read_plan(),
-            except_plan=sad_path,
-            else_plan=happy_path
+            except_plan=exception_path,
+            else_plan=standard_path
             )
         return ret
 

--- a/bluesky/tests/test_plans.py
+++ b/bluesky/tests/test_plans.py
@@ -4,6 +4,7 @@ import inspect
 from bluesky.tests.utils import DocCollector
 import bluesky.plans as bp
 import bluesky.plan_stubs as bps
+import bluesky.preprocessors as bpp
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
@@ -663,14 +664,53 @@ def test_describe_failure(RE):
     ophyd = pytest.importorskip("ophyd")
 
     class Aardvark(Exception):
-    # Unique exception to test behavior of describe.
+        # Unique exception to test behavior of describe.
         ...
 
-    class BadSignal(ophyd.Signal):
+    class BadSignalDescribe(ophyd.Signal):
         def describe(self):
             raise Aardvark("Look, an aardvark!")
 
-    bad_signal = BadSignal(value=5, name="Arty")
+    class BadSignalRead(ophyd.Signal):
+        def read(self):
+            raise Aardvark("Look, the other aardvark!")
 
+    bad_signal1 = BadSignalDescribe(value=5, name="Arty")
+    bad_signal2 = BadSignalRead(value=5, name="Arty")
+    good_signal = ophyd.Signal(value=42, name='baseline')
+
+    class StreamTester:
+        def __init__(self):
+            self.event_count = 0
+            self.stream_names = set()
+
+        def __call__(self, name, doc):
+            if name == 'event':
+                self.event_count += 1
+            if name == 'descriptor':
+                self.stream_names.add(doc['name'])
+
+        def verify(self):
+            assert self.event_count == 2
+            assert self.stream_names == set(['baseline'])
+    st = StreamTester()
     with pytest.raises(Aardvark, match="Look, an aardvark!"):
-        RE(bp.count([bad_signal]))
+        RE(
+            bpp.baseline_wrapper(
+                bp.count([bad_signal1]),
+                [good_signal]
+            ),
+            st
+        )
+    st.verify()
+
+    st = StreamTester()
+    with pytest.raises(Aardvark, match="Look, the other aardvark!"):
+        RE(
+            bpp.baseline_wrapper(
+                bp.count([bad_signal2]),
+                [good_signal]
+            ),
+            st
+        )
+    st.verify()

--- a/bluesky/tests/test_plans.py
+++ b/bluesky/tests/test_plans.py
@@ -663,13 +663,14 @@ def test_describe_failure(RE):
     ophyd = pytest.importorskip("ophyd")
 
     class Aardvark(Exception):
+    # Unique exception to test behavior of describe.
         ...
 
     class BadSignal(ophyd.Signal):
         def describe(self):
-            raise Aardvark("Look, and aardvark!")
+            raise Aardvark("Look, an aardvark!")
 
     bad_signal = BadSignal(value=5, name="Arty")
 
-    with pytest.raises(Aardvark, match="Look, and aardvark!"):
+    with pytest.raises(Aardvark, match="Look, an aardvark!"):
         RE(bp.count([bad_signal]))

--- a/bluesky/tests/test_plans.py
+++ b/bluesky/tests/test_plans.py
@@ -657,3 +657,19 @@ def test_grid_scans_failing(RE, hw, plan):
                     hw.motor1, 4, 5, 6,
                     hw.motor2, 7, 8, 9)
             RE(plan([hw.det], *args, snake_axes=snake_axes))
+
+
+def test_describe_failure(RE):
+    ophyd = pytest.importorskip("ophyd")
+
+    class Aardvark(Exception):
+        ...
+
+    class BadSignal(ophyd.Signal):
+        def describe(self):
+            raise Aardvark("Look, and aardvark!")
+
+    bad_signal = BadSignal(value=5, name="Arty")
+
+    with pytest.raises(Aardvark, match="Look, and aardvark!"):
+        RE(bp.count([bad_signal]))


### PR DESCRIPTION
## Description

Previously we would get confusing errors when:

  - event had been opened
  - read or describe raise any errors once
  - a wrapper (such as the baseline pre-processor) tries to take a reading as
  part of plan clean up

The error would be that you could not open an event with an event open which
would effectively drop the original error (the one you actually need to debug
the issue!) on the floor.

This could also be fixed by improving the multi-exception handling in the RE,
but this is a simpler fix.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

These errors are among the most confusing.  I helped @maffettone debug one of these today and finally got my act together to write this patch.

The fix is to make sure that `trigger_and_read` never leaves an event "open" when it returns control to its caller.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added a test.