### PR TITLE
MacOS fix for failing tests in the test_zmq.py 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "typing-extensions>=4.0.0;python_version<'3.11'",
     "dataclasses;python_version<'3.7'",
     "zict<3.0.0",
-    "multiprocess",
 ]
 dynamic = ["version"]
 license.file = "LICENSE"
@@ -49,6 +48,7 @@ dev = [
     "lmfit",
     "matplotlib >=3.5.0",
     "mongoquery",
+    "multiprocess",
     "mypy",
     "myst-parser",
     "networkx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dev = [
     "lmfit",
     "matplotlib >=3.5.0",
     "mongoquery",
-    "multiprocess",
     "mypy",
     "myst-parser",
     "networkx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "typing-extensions>=4.0.0;python_version<'3.11'",
     "dataclasses;python_version<'3.7'",
     "zict<3.0.0",
+    "multiprocess",
 ]
 dynamic = ["version"]
 license.file = "LICENSE"
@@ -48,6 +49,7 @@ dev = [
     "lmfit",
     "matplotlib >=3.5.0",
     "mongoquery",
+    "multiprocess",
     "mypy",
     "myst-parser",
     "networkx",

--- a/src/bluesky/tests/test_zmq.py
+++ b/src/bluesky/tests/test_zmq.py
@@ -13,7 +13,7 @@ from event_model import sanitize_doc
 from bluesky import Msg
 from bluesky.callbacks.zmq import Proxy, Publisher, RemoteDispatcher
 from bluesky.plans import count
-
+import multiprocess
 
 def test_proxy_script():
     p = run(["bluesky-0MQ-proxy", "-h"])
@@ -26,7 +26,7 @@ def test_zmq(RE, hw):
     def start_proxy():
         Proxy(5567, 5568).start()
 
-    proxy_proc = multiprocessing.Process(target=start_proxy, daemon=True)
+    proxy_proc = multiprocess.Process(target=start_proxy, daemon=True)
     proxy_proc.start()
     time.sleep(5)  # Give this plenty of time to start up.
 
@@ -52,8 +52,8 @@ def test_zmq(RE, hw):
         d.loop.call_later(9, d.stop)
         d.start()
 
-    queue = multiprocessing.Queue()
-    dispatcher_proc = multiprocessing.Process(target=make_and_start_dispatcher, daemon=True, args=(queue,))
+    queue = multiprocess.Queue()
+    dispatcher_proc = multiprocess.Process(target=make_and_start_dispatcher, daemon=True, args=(queue,))
     dispatcher_proc.start()
     time.sleep(5)  # As above, give this plenty of time to start.
 
@@ -145,7 +145,7 @@ def test_zmq_no_RE(RE):
     def start_proxy():
         Proxy(5567, 5568).start()
 
-    proxy_proc = multiprocessing.Process(target=start_proxy, daemon=True)
+    proxy_proc = multiprocess.Process(target=start_proxy, daemon=True)
     proxy_proc.start()
     time.sleep(5)  # Give this plenty of time to start up.
 
@@ -170,8 +170,8 @@ def test_zmq_no_RE(RE):
         d.loop.call_later(9, d.stop)
         d.start()
 
-    queue = multiprocessing.Queue()
-    dispatcher_proc = multiprocessing.Process(target=make_and_start_dispatcher, daemon=True, args=(queue,))
+    queue = multiprocess.Queue()
+    dispatcher_proc = multiprocess.Process(target=make_and_start_dispatcher, daemon=True, args=(queue,))
     dispatcher_proc.start()
     time.sleep(5)  # As above, give this plenty of time to start.
 
@@ -215,7 +215,7 @@ def test_zmq_no_RE_newserializer(RE):
     def start_proxy():
         Proxy(5567, 5568).start()
 
-    proxy_proc = multiprocessing.Process(target=start_proxy, daemon=True)
+    proxy_proc = multiprocess.Process(target=start_proxy, daemon=True)
     proxy_proc.start()
     time.sleep(5)  # Give this plenty of time to start up.
 
@@ -238,8 +238,8 @@ def test_zmq_no_RE_newserializer(RE):
         d.loop.call_later(9, d.stop)
         d.start()
 
-    queue = multiprocessing.Queue()
-    dispatcher_proc = multiprocessing.Process(target=make_and_start_dispatcher, daemon=True, args=(queue,))
+    queue = multiprocess.Queue()
+    dispatcher_proc = multiprocess.Process(target=make_and_start_dispatcher, daemon=True, args=(queue,))
     dispatcher_proc.start()
     time.sleep(5)  # As above, give this plenty of time to start.
 
@@ -281,7 +281,7 @@ def test_zmq_prefix(RE, hw):
     def start_proxy():
         Proxy(5567, 5568).start()
 
-    proxy_proc = multiprocessing.Process(target=start_proxy, daemon=True)
+    proxy_proc = multiprocess.Process(target=start_proxy, daemon=True)
     proxy_proc.start()
     time.sleep(5)  # Give this plenty of time to start up.
 
@@ -308,8 +308,8 @@ def test_zmq_prefix(RE, hw):
         d.loop.call_later(9, d.stop)
         d.start()
 
-    queue = multiprocessing.Queue()
-    dispatcher_proc = multiprocessing.Process(target=make_and_start_dispatcher, daemon=True, args=(queue,))
+    queue = multiprocess.Queue()
+    dispatcher_proc = multiprocess.Process(target=make_and_start_dispatcher, daemon=True, args=(queue,))
     dispatcher_proc.start()
     time.sleep(5)  # As above, give this plenty of time to start.
 

--- a/src/bluesky/tests/test_zmq.py
+++ b/src/bluesky/tests/test_zmq.py
@@ -1,11 +1,11 @@
 import gc
-import multiprocessing
 import os
 import signal
 import threading
 import time
 from subprocess import run
 
+import multiprocess
 import numpy as np
 import pytest
 from event_model import sanitize_doc
@@ -13,7 +13,7 @@ from event_model import sanitize_doc
 from bluesky import Msg
 from bluesky.callbacks.zmq import Proxy, Publisher, RemoteDispatcher
 from bluesky.plans import count
-import multiprocess
+
 
 def test_proxy_script():
     p = run(["bluesky-0MQ-proxy", "-h"])


### PR DESCRIPTION
8 tests in the test_zmq.py has been failing on MacOs system and it seems like there is a problem in pickling done in the `multiprocessing` module. The problems seems to be resolved by importing `multiprocess` which seems to be using dill  instead as suggested in [this example](https://stackoverflow.com/questions/72766345/attributeerror-cant-pickle-local-object-in-multiprocessing)
We run all tests both on Linux and MacOS after this change and problem seems to be solved. 
