### PR TITLE
Change the ZeroMQ tests to speed them up

### DIFF
--- a/src/bluesky/tests/test_zmq.py
+++ b/src/bluesky/tests/test_zmq.py
@@ -20,7 +20,7 @@ def test_proxy_script():
     assert p.returncode == 0
 
 
-def test_zmq(RE, hw):
+def test_zmq_basic(RE, hw):
     # COMPONENT 1
     # Run a 0MQ proxy on a separate process.
     def start_proxy():
@@ -139,7 +139,7 @@ def test_zmq_RD_ports_spec(host):
     del d
 
 
-def test_zmq_no_RE(RE):
+def test_zmq_no_RE_basic(RE):
     # COMPONENT 1
     # Run a 0MQ proxy on a separate process.
     def start_proxy():

--- a/src/bluesky/tests/test_zmq.py
+++ b/src/bluesky/tests/test_zmq.py
@@ -30,6 +30,8 @@ def _start_proxy_proc():
     proxy_proc.start()
     proxy_start_event.wait(timeout=5)
     assert proxy_start_event.is_set()
+    # The event only monitors that the process is started.
+    # Extra delay is needed to ensure that the proxy is started.
     time.sleep(0.2)
 
     return proxy_proc
@@ -58,6 +60,8 @@ def _start_dispatcher_proc(prefix=None):
     dispatcher_proc.start()
     dispatcher_start_event.wait(timeout=5)
     assert dispatcher_start_event.is_set()
+    # The event is set before dispatcher is started. It indicates that the process
+    # is running. Extra delay is needed to ensure that the dispatcher is started.
     time.sleep(0.2)
 
     return dispatcher_proc, queue


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Results:

- `tox -e tests -- src/bluesky/tests/test_zmq.py` takes slightly under 18s to complete (on my laptop), 
- `pytest -k test_zmq -vvv` takes slightly under 17s.

Related issue https://github.com/bluesky/bluesky/issues/1690

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
