### PR TITLE
Tweak Status.exception() protocol

### DIFF
--- a/bluesky/protocols.py
+++ b/bluesky/protocols.py
@@ -1,5 +1,4 @@
 from abc import abstractmethod
-from asyncio import CancelledError
 from typing import (
     Any,
     Awaitable,
@@ -131,8 +130,6 @@ Asset = Union[Tuple[Literal["resource"], PartialResource], Tuple[Literal["datum"
 T = TypeVar("T")
 SyncOrAsync = Union[T, Awaitable[T]]
 
-StatusException = Union[Exception, CancelledError]
-
 
 @runtime_checkable
 class Status(Protocol):
@@ -148,7 +145,7 @@ class Status(Protocol):
         ...
 
     @abstractmethod
-    def exception(self, timeout: Optional[float] = 0.0) -> Optional[StatusException]:
+    def exception(self, timeout: Optional[float] = 0.0) -> Optional[BaseException]:
         ...
 
     @property


### PR DESCRIPTION
## Description

Make it return `Optional[BaseException]` like `Future.exception()`

## Motivation and Context

So it's easier to make `ophyd.v2.core.AsyncStatus.exception` (as this is what `Task.exception()` returns)

