### PR TITLE
[ENH] Add __main__.py and entrypoint for checking version info.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ all = ["bluesky[dev,ipython,zmq,common,tools,streamz,plotting,cmd,olog]"]
 
 [project.scripts]
 bluesky-0MQ-proxy = "bluesky.commandline.zmq_proxy:main"
+bluesky = "bluesky.__main__:main"
 
 [project.urls]
 GitHub = "https://github.com/bluesky/bluesky"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,6 @@ all = ["bluesky[dev,ipython,zmq,common,tools,streamz,plotting,cmd,olog]"]
 
 [project.scripts]
 bluesky-0MQ-proxy = "bluesky.commandline.zmq_proxy:main"
-bluesky = "bluesky.__main__:main"
 
 [project.urls]
 GitHub = "https://github.com/bluesky/bluesky"

--- a/src/bluesky/__main__.py
+++ b/src/bluesky/__main__.py
@@ -1,0 +1,16 @@
+from argparse import ArgumentParser
+
+from . import __version__
+
+__all__ = ["main"]
+
+
+def main(args=None):
+    parser = ArgumentParser()
+    parser.add_argument("-v", "--version", action="version", version=__version__)
+    args = parser.parse_args(args)
+
+
+# test with: python -m bluesky
+if __name__ == "__main__":
+    main()

--- a/src/bluesky/tests/test_cli.py
+++ b/src/bluesky/tests/test_cli.py
@@ -1,0 +1,10 @@
+import subprocess
+import sys
+
+from bluesky import __version__
+
+
+def test_cli_version():
+    cmd = [sys.executable, "-m", "bluesky", "--version"]
+    assert subprocess.check_output(cmd).decode().strip() == __version__
+

--- a/src/bluesky/tests/test_cli.py
+++ b/src/bluesky/tests/test_cli.py
@@ -7,4 +7,3 @@ from bluesky import __version__
 def test_cli_version():
     cmd = [sys.executable, "-m", "bluesky", "--version"]
     assert subprocess.check_output(cmd).decode().strip() == __version__
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding `__main__.py` with simple main entrypoint that prints version, update `pyproject.toml`.

## Motivation and Context

Solves #1667

## How Has This Been Tested?

```
(venv) [jwlodek@vdi-10-65-15-187 bluesky]$ which python
~/Workspace/bluesky/venv/bin/python
(venv) [jwlodek@vdi-10-65-15-187 bluesky]$ python --version
Python 3.11.5
(venv) [jwlodek@vdi-10-65-15-187 bluesky]$ python -m bluesky --version
1.13.0a4.dev31+g6168e9d0.d20240415
```

<!--
## Screenshots (if appropriate):
-->
