### PR TITLE
FIX: do not leak public token maps

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -2612,13 +2612,12 @@ class Dispatcher:
         --------
         :meth:`Dispatcher.subscribe`
         """
-        for private_token in self._token_mapping[token]:
+        for private_token in self._token_mapping.pop(token, []):
             self.cb_registry.disconnect(private_token)
 
     def unsubscribe_all(self):
-        """Unregister all callbacks from the dispatcher
-        """
-        for public_token in self._token_mapping.keys():
+        """Unregister all callbacks from the dispatcher."""
+        for public_token in list(self._token_mapping.keys()):
             self.unsubscribe(public_token)
 
     @property

--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -1833,3 +1833,14 @@ def test_thread_name(RE):
 
     d = MockDevice()
     RE([Msg("trigger", d)])
+
+
+def test_unsubscribe(RE):
+    def foo(name, doc):
+        ...
+
+    for j in range(15):
+        cid = RE.subscribe(foo)
+        RE.unsubscribe(cid)
+
+    assert len(RE.dispatcher._token_mapping) == 0


### PR DESCRIPTION
We were not removing the old public tokens on subscribe so the internal state would grow without bounds.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

@dmgav Noticed that the internal mapping between the public and private subscription tokens was never reduced in size

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We should not have unbounded caches!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added a test.

<!--
## Screenshots (if appropriate):
-->
