### PR TITLE
Update for Tiled API change.

### DIFF
--- a/src/bluesky/callbacks/tiled_writer.py
+++ b/src/bluesky/callbacks/tiled_writer.py
@@ -379,10 +379,11 @@ class _RunWriter(DocumentRouter):
         handler.consume_stream_datum(doc)
 
         # Update StreamResource node in Tiled
-        # NOTE: Assigning data_source.id in the object and passing it in http params is superflous, but it is currently required by Tiled.  # noqa
+        # NOTE: Assigning data_source.id in the object and passing it in http
+        # params is superfluous, but it is currently required by Tiled.
         sres_node.refresh()
         data_source = handler.get_data_source()
-        data_source.id = sres_node.data_sources()[0]["id"]  # ID of the exisiting DataSource record
+        data_source.id = sres_node.data_sources()[0].id  # ID of the existing DataSource record
         endpoint = sres_node.uri.replace("/metadata/", "/data_source/", 1)
         handle_error(
             sres_node.context.http_client.put(


### PR DESCRIPTION
In the latest Tiled release, `get_data_sources()` changes its return type from `list[dict]` to `list[DataSource]` (a `dataclass`). Correspondingly, here in the `TiledWriter`, we need to update the usage from `data_source["id"]` to `data_source.id`. With the change, tests pass.