### PR TITLE
Use multiplied cyclers for non-snaked axes

### DIFF
--- a/bluesky/utils/__init__.py
+++ b/bluesky/utils/__init__.py
@@ -613,6 +613,8 @@ def snake_cyclers(cyclers, snake_booleans):
     """
     if len(cyclers) != len(snake_booleans):
         raise ValueError("number of cyclers does not match number of booleans")
+    if not any(snake_booleans[1:]):
+        return reduce(operator.mul, cyclers)
     lengths = []
     new_cyclers = []
     for c in cyclers:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This short circuits the `snake_cyclers` method in `utils` to use the equivalent multiplied cyclers when there is no snaking.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is primarily a memory usage consideration.
The cycler object represented by multiplied cyclers is much smaller than the fully expanded cycler (which is equivalent) that this method currently produces.
Even for some modestly sized scans such as (11, 101, 101), the full cycler produced was eating hundreds of MB of RAM when all of the data was repeated anyway.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->

The existing snaking tests already do exactly what I would want to do to test this: ensure that the output is as expected.

