### PR TITLE
Windows: make plans using default `RunEngine` interruptible using CTRL-C

### DIFF
--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -1627,7 +1627,13 @@ class DuringTask:
         blocking_event : threading.Event
 
         """
-        blocking_event.wait()
+        if os.name == "nt":
+            # On windows, threading.Event.wait cannot be interrupted by CTRL-C - so split the
+            # wait into a series of smaller waits with timeouts.
+            while not blocking_event.wait(0.1):
+                pass
+        else:
+            blocking_event.wait()
 
 
 class DefaultDuringTask(DuringTask):
@@ -1667,7 +1673,7 @@ class DefaultDuringTask(DuringTask):
         global _qapp
         if "matplotlib" not in sys.modules:
             # We are not using matplotlib + Qt. Just wait on the Event.
-            blocking_event.wait()
+            super().block(blocking_event)
         # Figure out if we are using matplotlib with which backend
         # without importing anything that is not already imported.
         else:
@@ -1832,7 +1838,7 @@ class DefaultDuringTask(DuringTask):
                         return
             else:
                 # We are not using matplotlib + Qt. Just wait on the Event.
-                blocking_event.wait()
+                super().block(blocking_event)
 
 
 def _rearrange_into_parallel_dicts(readings):


### PR DESCRIPTION
On windows, the following is not interruptible using ctrl-c:

```python
from bluesky.run_engine import RunEngine
import bluesky.plan_stubs as bps
RE = RunEngine()
RE(bps.sleep(999))
```

The same plan is interruptible under linux.

Note: it is interruptible on windows if you have imported `matplotlib` and matplotlib happens to be using one of the `qt` backends - that case has special handling already.

## Description

The underlying problem is that on windows, `threading.Event.wait()` cannot be interrupted by ctrl-c. See CPython issue 80116 for details.

I think the approach in this PR means that:
- `block()` still returns as soon as possible after the event is set
- CTRL-C events are handled reasonably responsively for interactive users (within 0.1 secs)
- The approach on linux is unchanged and continues to use a non-polling approach - which in theory is slightly more efficient

I chose 0.1 seconds fairly arbitrarily as a "reasonably responsive" wait timeout for an interactive user, my feeling is we probably don't need to expose this as a configuration parameter as people can always use a custom `during_task` arg to the runengine if they need special behaviour.

## Motivation and Context

At ISIS we run on windows and are starting to use bluesky.

While we can already solve this for our use-case by passing a windows-specific `during_task` into the run engine constructor, I think it would be better if the default run-engine constructor did this.

## How Has This Been Tested?
- CTRL-C handling is tricky to test in an automated way, but I've added a unit test that checks we call `wait()` with short timeouts on windows and retains existing behaviour on linux.
- Manually tested on windows
- Manually tested on linux in a `python:3.11` container

