### PR TITLE
Compatibility with Python3.11 and 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         runs-on: ["ubuntu-latest"] # can add windows-latest, macos-latest
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           # Include one that runs in the dev environment
           - runs-on: "ubuntu-latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # The devcontainer should use the developer target and run as root with podman
 # or docker with user namespaces.
-ARG PYTHON_VERSION=3.10
+ARG PYTHON_VERSION=3.12
 FROM python:${PYTHON_VERSION} as developer
 
 # Add any system dependencies for the developer/build environment here


### PR DESCRIPTION
Include Python3.11 and Python3.12 in CI, make 3.12 the default for the devcontainer and all non-test CI checks (like docs)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #1670 

## How Has This Been Tested?
Ensured that tests pass for both versions (and leave in CI), tested devcontainer locally