### PR TITLE
Pin Sphinx to <7.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dev = [
     "ruff",
     "scikit-image",
     "scipy",
+    "sphinx<7.3",
     "sphinx-autobuild",
     "sphinx-copybutton",
     "sphinx-design",


### PR DESCRIPTION
7.3 appears to be breaking the build, this PR pins it to unblock people. Issue to investigate further: https://github.com/bluesky/bluesky/issues/1716
