### PR TITLE
Add child protocol

### DIFF
--- a/bluesky/protocols.py
+++ b/bluesky/protocols.py
@@ -3,18 +3,29 @@ try:
 except ImportError:
     from typing import Literal, Protocol, TypedDict, runtime_checkable
 
+from abc import abstractmethod
 from asyncio import CancelledError
 from typing import (
-    Any, Awaitable, Callable, Dict, Generic, Iterator, List, Optional,
-    Sequence, Tuple, Type, TypeVar, Union
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Generic,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
 )
-
-from abc import abstractmethod
 
 
 # TODO: these are not placed in Events by RE yet
 class ReadingOptional(TypedDict, total=False):
     """A dictionary containing the optional per-reading metadata of a piece of scan data"""
+
     #: * -ve: alarm unknown, e.g. device disconnected
     #: * 0: ok, no alarm
     #: * +ve: there is an alarm
@@ -27,6 +38,7 @@ class ReadingOptional(TypedDict, total=False):
 
 class Reading(ReadingOptional):
     """A dictionary containing the value and timestamp of a piece of scan data"""
+
     #: The current value, as a JSON encodable type or numpy array
     value: Any
     #: Timestamp in seconds since the UNIX epoch
@@ -40,6 +52,7 @@ Dtype = Literal["string", "number", "array", "boolean", "integer"]
 # Just the data_key definition
 class DescriptorOptional(TypedDict, total=False):
     """A dictionary containing optional per-scan metadata of a series of Readings"""
+
     #: Where the data is stored if it is stored external to the events
     external: str
     #: The names for dimensions of the data. Empty list if scalar data
@@ -54,6 +67,7 @@ class DescriptorOptional(TypedDict, total=False):
 
 class Descriptor(DescriptorOptional):
     """A dictionary containing the source and datatype of a series of Readings"""
+
     #: The source of the data, e.g. an EPICS Process Variable
     source: str
     #: The JSON type of the data in the event. Deprecated for dtype_str
@@ -67,6 +81,7 @@ class Descriptor(DescriptorOptional):
 # But exclude descriptor, seq_num, uid added by RE
 class PartialEventOptional(TypedDict, total=False):
     """A dictionary containing optional Event data"""
+
     #: If any data key is in an external asset it should be present in this
     #: dictionary with value False
     filled: Dict[str, bool]
@@ -74,6 +89,7 @@ class PartialEventOptional(TypedDict, total=False):
 
 class PartialEvent(PartialEventOptional):
     """A dictionary containing Event data"""
+
     #: The event data for each data key
     data: Dict[str, Any]
     #: The timestamps for each data key
@@ -86,12 +102,14 @@ class PartialEvent(PartialEventOptional):
 # But exclude run_start added by RE
 class PartialResourceOptional(TypedDict, total=False):
     """A dictionary containing optional information needed to load an external resource"""
+
     #: Whether the path is a posix or windows path. If not given default to posix
     path_semantics: Literal["posix", "windows"]
 
 
 class PartialResource(TypedDict):
     """A dictionary containing information needed to load an external resource"""
+
     #: Hint about the format of the resource, and how it should be loaded
     spec: str
     #: Relative path, should not change over lifecycle of the resource
@@ -108,6 +126,7 @@ class PartialResource(TypedDict):
 # https://github.com/bluesky/event-model/blob/master/event_model/schemas/datum.json
 class Datum(TypedDict):
     """A dictionary containing information to load event data from a Resource"""
+
     #: The UID of a Resource
     resource: str
     #: UID that can be referenced in an Event
@@ -116,7 +135,9 @@ class Datum(TypedDict):
     datum_kwargs: Dict[str, Any]
 
 
-Asset = Union[Tuple[Literal["resource"], PartialResource], Tuple[Literal["datum"], Datum]]
+Asset = Union[
+    Tuple[Literal["resource"], PartialResource], Tuple[Literal["datum"], Datum]
+]
 
 T = TypeVar("T")
 SyncOrAsync = Union[T, Awaitable[T]]
@@ -178,6 +199,17 @@ class HasParent(Protocol):
 
 
 @runtime_checkable
+class HasChildren(Protocol):
+    @abstractmethod
+    def children(self) -> Iterator[Tuple[str, Any]]:
+        """``None``, or an iterator returning a tuple of str, Any.
+
+        each tuple contains the name of the child, and the reference to it.
+        """
+        ...
+
+
+@runtime_checkable
 class WritesExternalAssets(Protocol):
     @abstractmethod
     def collect_asset_docs(self) -> Iterator[Asset]:
@@ -229,8 +261,7 @@ class Configurable(Protocol):
 class Triggerable(Protocol):
     @abstractmethod
     def trigger(self) -> Status:
-        """Return a ``Status`` that is marked done when the device is done triggering.
-        """
+        """Return a ``Status`` that is marked done when the device is done triggering."""
         ...
 
 
@@ -287,6 +318,7 @@ class Movable(Protocol):
 
 class Location(TypedDict, Generic[T]):
     """A dictionary containing the location of a Device"""
+
     #: Where the Device was requested to move to
     setpoint: T
     #: Where the Device actually is at the moment
@@ -447,6 +479,7 @@ class Checkable(Protocol):
 
 class Hints(TypedDict, total=False):
     """A dictionary of optional hints for visualization"""
+
     #: A list of the interesting fields to plot
     fields: List[str]
     #: Partition fields (and their stream name) into dimensions for plotting
@@ -482,6 +515,8 @@ def check_supports(obj, protocol: Type[T]) -> T:
         readable = check_supports(obj, Readable)
         readable.read()
     """
-    assert isinstance(obj, protocol), \
-        "%s does not implement all %s methods" % (obj, protocol.__name__)
+    assert isinstance(obj, protocol), "%s does not implement all %s methods" % (
+        obj,
+        protocol.__name__,
+    )
     return obj


### PR DESCRIPTION
It has become useful in ophyd.v2 to add a `children` property to devices.

To remain consistent with the `parent` property, it was suggested that adding a protocol like `HasChildren`, analogous to `HasParent`, would be useful

## Description
A PR has been started about this for ophyd.v2. See here: https://github.com/bluesky/ophyd/pull/1138

## How Has This Been Tested?
I am unsure how protocols are tested, please advise and I will add tests.