### PR TITLE
Use Python version check rather than import error check to import Protocol

### DIFF
--- a/bluesky/protocols.py
+++ b/bluesky/protocols.py
@@ -1,6 +1,8 @@
-try:
+import sys
+
+if sys.version_info < (3, 8):
     from typing_extensions import Literal, Protocol, TypedDict, runtime_checkable
-except ImportError:
+else:
     from typing import Literal, Protocol, TypedDict, runtime_checkable
 
 from asyncio import CancelledError

--- a/bluesky/protocols.py
+++ b/bluesky/protocols.py
@@ -1,18 +1,25 @@
-import sys
-
-if sys.version_info < (3, 8):
-    from typing_extensions import Literal, Protocol, runtime_checkable
-else:
-    from typing import Literal, Protocol, runtime_checkable
-
+from abc import abstractmethod
 from asyncio import CancelledError
 from typing import (
-    Any, Awaitable, Callable, Dict, Generic, Iterator, List, Optional,
-    Sequence, Tuple, Type, TypeVar, Union
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Generic,
+    Iterator,
+    List,
+    Literal,
+    Optional,
+    Protocol,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    runtime_checkable,
 )
-from typing_extensions import TypedDict
 
-from abc import abstractmethod
+from typing_extensions import TypedDict
 
 
 # TODO: these are not placed in Events by RE yet

--- a/bluesky/protocols.py
+++ b/bluesky/protocols.py
@@ -1,15 +1,16 @@
 import sys
 
 if sys.version_info < (3, 8):
-    from typing_extensions import Literal, Protocol, TypedDict, runtime_checkable
+    from typing_extensions import Literal, Protocol, runtime_checkable
 else:
-    from typing import Literal, Protocol, TypedDict, runtime_checkable
+    from typing import Literal, Protocol, runtime_checkable
 
 from asyncio import CancelledError
 from typing import (
     Any, Awaitable, Callable, Dict, Generic, Iterator, List, Optional,
     Sequence, Tuple, Type, TypeVar, Union
 )
+from typing_extensions import TypedDict
 
 from abc import abstractmethod
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ numpy
 super_state_machine
 toolz
 tqdm>=4.44
-typing-extensions;python_version<'3.8'
+typing-extensions
 dataclasses;python_version<'3.7'
 zict<3.0.0


### PR DESCRIPTION
Use a softer import mode for protocols

## Motivation and Context
The `Protocol` class is available in `typing_extensions` until Python3.8, when it becomes part of `typing`.
Currently, we try to import from `typing_extensions` and, if there is an error, assume we are in Python3.8 or higher and import from `typing`. This presents a problem if you are using Python3.8+ and still using `typing_extensions` for another purpose, then the import from `typing_extensions` will succeed. This can be a problem if you wish to subclass one of the protocols. This PR enforces always using `typing` if the Python version is greater than 3.8.

## How Has This Been Tested?
Checked protocol still imports.
CI passes
