### PR TITLE
Use tmp_path instead of tmpdir fixture

### DIFF
--- a/src/bluesky/tests/conftest.py
+++ b/src/bluesky/tests/conftest.py
@@ -29,14 +29,14 @@ def RE(request):
 
 
 @pytest.fixture(scope="function")
-def hw(tmpdir):
+def hw(tmp_path):
     import ophyd
     from ophyd.sim import hw
 
     # ophyd 1.4.0 added support for customizing the directory used by simulated
     # hardware that generates files
     if packaging.version.Version(ophyd.__version__) >= packaging.version.Version("1.4.0"):
-        return hw(str(tmpdir))
+        return hw(str(tmp_path))
     else:
         return hw()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Addresses #1727. This was the only occurrence of the `tmpdir` fixture in the `tests` directory currently.

Tests seem to run OK.

