### PR TITLE
Include Python3.12 Classiefier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 description = "Experiment specification & orchestration."
 dependencies = [


### PR DESCRIPTION
Include python3.12 classifier in pyproject.toml

Leftover work from #1672 and #1683 
