### PR TITLE
Update bundlers.py to not raise RuntimeError for empty collect

### DIFF
--- a/bluesky/bundlers.py
+++ b/bluesky/bundlers.py
@@ -1005,10 +1005,6 @@ class RunBundler:
                     "A `collect` message on a device that isn't EventCollectable or EventPageCollectable "
                     "requires a `name=stream_name` argument"
                 )
-            if not indices_difference:
-                raise RuntimeError(
-                    "A `collect` message returned no events/event_pages or stream_datums"
-                )
 
             # Since there are no events or event_pages incrementing the sequence counter, we do it ourselves.
             self._sequence_counters[message_stream_name] += indices_difference


### PR DESCRIPTION
If a collect message returns nothing, this is not an indicator of a failing plan. So we should not raise an error/exception.

## Description
At the moment, we are raising a `RuntimeException` if a collect message does not return stream datums/events/event pages. But for the case of fly scanning, a collect message (e.g. queried every so often) could return nothing, and the bundler should be able to handle this case.

## Motivation and Context
A plan with a flyer can look something like:

```
yield from bps.kickoff(flyer)
complete_group = group_uuid("complete")
yield from bps.complete(flyer, group=complete_group)
done = False
while not done:
    try:
        yield from bps.wait(group=complete_group, timeout=flush_period)
    except TimeoutError:
        pass
    else:
        done = True
    yield from bps.collect(
        flyer, stream=True, return_payload=False, name=stream_name
    )
```

i.e. flyer.collect is polled every so often. It's entirely possible that , due to detector readout/exposure times, the first time collect is called there are no documents to produce yet.

## How Has This Been Tested?
Not yet tested. If coverage decreases with this removal, I will add a test.