### PR TITLE
Dont collect interactive tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,11 +112,17 @@ ignore_missing_imports = true # Ignore missing stubs in imported modules
 
 [tool.pytest.ini_options]
 # Run pytest with all our checkers, and don't spam us with massive tracebacks on error
+# Don't collect the interactive directory which is intended for manual execution
 addopts = """
-    --tb=native -vv --doctest-modules --doctest-glob="*.rst"
+    --tb=native -vv --doctest-modules --doctest-glob="*.rst" --ignore src/bluesky/tests/interactive
     """
 # https://iscinumpy.gitlab.io/post/bound-version-constraints/#watch-for-warnings
-filterwarnings = ["error", "ignore::PendingDeprecationWarning", "ignore::UserWarning", "ignore::DeprecationWarning"]
+filterwarnings = [
+    "error",
+    "ignore::PendingDeprecationWarning",
+    "ignore::UserWarning",
+    "ignore::DeprecationWarning",
+]
 # Doctest python code in docs, python code in src docstrings, test functions in tests
 testpaths = "src/bluesky/tests"
 
@@ -166,7 +172,4 @@ lint.select = [
     "I",  # isort - https://docs.astral.sh/ruff/rules/#isort-i
     "UP", # pyupgrade - https://docs.astral.sh/ruff/rules/#pyupgrade-up
 ]
-exclude = [
-    "docs/source/conf.py",
-    "docs/source/examples"
-]
+exclude = ["docs/source/conf.py", "docs/source/examples"]


### PR DESCRIPTION
This fixes #1689.

In vscode pytest collection is run every time changes are made in the test folder and this was causing MPL windows to pop up. This was disruptive.

The change tells pytest not to collect from the interactive subfolder of tests. This has no effect on the number of pytest tests collected as there are no pytest functions in the folder. However, it does take away some checks as exceptions happening when loading these modules would previously have caused pytest to abort and report the issue (thus not running the remaining tests).

@tacaswell was the intention for these tests to be executed in CI - if so a different approach is required.

One thing to note: there are still a couple of popups when executing the tests but this could be suppressed using `MPLBACKEND=agg pytest`. This fix means that using the agg backend no longer slows down test collection.
