### PR TITLE
Bad comparison created too many axes for plots

### DIFF
--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -245,7 +245,7 @@ class BestEffortCallback(QtAwareCallback):
                     layout = (len(columns), 1)
                 else:
                     nrows = ncols = int(np.ceil(np.sqrt(len(columns))))
-                    while (nrows - 1) * ncols > len(columns):
+                    while (nrows - 1) * ncols >= len(columns):
                         nrows -= 1
                     layout = (nrows, ncols)
                 if ndims == 1:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change the logic to create enough axes but not too many in the grid. `>=` instead of `>`. 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The logic here produces a 3x3 grid for 6 plots instead of a 2x3 grid. This is exceptionally problematic for these intervals, because there will be no x-axis labels with the shared axes, since the entire bottom row will have `visible = False`.
Adjusting the logic will create enough plots. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I am guilty of not using the `tests/interactive/best_effor_cb.py` because of errors with old versions of databroker. 
I did run this sanity check to make sure the logic would always produce enough axes, and that removing a full row would create an invalid figure with not enough axes (therefore is necessary). 
```python
import numpy as np
for l in range(5, 20):
    nrows = ncols = int(np.ceil(np.sqrt(l)))
    while (nrows-1) * ncols >= l:
        nrows -= 1
    assert(nrows*ncols >=l)
    assert(nrows*ncols - ncols < l)
```


## Screenshots
Before
![Before](https://user-images.githubusercontent.com/43007690/179813373-1a74eb38-f110-4c18-87f6-49b52e3303c1.png)

After
![After](https://user-images.githubusercontent.com/43007690/179813306-743ae01f-fb2d-4cf6-ab66-7644a8086c92.png)

