### PR TITLE
BLD: typing_extensions needs NotRequired (new 4.0.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ numpy
 super_state_machine
 toolz
 tqdm>=4.44
-typing-extensions
+typing-extensions>=4.0.0;python_version<'3.11'
 dataclasses;python_version<'3.7'
 zict<3.0.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In most of the build testing, `typing_extensions` has been satisfying this requirement. We found some edge cases in using a ROS2-Humble dev container that breaks this for system python. 

## Description
<!--- Describe your changes in detail -->
Following information here: https://typing-extensions.readthedocs.io/en/latest/#

> NotRequired
> See [typing.NotRequired](https://docs.python.org/3.12/library/typing.html#typing.NotRequired) and [PEP 655](https://peps.python.org/pep-0655/). In typing since 3.11.
> New in version 4.0.0.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
ROS development comes with lots of dependencies, and the build tools add an older version of `typing_extensions`. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in two containers. The base images here introduce the complexity when installing ament build tools. 
```RUN apt install ros-humble-ament-*`

This works:
```docker
FROM althack/ros2:humble-dev
RUN mkdir /src
WORKDIR /src
RUN git clone https://github.com/bluesky/bluesky
WORKDIR /src/bluesky
COPY new_requirements.txt requirements.txt
RUN pip3 install -e .

CMD ["/bin/bash", "-c", "python3 -c 'import bluesky'"]
```

This fails:
```docker 
FROM althack/ros2:humble-dev
RUN mkdir /src
WORKDIR /src
RUN git clone https://github.com/bluesky/bluesky
WORKDIR /src/bluesky
#COPY new_requirements.txt requirements.txt
RUN pip3 install -e .

CMD ["/bin/bash", "-c", "python3 -c 'import bluesky'"]
```

```
ImportError: cannot import name 'NotRequired' from 'typing_extensions' (/usr/lib/python3/dist-packages/typing_extensions.py)
```


<!--
## Screenshots (if appropriate):
-->
