### PR TITLE
DEP: remove deprecated get_event_loop()

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -2645,8 +2645,7 @@ def set_bluesky_event_loop(loop):
 
 def in_bluesky_event_loop() -> bool:
     try:
-        # TODO: change to asyncio.get_running_loop() when we drop py3.6
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
     except RuntimeError:
         # Ok, no running loop
         return False


### PR DESCRIPTION
Removing deprecated get_event_loop() as py3.6 has been dropped 

## Description
get_event_loop() changed to get_running_loop()

## Motivation and Context
py3.6 has been dropped 

## How Has This Been Tested?
All unit tests pass locally. In a python 3.9.1 venv.

