### PR TITLE
Fix a typo in the tutorial.

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -1023,7 +1023,7 @@ this signal and react like so. We will examine this output piece by piece.
     Your RunEngine is entering a paused state. These are your options for changing
     the state of the RunEngine:
     RE.resume()    Resume the plan.
-    RE.abort()     Perform cleanup, then kill plan. Mark exit_stats='aborted'.
+    RE.abort()     Perform cleanup, then kill plan. Mark exit_status='abort'.
     RE.stop()      Perform cleanup, then kill plan. Mark exit_status='success'.
     RE.halt()      Emergency Stop: Do not perform cleanup --- just stop.
 
@@ -1101,7 +1101,7 @@ options. If we decide not to continue we can quit in three different ways:
     Your RunEngine is entering a paused state. These are your options for changing
     the state of the RunEngine:
     RE.resume()    Resume the plan.
-    RE.abort()     Perform cleanup, then kill plan. Mark exit_stats='aborted'.
+    RE.abort()     Perform cleanup, then kill plan. Mark exit_status='abort'.
     RE.stop()      Perform cleanup, then kill plan. Mark exit_status='success'.
     RE.halt()      Emergency Stop: Do not perform cleanup --- just stop.
 


### PR DESCRIPTION
The `exit_status` value of an aborted run is recorded in the stop doc as `abort`, make it match here in the docs.

Just a typo correction.  The CI fail is not related.  (It failed when the branch was first created with no changes.)