### PR TITLE
Add type annotations to plans and plan stubs, update docstrings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dev = [
     "mypy",
     "myst-parser",
     "networkx",
-    "numpydoc",
+    "numpydoc>=1.8.0rc1",
     "ophyd",
     "packaging",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,10 @@ lint.select = [
     "I",  # isort - https://docs.astral.sh/ruff/rules/#isort-i
     "UP", # pyupgrade - https://docs.astral.sh/ruff/rules/#pyupgrade-up
 ]
+lint.ignore = [
+    "C408",  # dict(...) is fine to use
+    "C409",  # tuple(...) is fine to use
+]
 exclude = [
     "docs/source/conf.py",
     "docs/source/examples",

--- a/src/bluesky/plan_stubs.py
+++ b/src/bluesky/plan_stubs.py
@@ -32,6 +32,7 @@ except ImportError:
     from toolz import partition
 
 from .protocols import (
+    check_supports,
     Configurable,
     Flyable,
     Locatable,
@@ -640,7 +641,12 @@ def sleep(time: float) -> MsgGenerator:
 
 
 @plan
-def wait(group: Optional[Hashable] = None, *, timeout: Optional[float] = None):
+def wait(
+    group: Optional[Hashable] = None,
+    *,
+    timeout: Optional[float] = None,
+    move_on: bool = False,
+):
     """
     Wait for all statuses in a group to report being finished.
 
@@ -986,9 +992,10 @@ def complete_all(*args, group=None, wait=False, **kwargs):
 @plan
 def collect(
     obj: Flyable,
-    *,
+    *args,
     stream: bool = False,
     return_payload: bool = True,
+    name: Optional[str] = None
 ) -> MsgGenerator[List[PartialEvent]]:
     """
     Collect data cached by one or more fly-scanning devices and emit documents.
@@ -1019,7 +1026,7 @@ def collect(
     :func:`bluesky.plan_stubs.complete`
     :func:`bluesky.plan_stubs.wait`
     """
-    return (yield Msg("collect", obj, stream=stream, return_payload=return_payload))
+    return (yield Msg("collect", obj, *args, stream=stream, return_payload=return_payload, name=name))
 
 
 @plan

--- a/src/bluesky/plan_stubs.py
+++ b/src/bluesky/plan_stubs.py
@@ -58,7 +58,7 @@ from .utils import (
 from .utils import (
     short_uid as _short_uid,
     MsgGenerator,
-    ScalarOrIterable,
+    ScalarOrIterableFloat,
 )
 
 from event_model import ComposeEvent
@@ -1771,7 +1771,7 @@ def one_nd_step(
 def repeat(
     plan: Callable[[], MsgGenerator],
     num: int = 1,
-    delay: Optional[ScalarOrIterable] = None,
+    delay: Optional[ScalarOrIterableFloat] = None,
 ) -> MsgGenerator[Any]:
     """
     Repeat a plan num times with delay and checkpoint between each repeat.

--- a/src/bluesky/plan_stubs.py
+++ b/src/bluesky/plan_stubs.py
@@ -70,7 +70,7 @@ TakeReading = Callable[[List[Readable]], MsgGenerator[Mapping[str, Reading]]]
 
 @plan()
 def declare_stream(
-    *objs: Readable, name: str, collect:bool =False
+    *objs: Readable, name: str, collect: bool = False
 ) -> MsgGenerator[Tuple[EventDescriptor, ComposeEvent]]:
     """
     Bundle future readings into a new Event document.
@@ -97,7 +97,11 @@ def declare_stream(
     --------
     :func:`bluesky.plan_stubs.save`
     """
-    return (yield Msg("declare_stream", None, *separate_devices(objs), name=name, collect=collect))
+    return (
+        yield Msg(
+            "declare_stream", None, *separate_devices(objs), name=name, collect=collect
+        )
+    )
 
 
 @plan()
@@ -354,7 +358,11 @@ def rel_set(
     """
     from .preprocessors import relative_set_wrapper
 
-    return (yield from relative_set_wrapper(abs_set(obj, *args, group=group, wait=wait, **kwargs)))
+    return (
+        yield from relative_set_wrapper(
+            abs_set(obj, *args, group=group, wait=wait, **kwargs)
+        )
+    )
 
 
 @plan
@@ -745,14 +753,12 @@ def input_plan(prompt: str = "") -> MsgGenerator[str]:
 
 @plan
 def prepare(
-        obj: Flyable,
-        *args,
+    obj: Flyable,
+    *args,
     group: Optional[Hashable] = None,
     wait: bool = False,
-        group=None,
-        wait=False,
-        **kwargs
-): -> MsgGenerator[Status]:
+    **kwargs,
+) -> MsgGenerator[Status]:
     """
     Prepare a device.
 

--- a/src/bluesky/plan_stubs.py
+++ b/src/bluesky/plan_stubs.py
@@ -35,6 +35,7 @@ from .protocols import (
     Configurable,
     Flyable,
     Locatable,
+    Location,
     Movable,
     Readable,
     Reading,
@@ -68,7 +69,7 @@ from event_model.documents import EventDescriptor
 TakeReading = Callable[[List[Readable]], MsgGenerator[Mapping[str, Reading]]]
 
 
-@plan()
+@plan
 def declare_stream(
     *objs: Readable, name: str, collect: bool = False
 ) -> MsgGenerator[Tuple[EventDescriptor, ComposeEvent]]:
@@ -104,7 +105,7 @@ def declare_stream(
     )
 
 
-@plan()
+@plan
 def create(name: str = "primary") -> MsgGenerator:
     """
     Bundle future readings into a new Event document.

--- a/src/bluesky/plans.py
+++ b/src/bluesky/plans.py
@@ -23,7 +23,7 @@ from . import utils
 from .utils import (
     Msg,
     get_hinted_fields,
-    ScalarOrIterable,
+    ScalarOrIterableFloat,
     CustomPlanMetadata,
     MsgGenerator,
 )
@@ -52,7 +52,7 @@ PerStep = Callable[
 def count(
     detectors: Sequence[Readable],
     num: Optional[int] = 1,
-    delay: Optional[ScalarOrIterable] = None,
+    delay: Optional[ScalarOrIterableFloat] = None,
     *,
     per_shot: Optional[PerShot] = None,
     md: Optional[CustomPlanMetadata] = None,

--- a/src/bluesky/plans.py
+++ b/src/bluesky/plans.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from functools import partial
 from itertools import chain, zip_longest
 
-from typing import Any, Callable, Iterable, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Callable, Iterable, List, Mapping, Optional, Sequence, Tuple, Union
 from cycler import Cycler
 import numpy as np
 
@@ -123,7 +123,7 @@ def count(
 
 def list_scan(
     detectors: Sequence[Readable],
-    *args: Tuple[Movable, List[Any]],
+    *args: Tuple[Union[Movable, Any], List[Any]],
     per_step: Optional[PerStep] = None,
     md: Optional[CustomPlanMetadata] = None,
 ) -> MsgGenerator[str]:
@@ -236,7 +236,7 @@ def list_scan(
 
 def rel_list_scan(
     detectors: Sequence[Readable],
-    *args: Any,
+    *args: Union[Movable, Any],
     per_step: Optional[PerStep] = None,
     md: Optional[CustomPlanMetadata] = None,
 ) -> MsgGenerator[str]:
@@ -293,7 +293,7 @@ def rel_list_scan(
 
 def list_grid_scan(
     detectors: Sequence[Readable],
-    *args: Any,
+    *args: Union[Movable, Any],
     snake_axes: bool = False,
     per_step: Optional[PerStep] = None,
     md: Optional[CustomPlanMetadata] = None,
@@ -376,7 +376,7 @@ def list_grid_scan(
 
 def rel_list_grid_scan(
     detectors: Sequence[Readable],
-    *args: Any,
+    *args: Union[Movable, Any],
     snake_axes: bool = False,
     per_step: Optional[PerStep] = None,
     md: Optional[CustomPlanMetadata] = None,
@@ -1208,7 +1208,7 @@ def scan_nd(
 def inner_product_scan(
     detectors: Sequence[Readable],
     num: int,
-    *args: Any,
+    *args: Union[Movable, Any],
     per_step: Optional[PerStep] = None,
     md: Optional[CustomPlanMetadata] = None,
 ) -> MsgGenerator[str]:
@@ -1221,7 +1221,7 @@ def inner_product_scan(
 
 def scan(
     detectors,
-    *args: Any,
+    *args: Union[Movable, Any],
     num: Optional[int] = None,
     per_step: Optional[PerStep] = None,
     md: Optional[CustomPlanMetadata] = None,
@@ -1535,7 +1535,7 @@ def grid_scan(
 
 def rel_grid_scan(
     detectors: Sequence[Readable],
-    *args: Any,
+    *args: Union[Movable, Any],
     snake_axes: bool = None,
     per_step: Optional[PerStep] = None,
     md: Optional[CustomPlanMetadata] = None,
@@ -1599,7 +1599,7 @@ def rel_grid_scan(
 def relative_inner_product_scan(
     detectors: Sequence[Readable],
     num: int,
-    *args: Any,
+    *args: Union[Movable, Any],
     per_step: Optional[PerStep] = None,
     md: Optional[CustomPlanMetadata] = None,
 ) -> MsgGenerator[str]:
@@ -1612,7 +1612,7 @@ def relative_inner_product_scan(
 
 def rel_scan(
     detectors: Sequence[Readable],
-    *args: Any,
+    *args: Union[Movable, Any],
     num=None,
     per_step: Optional[PerStep] = None,
     md: Optional[CustomPlanMetadata] = None,

--- a/src/bluesky/plans.py
+++ b/src/bluesky/plans.py
@@ -7,8 +7,7 @@ from collections import defaultdict
 from functools import partial
 from itertools import chain, zip_longest
 
-
-from typing import Any, Callable, Iterable, List, Mapping, Optional, Tuple
+from typing import Any, Callable, Iterable, List, Mapping, Optional, Sequence, Tuple
 from cycler import Cycler
 import numpy as np
 
@@ -51,7 +50,7 @@ PerStep = Callable[
 
 
 def count(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     num: Optional[int] = 1,
     delay: Optional[ScalarOrIterable] = None,
     *,
@@ -123,7 +122,7 @@ def count(
 
 
 def list_scan(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     *args: Tuple[Movable, List[Any]],
     per_step: Optional[PerStep] = None,
     md: Optional[CustomPlanMetadata] = None,
@@ -236,7 +235,7 @@ def list_scan(
 
 
 def rel_list_scan(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     *args: Any,
     per_step: Optional[PerStep] = None,
     md: Optional[CustomPlanMetadata] = None,
@@ -293,7 +292,7 @@ def rel_list_scan(
 
 
 def list_grid_scan(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     *args: Any,
     snake_axes: bool = False,
     per_step: Optional[PerStep] = None,
@@ -376,7 +375,7 @@ def list_grid_scan(
 
 
 def rel_list_grid_scan(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     *args: Any,
     snake_axes: bool = False,
     per_step: Optional[PerStep] = None,
@@ -441,7 +440,7 @@ def rel_list_grid_scan(
 
 
 def _scan_1d(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     motor: Movable,
     start: float,
     stop: float,
@@ -517,7 +516,7 @@ def _scan_1d(
 
 
 def _rel_scan_1d(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     motor: Movable,
     start: float,
     stop: float,
@@ -568,7 +567,7 @@ def _rel_scan_1d(
 
 
 def log_scan(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     motor: Movable,
     start: float,
     stop: float,
@@ -648,7 +647,7 @@ def log_scan(
 
 
 def rel_log_scan(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     motor: Movable,
     start: float,
     stop: float,
@@ -699,7 +698,7 @@ def rel_log_scan(
 
 
 def adaptive_scan(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     target_field: str,
     motor: Movable,
     start: float,
@@ -829,7 +828,7 @@ def adaptive_scan(
 
 
 def rel_adaptive_scan(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     target_field: str,
     motor: Movable,
     start: float,
@@ -900,7 +899,7 @@ def rel_adaptive_scan(
 
 
 def tune_centroid(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     signal: str,
     motor: Movable,
     start: float,
@@ -1056,7 +1055,7 @@ def tune_centroid(
 
 
 def scan_nd(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     cycler: Cycler,
     *,
     per_step: Optional[PerStep] = None,
@@ -1207,7 +1206,7 @@ def scan_nd(
 
 
 def inner_product_scan(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     num: int,
     *args: Any,
     per_step: Optional[PerStep] = None,
@@ -1535,7 +1534,7 @@ def grid_scan(
 
 
 def rel_grid_scan(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     *args: Any,
     snake_axes: bool = None,
     per_step: Optional[PerStep] = None,
@@ -1598,7 +1597,7 @@ def rel_grid_scan(
 
 
 def relative_inner_product_scan(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     num: int,
     *args: Any,
     per_step: Optional[PerStep] = None,
@@ -1612,7 +1611,7 @@ def relative_inner_product_scan(
 
 
 def rel_scan(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     *args: Any,
     num=None,
     per_step: Optional[PerStep] = None,
@@ -1666,7 +1665,7 @@ def rel_scan(
 
 
 def tweak(
-    detector: List[Readable],
+    detector: Sequence[Readable],
     target_field: str,
     motor: Movable,
     step: float,
@@ -1752,7 +1751,7 @@ def tweak(
 
 
 def spiral_fermat(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     x_motor: Movable,
     y_motor: Movable,
     x_start: float,
@@ -1866,7 +1865,7 @@ def spiral_fermat(
 
 
 def rel_spiral_fermat(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     x_motor: Movable,
     y_motor: Movable,
     x_range: float,
@@ -1943,7 +1942,7 @@ def rel_spiral_fermat(
 
 
 def spiral(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     x_motor: Movable,
     y_motor: Movable,
     x_start: float,
@@ -2055,7 +2054,7 @@ def spiral(
 
 
 def rel_spiral(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     x_motor: Movable,
     y_motor: Movable,
     x_range: float,
@@ -2129,7 +2128,7 @@ def rel_spiral(
 
 
 def spiral_square(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     x_motor: Movable,
     y_motor: Movable,
     x_center: float,
@@ -2229,7 +2228,7 @@ def spiral_square(
 
 
 def rel_spiral_square(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     x_motor: Movable,
     y_motor: Movable,
     x_range: float,
@@ -2426,7 +2425,7 @@ def fly(
 
 
 def x2x_scan(
-    detectors: List[Readable],
+    detectors: Sequence[Readable],
     motor1: Movable,
     motor2: Movable,
     start: float,

--- a/src/bluesky/tests/test_scans.py
+++ b/src/bluesky/tests/test_scans.py
@@ -282,7 +282,7 @@ def test_list_grid_scan_snake_list(RE, hw):
                 }
             )
 
-    scan = bp.list_grid_scan([hw.det], hw.motor1, [6, 7, 8], hw.motor2, [18, 28, 38], snake_axes=[hw.motor2])
+    scan = bp.list_grid_scan([hw.det], hw.motor1, [6, 7, 8], hw.motor2, [18, 28, 38], snake_axes=True)
     multi_traj_checker(RE, scan, expected_data)
 
 
@@ -350,7 +350,7 @@ def test_rel_list_grid_scan_snake_list(RE, hw):
 
     hw.motor1.set(5)
     hw.motor2.set(8)
-    scan = bp.rel_list_grid_scan([hw.det], hw.motor1, [1, 2, 3], hw.motor2, [10, 20, 30], snake_axes=[hw.motor2])
+    scan = bp.rel_list_grid_scan([hw.det], hw.motor1, [1, 2, 3], hw.motor2, [10, 20, 30], snake_axes=True)
     multi_traj_checker(RE, scan, expected_data)
 
 

--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -1,3 +1,10 @@
+from collections import namedtuple
+from collections.abc import Iterable
+from functools import partial, reduce, wraps
+from functools import reduce
+from inspect import Parameter, Signature
+from typing import Any, Dict, Generator, Iterator, List, Optional, Callable, TypeVar, Union
+from weakref import ref, WeakKeyDictionary
 import abc
 import asyncio
 import collections.abc
@@ -12,12 +19,6 @@ import threading
 import time
 import traceback
 import types
-import uuid
-import warnings
-from collections import namedtuple
-from collections.abc import Iterable
-from functools import partial, reduce, wraps
-from inspect import Parameter, Signature
 from typing import (
     Any,
     AsyncIterable,
@@ -31,6 +32,8 @@ from typing import (
     Type,
     Union,
 )
+import uuid
+import warnings
 from weakref import WeakKeyDictionary, ref
 
 import msgpack
@@ -90,6 +93,19 @@ class Msg(namedtuple("Msg_base", ["command", "obj", "args", "kwargs", "run"])):
 
 
 MsgGenerator = Generator[Msg, Any, None]
+
+
+#: Return type of a plan, usually None. Always optional for dry-runs.
+P = TypeVar("P")
+
+#: Object usually returned from plan functions that is fed to the RunEngine
+MsgGenerator = Generator[Msg, Any, Optional[P]]
+
+#: Metadata passed from a plan to the RunEngine for embedding in a start document
+CustomPlanMetadata = Dict[str, Any]
+
+#: Scalar or iterable of values, one to be applied to each point in a scan
+ScalarOrIterable = Union[float, Iterable[float]]
 
 
 class RunEngineControlException(Exception):

--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -105,7 +105,7 @@ MsgGenerator = Generator[Msg, Any, Optional[P]]
 CustomPlanMetadata = Dict[str, Any]
 
 #: Scalar or iterable of values, one to be applied to each point in a scan
-ScalarOrIterable = Union[float, Iterable[float]]
+ScalarOrIterableFloat = Union[float, Iterable[float]]
 
 
 class RunEngineControlException(Exception):

--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -92,10 +92,6 @@ class Msg(namedtuple("Msg_base", ["command", "obj", "args", "kwargs", "run"])):
             f"args={self.args}, kwargs={self.kwargs}, run={self.run!r})"
         )
 
-
-MsgGenerator = Generator[Msg, Any, None]
-
-
 #: Return type of a plan, usually None. Always optional for dry-runs.
 P = TypeVar("P")
 

--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -4,6 +4,7 @@ from functools import partial, reduce, wraps
 from functools import reduce
 from inspect import Parameter, Signature
 from typing import Any, Dict, Generator, Iterator, List, Optional, Callable, TypeVar, Union
+from typing import Iterable as TypingIterable
 from weakref import ref, WeakKeyDictionary
 import abc
 import asyncio
@@ -105,7 +106,7 @@ MsgGenerator = Generator[Msg, Any, Optional[P]]
 CustomPlanMetadata = Dict[str, Any]
 
 #: Scalar or iterable of values, one to be applied to each point in a scan
-ScalarOrIterableFloat = Union[float, Iterable[float]]
+ScalarOrIterableFloat = Union[float, TypingIterable[float]]
 
 
 class RunEngineControlException(Exception):


### PR DESCRIPTION
## Description
Add type annotations to plans and plan stubs. IDEs such as vscode should now provide hints when using them. See screenshot below. Fix and update out-of-date docstrings on plans and plan stubs.

## Motivation and Context
Makes development with plans easier with auto-fill etc. Also allows downstream projects to make use of static type checking utilities such as mypy.

## How Has This Been Tested?
Docstrings and type annotations should not semantically change the code. All tests passing supports this.

## Screenshots (if appropriate):
![image](https://github.com/bluesky/bluesky/assets/29771545/b243ab22-4aa2-49f1-bda8-f7e82825c423)
![image](https://github.com/bluesky/bluesky/assets/29771545/bd2f29a5-807b-4c4f-9fe1-61974d00a33f)

