### PR TITLE
Enable collect for multiple detectors

### DIFF
--- a/bluesky/bundlers.py
+++ b/bluesky/bundlers.py
@@ -953,6 +953,17 @@ class RunBundler:
         collect_obj = check_supports(msg.obj, Collectable)
         collect_objects = collect_obj.detectors
 
+
+        # Obtain `local_descriptors` and describe collect depending on if `message_stream_name` was passed in
+        if message_stream_name:
+            if message_stream_name not in self._descriptors:
+                await self._describe_collect(collect_obj, message_stream_name=message_stream_name)
+        else:
+            if collect_obj not in self._local_descriptors:
+                await self._describe_collect(collect_obj)
+
+        local_descriptors = self._local_descriptors[collect_obj]
+
         # Get references to get_index methods if we have more than one collect object
         # raise error if collect_objects don't obey WritesStreamAssests protocol
         indices: List[Callable[[None],SyncOrAsync[int]]] = []
@@ -968,16 +979,6 @@ class RunBundler:
                     collect_object.name
                 )
             self._uncollected.discard(collect_object)
-
-            # Obtain `local_descriptors` and describe collect depending on if `message_stream_name` was passed in
-            if message_stream_name:
-                if message_stream_name not in self._descriptors:
-                    await self._describe_collect(collect_object, message_stream_name=message_stream_name)
-            else:
-                if collect_object not in self._local_descriptors:
-                    await self._describe_collect(collect_object)
-
-            local_descriptors = self._local_descriptors[collect_object]
 
         # Get the indicies from the collect objects
         coros = [maybe_await(get_index()) for get_index in indices]

--- a/bluesky/bundlers.py
+++ b/bluesky/bundlers.py
@@ -666,38 +666,75 @@ class RunBundler:
         obj = check_supports(obj, Collectable)
         self._describe_collect_cache[obj] = await maybe_await(obj.describe_collect())
 
-    async def _describe_collect(self, collect_obj: Flyable, message_stream_name: Optional[str] = None):
-        "Read the object's describe_collect and cache it."
+    async def _describe_collect(self, collect_objects: List[Collectable], message_stream_name: Optional[str] = None):
+        """Read object(s) describe_collect and cache it.
+        
+        Read describe collect for each collect object (one or more) and ensure it is
+        cached in the _describe_collect_cache. 
+        """
 
-        await self._ensure_cached(collect_obj, collect=True)
+        # Cache the desciptors for each of the collect objects
+        describe_collect = {}
+        for collect_obj in collect_objects:
+            await self._ensure_cached(collect_obj, collect=True)
+            describe_collect.update(self._describe_collect_cache[collect_obj])
 
-        describe_collect = self._describe_collect_cache[collect_obj]
+        ##### Is this formatting step still needed for backwards compatablity?
+            # (Because i would like to change it)
 
+        # describe_collect is a dictionary like this:
+        #     {name_for_desc1: data_keys_for_desc1,
+        #      name_for_desc2: data_keys_for_desc2, ...}
+        # with an entry for each detector:
+        # Which we need to make describe_collect_items, which is only used in the below
+        # for loop
         describe_collect_items = list(self._maybe_format_datakeys_with_stream_name(
-                describe_collect, message_stream_name=message_stream_name
+                describe_collect,
+                message_stream_name=message_stream_name
         ))
+        # it would be much nicer to have an object like this:
+
+        describe_collect_all = {collect_obj: self._describe_collect_cache[collect_obj]
+                                for collect_obj in collect_objects}
+
+        # and instead write something that checks the format of the datakeys without
+        # appending the stream name? (replaceing _maybe_format_datakeys_with_stream_name)
+
+        # It would also massively clean up the section after else.
+
 
         local_descriptors: Dict[Any, Dict[FrozenSet[str], ComposeDescriptorBundle]] = {}
 
