### PR TITLE
FIX: register the user's passed in event loop

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -355,7 +355,7 @@ class RunEngine:
                  during_task=None, call_returns_result=False):
         if loop is None:
             loop = asyncio.new_event_loop()
-            set_bluesky_event_loop(loop)
+        set_bluesky_event_loop(loop)
         self._th = _ensure_event_loop_running(loop)
         self._state_lock = threading.RLock()
         self._loop = loop


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In `RunEngine`'s `__init__`, make sure a user-supplied event loop is also registered.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some utilities in `bluesky` like `check_limits` require the `bluesky` event loop to be set, but it doesn't get set for users who supply their own event loop. A user who does this will get a cryptic "Bluesky event loop not running" error in these cases.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Makes my repo's tests pass again (was passing pre-v1.9.0), I didn't check against bluesky's internal tests.

<!--
## Screenshots (if appropriate):
-->
