### PR TITLE
Fix for #1693 - tests failing in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,9 @@
     },
     "remoteEnv": {
         // Allow X11 apps to run inside the container
-        "DISPLAY": "${localEnv:DISPLAY}"
+        "DISPLAY": "${localEnv:DISPLAY}",
+        // set up the MatPlotLib backend
+        "MPLBACKEND": "agg"
     },
     "customizations": {
         "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,9 +7,7 @@
     },
     "remoteEnv": {
         // Allow X11 apps to run inside the container
-        "DISPLAY": "${localEnv:DISPLAY}",
-        // set up the MatPlotLib backend
-        "MPLBACKEND": "agg"
+        "DISPLAY": "${localEnv:DISPLAY}"
     },
     "customizations": {
         "vscode": {
@@ -53,5 +51,5 @@
     // Mount the parent as /workspaces so we can pip install peers as editable
     "workspaceMount": "source=${localWorkspaceFolder}/..,target=/workspaces,type=bind",
     // After the container is created, install the python project in editable form
-    "postCreateCommand": "pip install $([ -f dev-requirements.txt ] && echo '-c dev-requirements.txt') -e '.[dev]' && pre-commit install",
+    "postCreateCommand": "pip install $([ -f dev-requirements.txt ] && echo '-c dev-requirements.txt') -e '.[dev]' && pre-commit install"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM python:${PYTHON_VERSION} as developer
 # Add any system dependencies for the developer/build environment here
 RUN apt-get update && apt-get install -y --no-install-recommends \
     graphviz \
+    libgl1-mesa-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Set up a virtual environment and put it in PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM python:${PYTHON_VERSION} as developer
 # Add any system dependencies for the developer/build environment here
 RUN apt-get update && apt-get install -y --no-install-recommends \
     graphviz \
-    libgl1-mesa-dev \
+    libqt5gui5 \
     && rm -rf /var/lib/apt/lists/*
 
 # Set up a virtual environment and put it in PATH


### PR DESCRIPTION
This is a  fix for the tests failing in the developer container.

To reproduce the issue open the repo in vscode and choose 'reopen in container' then run pytest (or tox -p).

The fixes are:
- rebase over https://github.com/bluesky/bluesky/pull/1672 to fix "main thread is not in main loop"
- add qt library into system depenedencies

Note that this still has pop ups for the interactive tests but that will be looked at in a separate issue https://github.com/bluesky/bluesky/issues/1689. The devcontainer supports X11 for this purpose.