### PR TITLE
API: add ENV to opt-in to automatic stream predeclaring

### DIFF
--- a/bluesky/tests/test_run_engine.py
+++ b/bluesky/tests/test_run_engine.py
@@ -1588,8 +1588,10 @@ def test_double_call(RE):
     assert uid1 != uid2
 
 
-def test_num_events(RE, hw, db):
-
+@pytest.mark.parametrize('predeclare', [True, False])
+def test_num_events(RE, hw, db, predeclare, monkeypatch):
+    if predeclare:
+        monkeypatch.setenv('BLUESKY_PREDECLARE', '1')
     RE.subscribe(db.insert)
 
     rs1 = RE(count([]))
@@ -1598,7 +1600,10 @@ def test_num_events(RE, hw, db):
     else:
         uid1 = rs1[0]
     h = db[uid1]
-    assert h.stop['num_events'] == {'primary': 0}
+    if predeclare:
+        assert h.stop['num_events'] == {'primary': 0}
+    else:
+        assert h.stop['num_events'] == {}
 
     rs2 = RE(count([hw.det], 5))
     if RE.call_returns_result:
@@ -1617,7 +1622,10 @@ def test_num_events(RE, hw, db):
     else:
         uid3 = rs3[0]
     h = db[uid3]
-    assert h.stop['num_events'] == {'primary': 0, 'baseline': 2}
+    if predeclare:
+        assert h.stop['num_events'] == {'primary': 0, 'baseline': 2}
+    else:
+        assert h.stop['num_events'] == {'baseline': 2}
 
     rs4 = RE(count([hw.det], 5))
     if RE.call_returns_result:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This is the code + testing part of making stream pre-declaration opt-in, it still needs documentation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Pre-declaring streams seems like a good idea in general (and it solves some problems) so in #1542 we made the built in plans do so by default.  However this exposed some ophyd objects (notable AD) that were using the `trigger` method to sort out what the keys will be.  If you call `describe` before `trigger` you get different answers so going all-in on this by default is a bit too aggressive.

closes #1609 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added tests and modified two test that assumed the existence of pre-declare a bit too hard to easily un do. 

<!--
## Screenshots (if appropriate):
-->
