### PR TITLE
ENH: make stage and unstage return status objects

### DIFF
--- a/bluesky/protocols.py
+++ b/bluesky/protocols.py
@@ -341,22 +341,20 @@ class Stageable(Protocol):
     # TODO: we were going to extend these to be able to return plans, what
     # signature should they have?
     @abstractmethod
-    def stage(self) -> List[Any]:
+    def stage(self) -> Union[Status, List[Any]]:
         """An optional hook for "setting up" the device for acquisition.
 
-        It should return a list of devices including itself and any other
-        devices that are staged as a result of staging this one.
-        (The ``parent`` attribute expresses this relationship: a device should
-        be staged/unstaged whenever its parent is staged/unstaged.)
+        It should return a ``Status`` that is marked done when the device is
+        done staging.
         """
         ...
 
     @abstractmethod
-    def unstage(self) -> List[Any]:
+    def unstage(self) -> Union[Status, List[Any]]:
         """A hook for "cleaning up" the device after acquisition.
 
-        It should return a list of devices including itself and any other
-        devices that are unstaged as a result of unstaging this one.
+        It should return a ``Status`` that is marked done when the device is finished
+        unstaging.
         """
         ...
 


### PR DESCRIPTION
Let stage and unstage return Status objects, so multiple objects can be staged at once.

## Description

I have made changes to  `_stage` and `_unstage` to allow Stageables to return status objects from their stage and unstage methods. The changes mimic `_trigger`. 

I have changed the type hints on the Stageable protocol.

I have created a test for staging 2 Stageables at once.  

I have also changed the plan stubs accordingly.

## Motivation and Context

resolves #1559 

This change will allow the run engine to stage multiple devices without blocking. And these can then be awaited but a wait message.

## How Has This Been Tested?

These changes have been tested by a new test `test_stage_and_unstage_status_objects()`.
Which stages/unstages 2 dummy Stageables then awaits their completion.

The new `_stage` and `_unstage` methods use `isinstance()` to check to see if the output of an objects stage/unstage method is a status object. If it is not they will return the result preserving previous behaviour for Stageables that returns lists of staged objects.
