### PR TITLE
Add metadata to descriptor document

### DIFF
--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -69,7 +69,7 @@ def create(name='primary'):
     return (yield Msg('create', name=name))
 
 
-def save():
+def save(**kwargs):
     """
     Close a bundle of readings and emit a completed Event document.
 
@@ -82,7 +82,7 @@ def save():
     --------
     :func:`bluesky.plan_stubs.create`
     """
-    return (yield Msg('save'))
+    return (yield Msg('save', **kwargs))
 
 
 def drop():
@@ -1002,7 +1002,7 @@ def wait_for(futures, **kwargs):
     return (yield Msg('wait_for', None, futures, **kwargs))
 
 
-def trigger_and_read(devices, name='primary'):
+def trigger_and_read(devices, name='primary', **md):
     """
     Trigger and read a list of detectors and bundle readings into one Event.
 
@@ -1047,7 +1047,7 @@ def trigger_and_read(devices, name='primary'):
             return ret
 
         def standard_path():
-            yield from save()
+            yield from save(**md)
 
         def exception_path(exp):
             yield from drop()

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -1844,6 +1844,8 @@ class RunEngine:
 
         Also note that changing the 'name' of the Event will create a new
         Descriptor document.
+
+        msg.kwargs will be injected into the resulting descriptor document.
         """
         run_key = msg.run
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cycler
-event-model>=1.14.0
+event-model@git+https://github.com/RAYemelyanova/event-model@740509b6581a3aa0d6b7634b924d7a6efa8e7efb
 historydict
 msgpack
 msgpack-numpy


### PR DESCRIPTION
Relates to https://github.com/bluesky/event-model/pull/286

Currently the DAQ-Core team in diamond is needing access to custom field setting on descriptor documents. This is because, for example, tomography scans should output to several streams, and we want our tools to read descriptor documents and be aware of the nexus application definitions that the data from those streams should be written in.