### PR TITLE
Fix/msg mutator

### DIFF
--- a/bluesky/preprocessors.py
+++ b/bluesky/preprocessors.py
@@ -307,7 +307,10 @@ def print_summary_wrapper(plan):
     """
 
     read_cache = []
-    for msg in plan:
+
+    def spy(msg):
+        nonlocal read_cache
+
         cmd = msg.command
         if cmd == 'open_run':
             print('{:=^80}'.format(' Open Run '))
@@ -322,7 +325,9 @@ def print_summary_wrapper(plan):
             read_cache.append(msg.obj.name)
         elif cmd == 'save':
             print('  Read {}'.format(read_cache))
-        yield msg
+        return msg
+
+    return (yield from msg_mutator(plan, spy))
 
 
 def run_wrapper(plan, *, md=None):

--- a/bluesky/tests/test_bec.py
+++ b/bluesky/tests/test_bec.py
@@ -1,3 +1,5 @@
+import warnings
+
 import ast
 import pytest
 import jsonschema
@@ -214,10 +216,10 @@ def test_plot_ints(RE):
     RE(bps.mov(s, int(0)))
     assert s.describe()['s']['dtype'] == 'integer'
     s.kind = 'hinted'
-    with pytest.warns(None) as record:
-        RE(count([s], num=35))
 
-    assert len(record) == 0
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        RE(count([s], num=35))
 
 
 def test_plot_prune_fifo(RE, hw):
@@ -326,9 +328,9 @@ def test_many_motors(RE, hw):
     bec = BestEffortCallback()
     RE.subscribe(bec)
     movement = [(motor, 1, 5, 5) for motor in motors]
-    with pytest.warns(None) as record:
+    with pytest.warns((RuntimeWarning, UserWarning)):
         RE(grid_scan(dets, *[item for sublist in movement for item in sublist]))
-    assert len(record) > 0
+
     assert not bec._live_plots
     assert not bec._live_grids
     assert not bec._live_scatters


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Correctly handle the exception communication channel in `msg_mutator`.

Fixes code from 3dd2ef03d73fc9b614abff1724a55a06ba74374b (2016). 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

closes #1626 and #1625 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Two new tests added:

 - one "pure" test that checks mechanical changes to a sequence of messages
 - one "integration" test that verifies that for `rel_scan` the close run message (which creates the stop document) will come out before the motors are returned to their initial position.

There are incidental changes make pytest not fail on me for pytest reasons locally.

<!--
## Screenshots (if appropriate):
-->
