### PR TITLE
Only allow plans to accept Sequences of detectors 

### DIFF
--- a/src/bluesky/plans.py
+++ b/src/bluesky/plans.py
@@ -6,7 +6,7 @@ import time
 from collections import defaultdict
 from functools import partial
 from itertools import chain, zip_longest
-from typing import Any, Callable, Iterable, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, List, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 from cycler import Cycler
@@ -24,12 +24,12 @@ from .protocols import Flyable, Movable, Readable
 from .utils import CustomPlanMetadata, Msg, MsgGenerator, ScalarOrIterableFloat, get_hinted_fields
 
 #: Plan function that can be used for each shot in a detector acquisition involving no actuation
-PerShot = Callable[[Iterable[Readable], Optional[bps.TakeReading]], MsgGenerator]
+PerShot = Callable[[Sequence[Readable], Optional[bps.TakeReading]], MsgGenerator]
 
 #: Plan function that can be used for each step in a scan
 PerStep = Callable[
     [
-        Iterable[Readable],
+        Sequence[Readable],
         Mapping[Movable, Any],
         Mapping[Movable, Any],
         Optional[bps.TakeReading],

--- a/src/bluesky/plans.py
+++ b/src/bluesky/plans.py
@@ -6,6 +6,7 @@ import time
 from collections import defaultdict
 from functools import partial
 from itertools import chain, zip_longest
+from typing import Sequence
 
 import numpy as np
 
@@ -19,6 +20,11 @@ from . import plan_patterns, utils
 from . import plan_stubs as bps
 from . import preprocessors as bpp
 from .utils import Msg, get_hinted_fields
+
+
+def _check_detectors_input(detectors):
+    if not isinstance(detectors, Sequence):
+        raise TypeError("The input argument must be either as a list or a tuple of reabale objects.")
 
 
 def count(detectors, num=1, delay=None, *, per_shot=None, md=None):
@@ -50,6 +56,7 @@ def count(detectors, num=1, delay=None, *, per_shot=None, md=None):
     If ``delay`` is an iterable, it must have at least ``num - 1`` entries or
     the plan will raise a ``ValueError`` during iteration.
     """
+    _check_detectors_input(detectors)
     if num is None:
         num_intervals = None
     else:
@@ -1206,6 +1213,7 @@ def grid_scan(detectors, *args, snake_axes=None, per_step=None, md=None):
     #   supplied, but if `snake_axes` is not `None` (the default value), it overrides
     #   any values of `snakeX` in `args`.
 
+    _check_detectors_input(detectors)
     args_pattern = plan_patterns.classify_outer_product_args_pattern(args)
     if (snake_axes is not None) and (args_pattern == plan_patterns.OuterProductArgsPattern.PATTERN_2):
         raise ValueError(

--- a/src/bluesky/tests/test_plans.py
+++ b/src/bluesky/tests/test_plans.py
@@ -697,3 +697,12 @@ def test_predeclare_env(hw, monkeypatch, predeclare):
             assert "declare_stream" in cmds
         else:
             assert "declare_stream" not in cmds
+
+
+def test_count_failure(RE, hw):
+    detector_generator = (det for det in [hw.det1, hw.det2])
+    with pytest.raises(TypeError):
+        RE(bp.count(detector_generator))
+
+    with pytest.raises(TypeError):
+        RE(bp.count(hw.det))

--- a/src/bluesky/tests/test_plans.py
+++ b/src/bluesky/tests/test_plans.py
@@ -591,6 +591,14 @@ def test_grid_scans_failing(RE, hw, plan):
             args = (hw.motor, 1, 2, 3, hw.motor1, 4, 5, 6, hw.motor2, 7, 8, 9)
             RE(plan([hw.det], *args, snake_axes=snake_axes))
 
+    # Argument detectors is a generator
+    generator = (detector for detector in [hw.det1, hw.det2])
+    with pytest.raises(
+        TypeError, match="The input argument must be either as a list or a tuple of reabale objects."
+    ):
+        args = (hw.motor, 1, 2, 3, hw.motor1, 4, 5, 6, True, hw.motor2, 7, 8, 9, False)
+        RE(plan(generator, *args))
+
 
 def test_describe_failure(RE):
     ophyd = pytest.importorskip("ophyd")

--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -31,6 +31,7 @@ from typing import (
     TypeVar,
     Union,
 )
+from typing import Iterable as TypingIterable
 from weakref import WeakKeyDictionary, ref
 
 import msgpack
@@ -95,6 +96,19 @@ MsgGenerator = Generator[Msg, Any, Optional[P]]
 
 #: Metadata passed from a plan to the RunEngine for embedding in a start document
 CustomPlanMetadata = Dict[str, Any]
+
+
+#: Return type of a plan, usually None. Always optional for dry-runs.
+P = TypeVar("P")
+
+#: Object usually returned from plan functions that is fed to the RunEngine
+MsgGenerator = Generator[Msg, Any, Optional[P]]
+
+#: Metadata passed from a plan to the RunEngine for embedding in a start document
+CustomPlanMetadata = Dict[str, Any]
+
+#: Scalar or iterable of values, one to be applied to each point in a scan
+ScalarOrIterableFloat = Union[float, TypingIterable[float]]
 
 
 class RunEngineControlException(Exception):

--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -17,7 +17,20 @@ from collections import namedtuple
 from collections.abc import Iterable
 from functools import partial, reduce, wraps
 from inspect import Parameter, Signature
-from typing import Any, AsyncIterable, AsyncIterator, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import (
+    Any,
+    AsyncIterable,
+    AsyncIterator,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 from weakref import WeakKeyDictionary, ref
 
 import msgpack
@@ -72,6 +85,16 @@ class Msg(namedtuple("Msg_base", ["command", "obj", "args", "kwargs", "run"])):
             f"Msg({self.command!r}, obj={self.obj!r}, "
             f"args={self.args}, kwargs={self.kwargs}, run={self.run!r})"
         )
+
+
+#: Return type of a plan, usually None. Always optional for dry-runs.
+P = TypeVar("P")
+
+#: Object usually returned from plan functions that is fed to the RunEngine
+MsgGenerator = Generator[Msg, Any, Optional[P]]
+
+#: Metadata passed from a plan to the RunEngine for embedding in a start document
+CustomPlanMetadata = Dict[str, Any]
 
 
 class RunEngineControlException(Exception):


### PR DESCRIPTION
Allow the plans to only accept lists or tuples of hardware devices eg. detector to avoid unexpected behaviour.

## Description
- Adds a check on the type of the `detector` argument passed to the plan and raises an error if not a Sequence.
- Adds type checking to plans and plan stubs.

Pulled in [PR#1610](https://github.com/bluesky/bluesky/pull/1610) which had started the work on type checking.

## Motivation and Contex
Currently plans will still run to completion if passed an iterable different from a generator as input, but will do the wrong thing in the background.
See #1613 .

## How Has This Been Tested?
- Type annotations should not change the functionality of the code.
- Small additions to unit tests to verify that plans raise a TypeError if a generator is passed instead of a list.

