### PR TITLE
removed with_traceback call

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -2225,7 +2225,7 @@ class RunEngine:
             with self._state_lock:
                 try:
                     exc = ret.exception(timeout=0)
-                    raise FailedStatus(ret).with_traceback(exc.__traceback__) from exc
+                    raise FailedStatus(ret) from exc
                 except Exception as e:
                     self._exception = e
         p_event.set()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Previously we had an exception being raised like so:

`raise FailedStatus(ret).with_traceback(ret.__traceback__) from exc`

It's been brought to my attention that this is redundant, so I've just removed the dunder method here.
