### PR TITLE
ENH: add resume thresholds to suspender justification message

### DIFF
--- a/bluesky/suspenders.py
+++ b/bluesky/suspenders.py
@@ -377,12 +377,14 @@ class SuspendFloor(_Threshold):
         if not self.tripped:
             return ''
 
-        just = ('Signal {} = {!r} is below {}'
-                ''.format(self._sig.name, self._sig.get(),
-                          self._suspend_thresh)
-                )
-        return ': '.join(s for s in (just, self._tripped_message)
-                         if s)
+        just = (
+            f'Signal {self._sig.name} = {self._sig.get()!r} ' +
+            f'fell below {self._suspend_thresh} ' +
+            f'and has not yet crossed above {self._resume_thresh}.'
+        )
+        return ': '.join(
+            s for s in (just, self._tripped_message) if s
+        )
 
 
 class SuspendCeil(_Threshold):
@@ -431,12 +433,14 @@ class SuspendCeil(_Threshold):
         if not self.tripped:
             return ''
 
-        just = ('Signal {} = {!r} is above {}'
-                ''.format(self._sig.name, self._sig.get(),
-                          self._suspend_thresh)
-                )
-        return ': '.join(s for s in (just, self._tripped_message)
-                         if s)
+        just = (
+            f'Signal {self._sig.name} = {self._sig.get()!r} ' +
+            f'went above {self._suspend_thresh} ' +
+            f'and has not yet crossed below {self._resume_thresh}.'
+        )
+        return ': '.join(
+            s for s in (just, self._tripped_message) if s
+        )
 
 
 class _SuspendBandBase(SuspenderBase):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adds more context to the justification emitted by the suspenders.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Not including the resume condition lead beamline staff to become concerned we were doing "new math".

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Covered by existing test cases, however we do no check the contents of stdout, disabling capture and running the tests locally gives

```
.Suspending....To get prompt hit Ctrl-C twice to pause.
Suspension occurred at 2022-12-08 13:25:32.
Justification for this suspension:
Signal bool_sig = 0 fell below 0.5 and has not yet crossed above 0.5.
Suspender SuspendFloor(Signal(name='bool_sig', value=1, timestamp=1670523933.1577613), sleep=0.2, pre_plan=None, post_plan=None,tripped_message=) reports a return to nominal conditions. Will sleep for 0.2 seconds and then release suspension at 2022-12-08 13:25:33.
0.9057326316833496
.Suspending....To get prompt hit Ctrl-C twice to pause.
Suspension occurred at 2022-12-08 13:25:33.
Justification for this suspension:
Signal bool_sig = 1 went above 0.5 and has not yet crossed below 0.5.
Suspender SuspendCeil(Signal(name='bool_sig', value=0, timestamp=1670523934.2849662), sleep=0.2, pre_plan=None, post_plan=None,tripped_message=) reports a return to nominal conditions. Will sleep for 0.2 seconds and then release suspension at 2022-12-08 13:25:34.
0.9056258201599121
```

<!--
## Screenshots (if appropriate):
-->