-        # collect_obj.describe_collect() returns a dictionary like this:
-        #     {name_for_desc1: data_keys_for_desc1,
-        #      name_for_desc2: data_keys_for_desc2, ...}
-        for stream_name, stream_data_keys in describe_collect_items:
-            if stream_name not in self._descriptor_objs or collect_obj not in self._descriptor_objs[stream_name]:
+        # Is this structure still needed for backwards compatability?
+        # (the stuff after the "or" below) Or the (formatting with describe_collect_items)
+        for stream_name, stream_data_keys in describe_collect_items: 
+            if stream_name not in self._descriptor_objs or (
+                collect_obj not in self._descriptor_objs[stream_name]
+                for collect_obj in collect_objects
+            ):
                 # We do not have an Event Descriptor for this collect_obj.
-                await self._prepare_stream(stream_name, {collect_obj: stream_data_keys})
-            else:
+                await self._prepare_stream(
+                    stream_name,
+                    {collect_obj: self._describe_collect_cache[collect_obj]
+                     for collect_obj in collect_objects})
+            else: # test this
                 objs_read = self._descriptor_objs[stream_name]
-                if stream_data_keys != objs_read[collect_obj]:
-                    raise RuntimeError(
-                        "Mismatched objects read, "
-                        "expected {!s}, "
-                        "got {!s}".format(stream_data_keys, objs_read)
-                    )
-
+                for collect_obj, data_key in objs_read.items():
+                    if data_key.items() <= stream_data_keys.items() and (
+                        data_key != objs_read[collect_obj]):
+                        raise RuntimeError(
+                            "Mismatched objects read, "
+                            "expected {!s}, "
+                            "got {!s}".format(describe_collect_all, objs_read)
+                        )
             local_descriptors[frozenset(stream_data_keys)] = self._descriptors[stream_name]
 
