### PR TITLE
fix for #1693

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,9 @@
     },
     "remoteEnv": {
         // Allow X11 apps to run inside the container
-        "DISPLAY": "${localEnv:DISPLAY}"
+        "DISPLAY": "${localEnv:DISPLAY}",
+        // set up the MatPlotLib backend
+        "MPLBACKEND": "agg"
     },
     "customizations": {
         "vscode": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM python:${PYTHON_VERSION} as developer
 # Add any system dependencies for the developer/build environment here
 RUN apt-get update && apt-get install -y --no-install-recommends \
     graphviz \
+    libgl1-mesa-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Set up a virtual environment and put it in PATH


### PR DESCRIPTION
This is a workaround for the tests failing in the developer container.

To reproduce the issue open the repo in vscode and choose 'reopen in container' then run `pytest` (or `tox -p`).

The changes fix two issues:

- The default tk backend for matplotlib was failing like this:
  ```
  File "/usr/local/lib/python3.10/tkinter/__init__.py", line 871, in after_cancel
    data = self.tk.call('after', 'info', id)
  RuntimeError: main thread is not in main loop
  ```
- The two tests with prefix `test_in_plan_qt_callback` required the system dependency libGL.so.1

FIXES:
-  `MPLBACKEND=agg` environment for headless operation 
- add libgl1-mesa-dev system dependency.

Making this a draft as others have added to the issue since I last looked!