### PR TITLE
Point at newly versioned event model docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -319,7 +319,7 @@ intersphinx_mapping = {
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable', None),
     'matplotlib': ('https://matplotlib.org/stable/', None),
     'ophyd': ('https://blueskyproject.io/ophyd/', None),
-    'event-model': ('https://blueskyproject.io/event-model/', None),
+    'event-model': ('https://blueskyproject.io/event-model/main', None),
   }
 
 sys.path.append(os.path.abspath("examples"))


### PR DESCRIPTION
## Description
When event model started writing versioned docs the path for intersphinx changed, this fixes it

## How Has This Been Tested?
Let's see if CI passes...
