### PR TITLE
Correct type comparison to prevent flake8 errors

### DIFF
--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -1395,7 +1395,7 @@ def test_exceptions_kill_run_and_failed_status_holds_detail(RE):
     with pytest.raises(FailedStatus) as exc:
         RE([Msg('set', dummy, 1, group='test'),
             Msg('wait', group='test')])
-        assert type(exc.args[0]) == UnknownStatusFailure
+        assert type(exc.args[0]) is UnknownStatusFailure
 
 
 @requires_ophyd
@@ -1427,7 +1427,7 @@ def test_status_propagates_exception_through_run_engine(RE):
         assert traceback[-1].name == "set"
         assert traceback[-1].line == "1/0"
 
-        assert type(exc.args[0]) == ZeroDivisionError
+        assert type(exc.args[0]) is ZeroDivisionError
 
 
 def test_colliding_streams(RE, hw):


### PR DESCRIPTION
The flake8 build was failing with the latest version

```shell
bluesky/tests/test_run_engine.py:1398:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
bluesky/tests/test_run_engine.py:1430:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
```