### PR TITLE
MNT: use constrained rather than tight layout

### DIFF
--- a/bluesky/callbacks/best_effort.py
+++ b/bluesky/callbacks/best_effort.py
@@ -5,6 +5,7 @@
 '''
 from cycler import cycler
 from datetime import datetime
+from functools import partial
 from io import StringIO
 import itertools
 import numpy as np
@@ -39,7 +40,9 @@ class BestEffortCallback(QtAwareCallback):
         self._baseline_enabled = True
         self._plots_enabled = True
         # axes supplied from outside
-        self._fig_factory = fig_factory if fig_factory is not None else plt.figure
+        self._fig_factory = (
+            fig_factory if fig_factory is not None else partial(plt.figure, layout='constrained')
+        )
         # maps descriptor uid to dict which maps data key to LivePlot instance
         self._live_plots = {}
         self._live_grids = {}
@@ -324,10 +327,6 @@ class BestEffortCallback(QtAwareCallback):
             else:
                 raise NotImplementedError("we do not support 3D+ in BEC yet "
                                           "(and it should have bailed above)")
-            try:
-                fig.tight_layout()
-            except ValueError:
-                pass
 
     def descriptor(self, doc):
         self._descriptors[doc['uid']] = doc

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ ipython
 ipywidgets
 jinja2
 lmfit
-matplotlib != 3.0.1  # bug in scatter method
+matplotlib >=3.5.0
 mongoquery
 mypy
 networkx


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes a documentation failure due to mpl 3.7.2 warning on repeated calls to `fig.tight_layout` (https://github.com/matplotlib/matplotlib/issues/26290 / 
 https://github.com/matplotlib/matplotlib/pull/26300).

This drops our use of `fig.tight_layout()` in favor of using constrained layout.

This puts a floor on our Matplotlib support at 3.5.0 (Nov 2021) when the `layout` kwarg was added.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes a doc build failure found by @evalott100 .  The docs build is failing on the current default branch, this fixes the docs build.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

existing tests + docs pass.

<!--
## Screenshots (if appropriate):
-->