-        self._local_descriptors[collect_obj] = local_descriptors
+            
+            self._local_descriptors[frozenset(collect_objects)] = local_descriptors
+            # I don't think we want to do this.
+            # Do we instead want to have a local discriptor for each collect object?
+
+
 
     async def _pack_seq_nums_into_stream_datum(
         self,
@@ -923,11 +960,10 @@ class RunBundler:
         Collect data cached by a flyer and emit documents.
 
         Expect message object is
-
-            Msg('collect', collect_obj, collect_obj_2, ...)
-            Msg('collect', flyer_object, flyer_object_2, ..., stream=True, return_payload=False, name='stream_name')
+            Msg('collect',  collect_obj,  collect_obj_2, ..., stream=True, 
+                return_payload=False, name='stream_name')
         
-        Where there must be at least one collect or flyer object. If multiple are used
+        Where there must be at least one collect object. If multiple are used
         they must obey the WritesStreamAssets protocol.
         """
 
@@ -950,19 +986,8 @@ class RunBundler:
         # accumulate, and return None.
         return_payload = msg.kwargs.get('return_payload', True)
 
-        collect_obj = check_supports(msg.obj, Collectable)
-        collect_objects = collect_obj.detectors
-
-
-        # Obtain `local_descriptors` and describe collect depending on if `message_stream_name` was passed in
-        if message_stream_name:
-            if message_stream_name not in self._descriptors:
-                await self._describe_collect(collect_obj, message_stream_name=message_stream_name)
-        else:
-            if collect_obj not in self._local_descriptors:
-                await self._describe_collect(collect_obj)
-
-        local_descriptors = self._local_descriptors[collect_obj]
+        # Get a list of the collectable objects from the message obj and args
+        collect_objects = [check_supports(obj, Collectable) for obj in (msg.obj,)+ msg.args]
 
         # Get references to get_index methods if we have more than one collect object
         # raise error if collect_objects don't obey WritesStreamAssests protocol
@@ -979,6 +1004,20 @@ class RunBundler:
                     collect_object.name
                 )
             self._uncollected.discard(collect_object)
+
+        # Obtain `local_descriptors` and describe collect depending on if `message_stream_name` was passed in
+        if message_stream_name:
+            if message_stream_name not in self._descriptors:
+                await self._describe_collect(collect_objects, message_stream_name=message_stream_name)
+        else:
+            #  this will not work the new way
+            for collect_object in collect_objects: # i think this way is ment to be done if you only have one collect object?
+                if collect_objects not in self._local_descriptors:
+                    await self._describe_collect(collect_objects)
+
+        #or this
+        local_descriptors = self._local_descriptors[frozenset(collect_objects)]
+
 
         # Get the indicies from the collect objects
         coros = [maybe_await(get_index()) for get_index in indices]

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -25,7 +25,7 @@ from .utils import (
 )
 
 
-def declare_stream(*objs, name=None, collect=False):
+def declare_stream(*objs, name: str, collect=False):
     """
     Bundle future readings into a new Event document.
 

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -695,14 +695,13 @@ def complete(obj, *, group=None, wait=False, **kwargs):
     return ret
 
 
-def collect(obj, *, stream=False, return_payload=True, name=None):
+def collect(obj, *args, stream=False, return_payload=True, name=None):
     """
     Collect data cached by a fly-scanning device and emit documents.
 
     Parameters
     ----------
-    obj : fly-able
-        Device with 'kickoff', 'complete', and 'collect' methods
+    obj : list of devices with 'kickoff', 'complete', and 'collect' methods
     stream : boolean, optional
         If False (default), emit Event documents in one bulk dump. If True,
         emit events one at time.
@@ -726,8 +725,8 @@ def collect(obj, *, stream=False, return_payload=True, name=None):
     :func:`bluesky.plan_stubs.complete`
     :func:`bluesky.plan_stubs.wait`
     """
-    return (yield Msg('collect', obj, stream=stream, return_payload=return_payload, name=name))
-
+    return (yield Msg('collect', obj, *args, stream=stream, return_payload=return_payload, name=name))
+ 
 
 def configure(obj, *args, **kwargs):
     """

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -630,9 +630,9 @@ def kickoff(obj, *, group=None, wait=False, **kwargs):
     Parameters
     ----------
     obj : fly-able
-        Device with 'kickoff', 'complete', and 'collect' methods
+        Device with 'kickoff', and 'complete' methods.
     group : string (or any hashable object), optional
-        identifier used by 'wait'
+        identifier used by 'wait'.
     wait : boolean, optional
         If True, wait for completion before processing any more messages.
         False by default.

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -726,7 +726,7 @@ def collect(obj, *args, stream=False, return_payload=True, name=None):
     :func:`bluesky.plan_stubs.wait`
     """
     return (yield Msg('collect', obj, *args, stream=stream, return_payload=return_payload, name=name))
- 
+
 
 def configure(obj, *args, **kwargs):
     """

--- a/bluesky/plan_stubs.py
+++ b/bluesky/plan_stubs.py
@@ -669,7 +669,7 @@ def complete(obj, *, group=None, wait=False, **kwargs):
     Parameters
     ----------
     obj : fly-able
-        Device with 'kickoff', 'complete', and 'collect' methods
+        Device with 'kickoff' and 'complete' methods.
     group : string (or any hashable object), optional
         identifier used by 'wait'
     wait : boolean, optional
@@ -697,11 +697,11 @@ def complete(obj, *, group=None, wait=False, **kwargs):
 
 def collect(obj, *args, stream=False, return_payload=True, name=None):
     """
-    Collect data cached by a fly-scanning device and emit documents.
+    Collect data cached by one or more fly-scanning devices and emit documents.
 
     Parameters
     ----------
-    obj : list of devices with 'kickoff', 'complete', and 'collect' methods
+    obj : A device with 'kickoff', 'complete', and 'collect' methods.
     stream : boolean, optional
         If False (default), emit Event documents in one bulk dump. If True,
         emit events one at time.

--- a/bluesky/protocols.py
+++ b/bluesky/protocols.py
@@ -153,14 +153,37 @@ class WritesExternalAssets(Protocol):
 class WritesStreamAssets(Protocol):
     @abstractmethod
     def collect_asset_docs(self, index: Optional[int]=None) -> SyncOrAsyncIterator[StreamAsset]:
-        """Collect the asset docs up a given index.
-        
-        The asset docs will be collected from multiple streams synchronised on the
-        highest common stream index. """
+        """Create the resource and datum documents describing data in external
+            source up to a given index if provided.
+
+            An index will be provided when using stream resources and datums. The asset
+            docs will be collected from multiple streams and synchronised on the
+            highest common stream index.
+
+        Example yielded values:
+
+        .. code-block:: python
+
+            ('resource', {
+                'path_semantics': 'posix',
+                'resource_kwargs': {'frame_per_point': 1},
+                'resource_path': 'det.h5',
+                'root': '/tmp/tmpcvxbqctr/',
+                'spec': 'AD_HDF5',
+                'uid': '9123df61-a09f-49ae-9d23-41d4d6c6d788'
+            })
+            # or
+            ('datum', {
+                'datum_id': '9123df61-a09f-49ae-9d23-41d4d6c6d788/0',
+                'datum_kwargs': {'point_number': 0},
+                'resource': '9123df61-a09f-49ae-9d23-41d4d6c6d788'}
+            })
+            """
         ...
     
     @abstractmethod
     def get_index(self) -> SyncOrAsync[int]:
+        """Retrive the current index of writer."""
         ...
 
 @runtime_checkable

--- a/bluesky/protocols.py
+++ b/bluesky/protocols.py
@@ -55,9 +55,13 @@ class Reading(ReadingOptional):
 Asset = Union[
     Tuple[Literal["resource"], PartialResource],
     Tuple[Literal["datum"], Datum],
-    Tuple[Literal["stream_resource"], StreamResource],
-    Tuple[Literal["stream_datum"], StreamDatum]
     ]
+
+StreamAsset = Union [
+    Tuple[Literal["stream_resource"], StreamResource],
+    Tuple[Literal["stream_datum"], StreamDatum],
+    ]
+
 
 T = TypeVar("T")
 SyncOrAsync = Union[T, Awaitable[T]]
@@ -121,8 +125,8 @@ class HasParent(Protocol):
 class WritesExternalAssets(Protocol):
     @abstractmethod
     def collect_asset_docs(self) -> SyncOrAsyncIterator[Asset]:
-        """Create the resource, datum, stream_resource, and stream_datum
-        documents describing data in external source.
+        """Create the resource and datum documents describing data in external
+            source.
 
         Example yielded values:
 
@@ -145,6 +149,19 @@ class WritesExternalAssets(Protocol):
         """
         ...
 
+
+class WritesStreamAssets(Protocol):
+    @abstractmethod
+    def collect_asset_docs(self, index: Optional[int]=None) -> SyncOrAsyncIterator[StreamAsset]:
+        """Collect the asset docs up a given index.
+        
+        The asset docs will be collected from multiple streams synchronised on the
+        highest common stream index. """
+        ...
+    
+    @abstractmethod
+    def get_index(self) -> SyncOrAsync[int]:
+        ...
 
 @runtime_checkable
 class Configurable(Protocol):

--- a/bluesky/protocols.py
+++ b/bluesky/protocols.py
@@ -149,7 +149,7 @@ class WritesExternalAssets(Protocol):
         """
         ...
 
-
+@runtime_checkable
 class WritesStreamAssets(Protocol):
     @abstractmethod
     def collect_asset_docs(self, index: Optional[int]=None) -> SyncOrAsyncIterator[StreamAsset]:

--- a/bluesky/protocols.py
+++ b/bluesky/protocols.py
@@ -57,7 +57,7 @@ Asset = Union[
     Tuple[Literal["datum"], Datum],
     ]
 
-StreamAsset = Union [
+StreamAsset = Union[
     Tuple[Literal["stream_resource"], StreamResource],
     Tuple[Literal["stream_datum"], StreamDatum],
     ]
@@ -149,10 +149,11 @@ class WritesExternalAssets(Protocol):
         """
         ...
 
+
 @runtime_checkable
 class WritesStreamAssets(Protocol):
     @abstractmethod
-    def collect_asset_docs(self, index: Optional[int]=None) -> SyncOrAsyncIterator[StreamAsset]:
+    def collect_asset_docs(self, index: Optional[int] = None) -> SyncOrAsyncIterator[StreamAsset]:
         """Create the resource and datum documents describing data in external
             source up to a given index if provided.
 
@@ -180,11 +181,12 @@ class WritesStreamAssets(Protocol):
             })
             """
         ...
-    
+
     @abstractmethod
     def get_index(self) -> SyncOrAsync[int]:
         """Retrive the current index of writer."""
         ...
+
 
 @runtime_checkable
 class Configurable(Protocol):

--- a/bluesky/tests/test_seq_num_indices_in_sync.py
+++ b/bluesky/tests/test_seq_num_indices_in_sync.py
@@ -194,6 +194,7 @@ def test_flyscan_with_stream_datum_pause(RE):
                 Msg("open_run", x),
                 Msg("kickoff", x),
                 Msg("pause", x),
+                Msg("declare_stream", None, x, name="primary", collect=True),
                 *[Msg("collect", x, name="primary")] * 10,
                 Msg("complete", x),
                 Msg("close_run", x),
@@ -255,6 +256,7 @@ def test_flyscan_with_mismatched_indices(RE):
         Msg("open_run", x),
         Msg("kickoff", x),
         Msg("pause", x),
+        Msg("declare_stream", None, x, name="stream1", collect=True),
         *[Msg("collect", x, name="stream1")] * 10,
         Msg("complete", x),
         Msg("close_run", x),
@@ -325,6 +327,7 @@ def test_changing_stream_resource_after_stream_datum_emitted(RE):
     plan = [
         Msg("open_run", x),
         Msg("kickoff", x),
+        Msg("declare_stream", None, x, name="primary", collect=True),
         *[Msg("collect", x, name="primary")] * 10,
         Msg("complete", x),
         Msg("close_run", x),

--- a/bluesky/utils/__init__.py
+++ b/bluesky/utils/__init__.py
@@ -1834,15 +1834,15 @@ async def iterate_maybe_async(iterator: SyncOrAsyncIterator[T]) -> AsyncIterator
 
 
 async def maybe_collect_asset_docs(msg, obj, index: Optional[int] = None, *args, **kwargs) -> Iterator[Asset]:
-    warn_if_msg_args_or_kwargs(msg, obj.collect_asset_docs, args, kwargs)
-
     # The if/elif statement must be done in this order because isinstance for protocol
     # doesn't check for exclusive signatures, and WritesExternalAssets will also
     # return true for a WritesStreamAsset as they both contain collect_asset_docs
     if isinstance(obj, WritesStreamAssets):
+        warn_if_msg_args_or_kwargs(msg, obj.collect_asset_docs, args, kwargs)
         async for v in iterate_maybe_async(obj.collect_asset_docs(index, *args, **kwargs)):
             yield v
     elif isinstance(obj, WritesExternalAssets):
+        warn_if_msg_args_or_kwargs(msg, obj.collect_asset_docs, args, kwargs)
         async for v in iterate_maybe_async(obj.collect_asset_docs(*args, **kwargs)):
             yield v
 


### PR DESCRIPTION
## Description
Changes the collect method in bundler to handle the collection of multiple detectors. Contains the logic to collect stream resources using the maximum common number of frames written, determined by the minimum index.

`Asset` has been altered to only address a `resource` and `datum` and a new `StreamAsset` has been created to address `stream_resource` and `stream_datum`.

## Motivation and Context
This enables logic to be moved out of Ophyd-async, generalising the process
Fixes #1649.

## How Has This Been Tested?
TBC.
