### PR TITLE
FIX: make sure declared but empty streams report 0 length

### DIFF
--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -1573,7 +1573,7 @@ def test_num_events(RE, hw, db):
     else:
         uid1 = rs1[0]
     h = db[uid1]
-    assert h.stop['num_events'] == {}
+    assert h.stop['num_events'] == {'primary': 0}
 
     rs2 = RE(count([hw.det], 5))
     if RE.call_returns_result:
@@ -1592,7 +1592,7 @@ def test_num_events(RE, hw, db):
     else:
         uid3 = rs3[0]
     h = db[uid3]
-    assert h.stop['num_events'] == {'baseline': 2}
+    assert h.stop['num_events'] == {'baseline': 2, 'primary': 0}
 
     rs4 = RE(count([hw.det], 5))
     if RE.call_returns_result:
@@ -1833,3 +1833,12 @@ def test_thread_name(RE):
 
     d = MockDevice()
     RE([Msg("trigger", d)])
+
+
+def test_empty_streams(RE):
+    docs = []
+    RE.subscribe(lambda name, doc: docs.append((name, doc)))
+    RE(count([]))
+    *head, (name, doc) = docs
+    assert name == 'stop'
+    assert doc['num_events'] == {'primary': 0}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If the stream is declared (via pre-declare) but never populated report that it has 0 events in the stop documents (rather than just memory-holing it and not including an entry).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If there is a descriptor doc it should show up in the list of streams in the stop document.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added test (and manually tested).


<!--
## Screenshots (if appropriate):
-->
