### PR TITLE
pin pyepics for py38

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,8 @@ dev = [
     "pipdeptree",
     "pre-commit",
     "pydata-sphinx-theme>=0.12",
-    "pyepics",
+    "pyepics<=3.5.2;python_version<'3.9'", # Currently broken on py3.8 
+    "pyepics;python_version>='3.9'",
     "pyqt5",
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
Currently it seems like pyepics is broken for python 3.8 due to requiring a 3.9+ version of importlib: https://github.com/pyepics/pyepics/issues/266

I propose just pinning it for python 3.8 until this is addressed

(note, test failure on 3.9 is due to unrelated numpy2.0/p4p issue https://github.com/mdavidsaver/p4p/issues/145)
