### PR TITLE
FIX: LiveGrids placing x-axis tick labels on all columns

### DIFF
--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -224,9 +224,15 @@ class BestEffortCallback(QtAwareCallback):
 
                 fig_size = np.array(layout[::-1]) * 5
                 fig.set_size_inches(*fig_size)
-                fig.subplots(*map(int, layout), **share_kwargs)
+                axes_grid = fig.subplots(*map(int, layout), **share_kwargs)
                 for ax in fig.axes[len(columns):]:
                     ax.set_visible(False)
+
+                if len(axes_grid.shape) == 2:
+                    # Axes go left to right, top to bottom, and will make some labels invisible
+                    for i in range(int(layout[1])):
+                        if axes_grid[-1, i].get_visible() is False:
+                            axes_grid[-2, i].tick_params(axis="x", labelbottom=True)
 
             axes = fig.axes
 

--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -228,7 +228,7 @@ class BestEffortCallback(QtAwareCallback):
                 for ax in fig.axes[len(columns):]:
                     ax.set_visible(False)
 
-                if len(axes_grid.shape) == 2:
+                if len(fig.axes) > 1 and len(axes_grid.shape) == 2:
                     # Axes go left to right, top to bottom, and will make some labels invisible
                     for i in range(int(layout[1])):
                         if axes_grid[-1, i].get_visible() is False:

--- a/bluesky/tests/test_bec.py
+++ b/bluesky/tests/test_bec.py
@@ -96,6 +96,25 @@ def test_live_grid(RE, hw):
     RE(grid_scan([hw.det4], hw.motor1, 0, 1, 1, hw.motor2, 0, 1, 2, True))
 
 
+def test_many_grids(RE, hw):
+    bec = BestEffortCallback()
+    RE.subscribe(bec)
+    RE(grid_scan([hw.det1, hw.det2, hw.det3, hw.det4, hw.det5], hw.motor1, 0, 1, 1, hw.motor2, 0, 1, 2, True))
+    # Exactly 3 Live plots should have x tick labels in a 3 column grid
+    assert sum([bool(lg.ax.get_xticklabels()) for lg in list(bec._live_grids.values())[0].values()]) == 3
+    # Exactly 5 axes should be visible of the 6 in the figure (ignoring color bars)
+    assert (
+        sum(
+            [
+                bool(ax.get_visible())
+                for ax in list(list(bec._live_grids.values())[0].values())[0].ax.figure.axes
+                if ax.get_label() != "<colorbar>"
+            ]
+        )
+        == 5
+    )
+
+
 def test_push_start_document(capsys):
     """ Pass the start document to BEC and verify if the scan information is printed correctly"""
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Making sure each column of live grids in the BEC have x-tick labels. This is not an issue for rows since the plots in the square grid are filled top to bottom, left to right. 

## Description
<!--- Describe your changes in detail -->
Add a section on sanity checking for 2d grids of plots. This prevents the bottom row from producing an invisible axis, then leaving a column with no x-tick labels. 
Followed the documentation suggestion from https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.subplots.html, and made the adjustments post-hoc using `tick_params`. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
CSX beamline likes to plot lots of detectors at once. 
https://jira.nsls2.bnl.gov/browse/SXSS-205

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests were added for checking the number of total visible plots and the axis tick label visibility. 

<!--
## Screenshots (if appropriate):
-->
