### PR TITLE
ENH: allow the contingency wrapper to eat exceptions

### DIFF
--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -533,7 +533,8 @@ def contingency_wrapper(plan, *,
                         except_plan=None,
                         else_plan=None,
                         final_plan=None,
-                        pause_for_debug=False):
+                        pause_for_debug=False,
+                        auto_raise=True):
     '''try...except...else...finally helper
 
     See :func:`finalize_wrapper` for a simplified but less powerful
@@ -559,6 +560,7 @@ def contingency_wrapper(plan, *,
     pause_for_debug : bool, optional
         If the plan should pause before running the clean final_plan in
         the case of an Exception.  This is intended as a debugging tool only.
+    auto_raise : bool, optional
 
     Yields
     ------
@@ -582,8 +584,13 @@ def contingency_wrapper(plan, *,
         if except_plan:
             # it might be better to throw this in, but this is simpler
             # to implement for now
-            yield from except_plan(e)
-        raise
+            ret = yield from except_plan(e)
+            if auto_raise:
+                raise
+            else:
+                return ret
+        else:
+            raise
     else:
         if else_plan:
             yield from else_plan()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add an option to contingency_wrapper to not automatically re-raise if the except plan returns a value rather than raising its own exception.

We have to do this with a flag like this for back-compatibility reasons

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


We (I) made a design mistake with `contingency_wrapper` because there is no way to actually suppress the exception.  The reason we wrote this wrapper (and finalize wrapper) is to keep users from having to understand the extra set of constraints around the cancel and generator exit exceptions so this omission defeats the point.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Needs tests! 

<!--
## Screenshots (if appropriate):
-->
