### PR TITLE
ENH: Add a generic device configuration wrapper

### DIFF
--- a/src/bluesky/preprocessors.py
+++ b/src/bluesky/preprocessors.py
@@ -1300,6 +1300,7 @@ run_decorator = make_decorator(run_wrapper)
 contingency_decorator = make_decorator(contingency_wrapper)
 stub_decorator = make_decorator(stub_wrapper)
 configure_count_time_decorator = make_decorator(configure_count_time_wrapper)
+configure_devices_decorator = make_decorator(configure_devices_wrapper)
 
 
 class SupplementalData:


### PR DESCRIPTION
Added a generic device configuration wrapper, corresponding decorator and a unit test.

## Description
Added a plan wrapper that allows to bulk-configure devices based on a configuration dictionary
`{<component_name>: <component_value>}`

## Motivation and Context
I have written the wrapper for CLS bluesky project needs, and thought it's generic enough to be added to the bluesky codebase.
Hopefully someone in the community finds it useful.

## How Has This Been Tested?
In addition to a unit test that is a part of this PR, the wrapper has been tested with some custom simulated hardware.

The details of test setup can be provided upon request. Since it depends heavily on `ophyd` and includes some custom simulated hardware based off of classes from `ophyd.sim`, the full test setup can't be added to `bluesky` PR.

More unit tests can be written if required.

closes #1762 
