### PR TITLE
pinned zict to <3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ toolz
 tqdm>=4.44
 typing-extensions;python_version<'3.8'
 dataclasses;python_version<'3.7'
-zict
+zict<3.0.0


### PR DESCRIPTION
related to https://github.com/bluesky/bluesky/pull/1575

It was found that tests were failing due to a breaking change in zict. For now this is being pinned and an issue has been opened. This is just a temporary fix.