### PR TITLE
DEP: remove loop param from AsyncInput in bluesky.utils

### DIFF
--- a/bluesky/utils/__init__.py
+++ b/bluesky/utils/__init__.py
@@ -1049,7 +1049,10 @@ class AsyncInput:
     """
     def __init__(self, loop=None):
         self.loop = loop or asyncio.get_event_loop()
-        self.q = asyncio.Queue(loop=self.loop)
+        if sys.version_info < (3, 10):
+            self.q = asyncio.Queue(loop=self.loop)
+        else:
+            self.q = asyncio.Queue()
         self.loop.add_reader(sys.stdin, self.got_input)
 
     def got_input(self):


### PR DESCRIPTION
See #1550

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Instantiation of asyncio.Queue in bluesky/utils is changed from the following aproach:
https://github.com/bluesky/bluesky/blob/a60e5c7323a61b9a988ce9f8d1b4d7f4ac495ee8/bluesky/utils/__init__.py#L1052
to the following conditional approach:
```py
        if sys.version_info < (3, 10):
            self.q = asyncio.Queue(loop=self.loop)
        else:
            self.q = asyncio.Queue()
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The problematic syntax used in bluesky's async input implementation has been raised as an issue here: #1550. This patch is an attempt to fix the issue.

Synchronization primitives such as `asyncio.Queue` in python 3.10+ no longer accept a *loop* parameter at instantiation. Instead, new primitives internally use a thread-safe mechanism to capture the current *loop* on await (see [discussion](https://github.com/python/cpython/issues/86558) for more details). This patch updates Queue instantiation to match the expected syntax in python 3.8, 3.9, 3.10.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A full unit test on python 3.8, 3.9, and 3.10 [passed](https://github.com/hyperrealist/bluesky/actions/runs/4133422888). Note: the unit test were performed on a separate [branch based on this topic branch](hyperrealist/bluesky/tree/unit_test) with a slightly modified workflow (modification: added a `workflow_dispatch` to [testing.yml](https://github.com/hyperrealist/bluesky/blob/c21704061bbd65ca501bcda48929c103753041c5/.github/workflows/testing.yml#L4) in order to manually trigger a unit test. Reason: github did not trigger an automatic unit test on push).

Moreover, bluesky.utils [adapts](https://github.com/bluesky/bluesky/blob/72ea2473359e3020a27f4338bad5446534dc7d02/bluesky/utils/__init__.py#L1048) async input implementation from http://stackoverflow.com/a/35514777/1221924 (which has since been updated to python 3.10 syntax). I manually tested the original example, but with the same proposed fix. All manual tests on python versions 3.6, 3.7, 3.8, 3.9, 3.10 (using separate conda environments) were successful.
<!--
## Screenshots (if appropriate):
-->
