### PR TITLE
Remove empty complete method from RunBundler

### DIFF
--- a/bluesky/bundlers.py
+++ b/bluesky/bundlers.py
@@ -615,24 +615,6 @@ class RunBundler:
         """
         self._uncollected.add(msg.obj)
 
-    async def complete(self, msg):
-        """
-        Tell a flyer, 'stop collecting, whenever you are ready'.
-
-        The flyer returns a status object. Some flyers respond to this
-        command by stopping collection and returning a finished status
-        object immediately. Other flyers finish their given course and
-        finish whenever they finish, irrespective of when this command is
-        issued.
-
-        Expected message object is::
-
-            Msg('complete', flyer, group=<GROUP>)
-
-        where <GROUP> is a hashable identifier.
-        """
-        ...
-
     def _maybe_format_datakeys_with_stream_name(
         self,
         describe_collect_dict: Union[Dict[str, DataKey], Dict[str, Dict[str, DataKey]]],

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -2061,14 +2061,6 @@ class RunEngine:
 
         where <GROUP> is a hashable identifier.
         """
-        run_key = msg.run
-        try:
-            current_run = self._run_bundlers[run_key]
-        except KeyError as ke:
-            raise IllegalMessageSequence("A 'complete' message was sent but no "
-                                         "run is open.") from ke
-
-        await current_run.complete(msg)
         kwargs = dict(msg.kwargs)
         group = kwargs.pop("group", None)
         obj = check_supports(msg.obj, Flyable)


### PR DESCRIPTION
## Description
We have an empty complete method in the RunBundler. This simply removes it, and the associated call from the RunEngine._complete method to it.

## Motivation and Context
I think it's good to remove code that seems unnecessary. This is one example of such code. 

## Related Discussions
I have realised that, with this removal, there is no need for Msg("complete") to be sent when a run is open. However, we probably want to enforce a certain order of messages being sent/injested by the RunEngine. I recognise that this has probably been discussed before, and it's difficult (if not just impossible) to introspect what messages the RunEngine will get from generator functions/coroutines. However, maybe there is a way to enforce, with things like "collect", that we only want those to be called e.g. if kickoff has been called too (and therefore inside a run).
