### PR TITLE
returned the results of `asyncio.wait` in `bps.wait_for`

### DIFF
--- a/docs/msg.rst
+++ b/docs/msg.rst
@@ -272,7 +272,7 @@ Ex ::
     def plan()
         results = (yield Msg('wait_for', [lambda : future ,]))
         for result in results:
-            # will give True if future raised an exception
+            # will give the exception raised
             result.exception()
 
 input

--- a/docs/msg.rst
+++ b/docs/msg.rst
@@ -263,6 +263,17 @@ Ex ::
     future.set_result(3)
     future.done() # will give True
 
+Returns a set of the tasks that were waited on.
+Ex ::
+
+    from asyncio.futures import Future
+    future = Future()
+    future.done() # will give false
+    def plan()
+        results = (yield Msg('wait_for', [lambda : future ,]))
+        for result in results:
+            # will give True if future raised an exception
+            result.exception()
 
 input
 +++++

--- a/src/bluesky/plan_stubs.py
+++ b/src/bluesky/plan_stubs.py
@@ -1196,6 +1196,11 @@ def wait_for(futures, **kwargs):
     msg : Msg
         ``Msg('wait_for', None, futures, **kwargs)``
 
+    Returns
+    -------
+    val : ``Set[asyncio.Task]``
+        a set of the asyncio tasks waited on.
+
     See Also
     --------
     :func:`bluesky.plan_stubs.wait`

--- a/src/bluesky/plan_stubs.py
+++ b/src/bluesky/plan_stubs.py
@@ -1196,11 +1196,6 @@ def wait_for(futures, **kwargs):
     msg : Msg
         ``Msg('wait_for', None, futures, **kwargs)``
 
-    Returns
-    -------
-    val : ``Set[asyncio.Task]``
-        a set of the asyncio tasks waited on.
-
     See Also
     --------
     :func:`bluesky.plan_stubs.wait`

--- a/src/bluesky/run_engine.py
+++ b/src/bluesky/run_engine.py
@@ -1781,7 +1781,7 @@ class RunEngine:
         return plan_return
 
     async def _wait_for(self, msg):
-        """Instruct the RunEngine to wait for futures
+        """Instruct the RunEngine to wait for futures and return the resulting tasks.
 
         Expected message object is:
 
@@ -1798,9 +1798,10 @@ class RunEngine:
 
         (futs,) = msg.args
         futs = [asyncio.ensure_future(f()) for f in futs]
-        _, pending = await asyncio.wait(futs, **self._loop_for_kwargs, **msg.kwargs)
+        completed, pending = await asyncio.wait(futs, **self._loop_for_kwargs, **msg.kwargs)
         if pending:
             raise WaitForTimeoutError("Plan failed to complete in the specified time")
+        return completed
 
     async def _open_run(self, msg):
         """Instruct the RunEngine to start a new "run"

--- a/src/bluesky/run_engine.py
+++ b/src/bluesky/run_engine.py
@@ -1801,7 +1801,7 @@ class RunEngine:
         completed, pending = await asyncio.wait(futs, **self._loop_for_kwargs, **msg.kwargs)
         if pending:
             raise WaitForTimeoutError("Plan failed to complete in the specified time")
-        return completed
+        return futs
 
     async def _open_run(self, msg):
         """Instruct the RunEngine to start a new "run"

--- a/src/bluesky/tests/test_run_engine.py
+++ b/src/bluesky/tests/test_run_engine.py
@@ -1972,7 +1972,7 @@ def test_wait_with_planstub(RE):
         failing_task = asyncio.create_task(failing_coro())
 
         tasks = yield from wait_for([lambda: passing_task, lambda: failing_task])
-        assert tasks == {passing_task, failing_task}
+        assert passing_task is tasks[0] and failing_task is tasks[1]
         assert passing_task.done() and passing_task.result() == 1080
         assert failing_task.done() and isinstance(failing_task.exception(), RuntimeError)
 


### PR DESCRIPTION
Also updated docs to reflect this, and added a test.
