### PR TITLE
FIX: Remove callable from plan signature for qserver

### DIFF
--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -1133,7 +1133,7 @@ def caching_repeater(n, plan):
         yield from (m for m in lst_plan)
 
 
-def one_shot(detectors, take_reading=trigger_and_read):
+def one_shot(detectors, take_reading=None):
     """Inner loop of a count.
 
     This is the default function for ``per_shot`` in count plans.
@@ -1153,11 +1153,12 @@ def one_shot(detectors, take_reading=trigger_and_read):
 
         Defaults to `trigger_and_read`
     """
+    take_reading = trigger_and_read if take_reading is None else take_reading
     yield Msg('checkpoint')
     yield from take_reading(list(detectors))
 
 
-def one_1d_step(detectors, motor, step, take_reading=trigger_and_read):
+def one_1d_step(detectors, motor, step, take_reading=None):
     """
     Inner loop of a 1D step scan
 
@@ -1181,6 +1182,8 @@ def one_1d_step(detectors, motor, step, take_reading=trigger_and_read):
 
         Defaults to `trigger_and_read`
     """
+    take_reading = trigger_and_read if take_reading is None else take_reading
+
     def move():
         grp = _short_uid('set')
         yield Msg('checkpoint')
@@ -1215,7 +1218,7 @@ def move_per_step(step, pos_cache):
     yield Msg('wait', None, group=grp)
 
 
-def one_nd_step(detectors, step, pos_cache, take_reading=trigger_and_read):
+def one_nd_step(detectors, step, pos_cache, take_reading=None):
     """
     Inner loop of an N-dimensional step scan
 
@@ -1239,6 +1242,7 @@ def one_nd_step(detectors, step, pos_cache, take_reading=trigger_and_read):
 
         Defaults to `trigger_and_read`
     """
+    take_reading = trigger_and_read if take_reading is None else take_reading
     motors = step.keys()
     yield from move_per_step(step, pos_cache)
     yield from take_reading(list(detectors) + list(motors))

--- a/bluesky/tests/test_plans.py
+++ b/bluesky/tests/test_plans.py
@@ -163,7 +163,7 @@ def test_relative_pseudo(hw, RE, db):
     else:
         uid = rs[0]
 
-    tb1 = db[uid].table().drop('time', 1)
+    tb1 = db[uid].table().drop('time', axis=1)
     assert p.position == base_pos
 
     # this triggers this does not
@@ -176,7 +176,7 @@ def test_relative_pseudo(hw, RE, db):
     else:
         uid = rs[0]
 
-    tb2 = db[uid].table().drop('time', 1)
+    tb2 = db[uid].table().drop('time', axis=1)
     assert p.position == base_pos
 
     # same columns


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This removes the  explicit default `trigger_and_read` from the function definition signature.

## Description
<!--- Describe your changes in detail -->
Instead of the callable in the signature, the default is set to `None`, and then checked to replace with `trigger_and_read`. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This issue pops up when importing these plans into the startup files used by the queue-server. 
- `one_nd_step`
- `one_1d_step`
- `one_shot`



```
# [E 2023-04-01 17:25:38,999 bluesky_queueserver.manager.worker] Failed to start RE Worker environment. Error while loading startup code: Failed to create description of plan 'one_1d_step': Parameter 'take_reading': The expression (<function trigger_and_read at 0x7ff0ae7ab640>) can not be evaluated with 'ast.literal_eval()': unsupported type of default value..
# Traceback (most recent call last):
#   File "/nsls2/conda/envs/2023-1.3-py310-tiled/lib/python3.10/site-packages/bluesky_queueserver/manager/profile_ops.py", line 2582, in convert_expression_to_string
#     ast.literal_eval(s_value)
#   File "/nsls2/conda/envs/2023-1.3-py310-tiled/lib/python3.10/ast.py", line 64, in literal_eval
#     node_or_string = parse(node_or_string.lstrip(" \t"), mode='eval')
#   File "/nsls2/conda/envs/2023-1.3-py310-tiled/lib/python3.10/ast.py", line 50, in parse
#     return compile(source, filename, mode, flags,
#   File "<unknown>", line 1
#     <function trigger_and_read at 0x7ff0ae7ab640>
#     ^
# SyntaxError: invalid syntax
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Copied these new plans into a queserver test environment. 

<!--
## Screenshots (if appropriate):
-->
