### PR TITLE
Modify return type of WritesExternalAssets.collect_asset_docs

### DIFF
--- a/bluesky/protocols.py
+++ b/bluesky/protocols.py
@@ -120,7 +120,7 @@ class HasParent(Protocol):
 @runtime_checkable
 class WritesExternalAssets(Protocol):
     @abstractmethod
-    def collect_asset_docs(self) -> SyncOrAsyncIterator[Iterator[Asset]]:
+    def collect_asset_docs(self) -> SyncOrAsyncIterator[Asset]:
         """Create the resource, datum, stream_resource, and stream_datum
         documents describing data in external source.
 


### PR DESCRIPTION
When developing ophyd-async I found a problem with the return type of WritesExternalAssets, so this PR is simply to fix that.

collect_asset_docs should definitely not return nested iterators.