### PR TITLE
Update test for revised StreamResource.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "networkx",
     "numpydoc",
     "ophyd",
+    "packaging",
     "pandas",
     "pickleshare",
     "pipdeptree",

--- a/src/bluesky/tests/test_seq_num_indices_in_sync.py
+++ b/src/bluesky/tests/test_seq_num_indices_in_sync.py
@@ -40,8 +40,9 @@ class ExternalAssetDevice:
                 mimetype="application/x-hdf5",
                 uri=f"file://localhost/non_existent_{det}.hdf5",
                 data_key=det,
-                parameters={"path": "/data"}
-            ) for det in self.detectors
+                parameters={"path": "/data"},
+            )
+            for det in self.detectors
         )
         # Number of collect calls that will be made
         self.number_of_chunks = number_of_chunks
@@ -115,7 +116,7 @@ class ExternalAssetDevice:
                     mimetype="application/x-hdf5",
                     uri=f"file://localhost/non_existent_{det}.hdf5",
                     data_key=det,
-                    parameters={"path": "/data"}
+                    parameters={"path": "/data"},
                 )
                 for det in self.detectors
             )

--- a/src/bluesky/tests/test_seq_num_indices_in_sync.py
+++ b/src/bluesky/tests/test_seq_num_indices_in_sync.py
@@ -36,7 +36,12 @@ class ExternalAssetDevice:
         self.detectors = detectors or ["det1", "det2", "det3"]
         self.compose_stream_resource = ComposeStreamResource()
         self.stream_resource_compose_datum_pairs = tuple(
-            self.compose_stream_resource("", "", f"non_existent_{det}.hdf5", det, {}) for det in self.detectors
+            self.compose_stream_resource(
+                mimetype="application/x-hdf5",
+                uri=f"file://localhost/non_existent_{det}.hdf5",
+                data_key=det,
+                parameters={"path": "/data"}
+            ) for det in self.detectors
         )
         # Number of collect calls that will be made
         self.number_of_chunks = number_of_chunks
@@ -106,7 +111,13 @@ class ExternalAssetDevice:
         if self.current_chunk == int(self.number_of_chunks / 2):
             # New stream_resource half way through the run
             self.stream_resource_compose_datum_pairs = tuple(
-                self.compose_stream_resource("", "", f"non_existent_{det}.hdf5", det, {}) for det in self.detectors
+                self.compose_stream_resource(
+                    mimetype="application/x-hdf5",
+                    uri=f"file://localhost/non_existent_{det}.hdf5",
+                    data_key=det,
+                    parameters={"path": "/data"}
+                )
+                for det in self.detectors
             )
             yield from self.collect_resources()
 


### PR DESCRIPTION
The release of event-model 1.21.0 changed the schema of the experimental StreamResource document. This PR updates the tests to match.

This PR also fills in more realistic values for the dummy documents and switches to using keyword arguments. Neither of these changes affect how the code runs, but aim to make it a little easier to follow.