### PR TITLE
MNT: move fig_factory default resolution in BestEffortCallback

### DIFF
--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -39,7 +39,7 @@ class BestEffortCallback(QtAwareCallback):
         self._baseline_enabled = True
         self._plots_enabled = True
         # axes supplied from outside
-        self._fig_factory = fig_factory
+        self._fig_factory = fig_factory if fig_factory is not None else plt.figure
         # maps descriptor uid to dict which maps data key to LivePlot instance
         self._live_plots = {}
         self._live_grids = {}
@@ -202,10 +202,7 @@ class BestEffortCallback(QtAwareCallback):
                      "Adjust the metadata hints field for BestEffortCallback to produce plots.")
                 return
 
-            if self._fig_factory:
-                fig = self._fig_factory(fig_name)
-            else:
-                fig = plt.figure(fig_name)
+            fig = self._fig_factory(fig_name)
 
             if not fig.axes:
                 if len(columns) < 5:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Move the resolution of the default figure factory in BestEffortCallback to the `__init__` from its call site.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

General cleanup, doing this early is better than doing this late (and every time).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

CI

<!--
## Screenshots (if appropriate):
-->
