### PR TITLE
DOC clarify how to exit from a plan

### DIFF
--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -732,7 +732,8 @@ class RunEngine:
         Command the Run Engine to pause.
 
         This function is called by 'pause' Messages. It can also be called
-        by other threads. It cannot be called on the main thread during a run,
+        by other threads. It cannot be called on the main thread during a run
+        (in a plan, use ``yield from bps.pause()``),
         but it is called by SIGINT (i.e., Ctrl+C).
 
         If there current run has no checkpoint (via the 'clear_checkpoint'

--- a/docs/source/state-machine.rst
+++ b/docs/source/state-machine.rst
@@ -332,6 +332,19 @@ abort instead.
     actions that it is not safe to replay: staging a device, adding a
     monitor, or adding a subscription.
 
+.. caution::
+
+    This plan will exit the entire Python session immediately:
+
+    .. code-block:: python
+
+        import bluesky.plan_stubs as bps
+
+        def exit_python_session_now():
+            """Exit this Python session immediately."""
+            yield from bps.clear_checkpoint()  # this plan will not resume
+            yield from bps.pause()  # trigger the Python session to exit
+
 .. _planned_pauses:
 
 Planned Pauses


### PR DESCRIPTION
Sometimes during execution of a plan by the RunEngine, it is deemed essential that the Bluesky session must be terminated immediately in an orderly manner.  Describe these steps clearly.

## Description
Documentation was added to provide a plan that will stop the session both immediately and orderly, under the control of the RunEngine.

## Motivation and Context
APS beam lines (tomo, USAXS, depo lab) have requested instructions how to make an emergency stop of the entire session in response to some monitored conditions.  Previously, the `clear_checkpoint()` plan was added in response.  

The documentation of how to finish the task after calling `yield from clear_checkpoint()` was vague.

## How Has This Been Tested?

```py
"""
demo_orderly_exit.py

Demonstrate how to STOP and exit Python from a Bluesky suspender.

1. Set BIT_PV set to 0 before starting this code.
2. Start this code.
3. From a separate EPICS client, change BIT_PV to 1.  
   This will activate the suspender.  Subsequently, the Python session will exit
   with an exception trace.
   After the trace, the ``atexit`` handler is called.  That's where to put any
   final instructions.
"""

from bluesky import RunEngine
from bluesky import plan_stubs as bps
from bluesky.suspenders import *
from ophyd import EpicsSignalRO
import atexit

BIT_PV = "gp:gp:bit1"  # Some bo PV
RE = RunEngine()


def pre_response(*args, **kwargs):
    print(f"pre_response(): {args=}  {kwargs=}")
    print("request clear_checkpoint()")
    yield from bps.clear_checkpoint()
    print(f"pre pause(): {RE.state=}")
    yield from bps.pause()
    print(f"post pause(): {RE.state=}")


def exit_notice(*args, **kwargs):
    print("Python session has ended.  Ignore the errors.  EXPLAIN further...")


bit = EpicsSignalRO(BIT_PV, name="bit")
bit.wait_for_connection()
suspender = SuspendBoolHigh(
    bit, pre_plan=pre_response, tripped_message="This suspender will not resume."
)
RE.install_suspender(suspender)
atexit.register(exit_notice)


def loop_forever():
    "a silly plan"
    while True:
        print(f"Hi")
        yield from bps.sleep(1)


# Execute the plan.
RE(loop_forever())
```