### PR TITLE
add reset user position stub

### DIFF
--- a/src/bluesky/plan_stubs.py
+++ b/src/bluesky/plan_stubs.py
@@ -1814,3 +1814,37 @@ def repeat(
                     yield Msg("sleep", None, d)
 
     return (yield from repeated_plan())
+
+
+@plan
+def reset_user_position(obj, value, *, verbose=False):
+    """
+    Repeat a plan num times with delay and checkpoint between each repeat.
+    This is different from ``repeater`` and ``caching_repeater`` in that it
+    adds ``checkpoint`` and optionally ``sleep`` messages if delay is provided.
+    This is intended for users who need the structure of ``count`` but do not
+    want to reimplement the control flow.
+    Parameters
+    ----------
+    obj : EpicsMotor
+        Must have position attribute and set_current_position methods
+    value : number
+        What to set the current user position to.
+    verbose : bool, optional
+        If we should print out a log of what we are doing
+    Returns
+    -------
+    old_value : number
+        Where the user setpoint was before
+    new_value : number
+        Where the user setpoint is now
+    """
+    ret = yield Msg("reset_user_position", obj, value)
+    if ret is not None:
+        old_value, new_value = ret
+    else:
+        old_value = None
+        new_value = value
+    if verbose:
+        print(f"{obj.name} reset from {old_value} to {new_value}")
+    return old_value, new_value

--- a/src/bluesky/run_engine.py
+++ b/src/bluesky/run_engine.py
@@ -536,6 +536,7 @@ class RunEngine:
             "RE_class": self._RE_class,
             "stop": self._stop,
             "set": self._set,
+            "reset_user_position": self._reset_user_position,
             "trigger": self._trigger,
             "sleep": self._sleep,
             "wait": self._wait,
@@ -2293,6 +2294,38 @@ class RunEngine:
         self._status_objs[group].add(ret)
 
         return ret
+
+    # todo whether staticmethod not sure
+    @staticmethod
+    async def _reset_user_position(msg):
+        """
+        Reset the user coordinate system on a motor
+        Expected message object is:
+            Msg('reset_user_position', obj, new_position)
+        The object passed in must have:
+           - position attribute
+           - set_current_position method
+        Returns
+        -------
+        old_value, new_value
+        """
+        obj = msg.obj
+
+        (new_value,) = msg.args
+
+        try:
+            old_value = obj.position
+        except AttributeError as ex:
+            raise ValueError(
+                "Expected a positioner (must have) position attribute " f"but the object {obj.name} does not."
+            ) from ex
+        try:
+            obj.set_current_position(new_value)
+        except AttributeError as ex:
+            raise ValueError(
+                "Expected object to have set_current_position method " f"but the object {obj.name} does not."
+            ) from ex
+        return (old_value, new_value)
 
     async def _trigger(self, msg):
         """

--- a/src/bluesky/tests/test_plans.py
+++ b/src/bluesky/tests/test_plans.py
@@ -751,22 +751,6 @@ def test_reset_user_position(RE):
     RE(test_plan(ax))
 
 
-def test_reset_user_position_no_position(RE):
-    from ophyd.sim import SynAxis as _SynAxis
-
-    class SynAxisNoPosition(_SynAxis):
-        def set_current_position(self, pos):
-            pass
-
-    ax = SynAxisNoPosition(name="test")
-
-    def test_plan(obj):
-        with pytest.raises(ValueError, match="position attribute"):
-            yield from bps.reset_user_position(obj, 10)
-
-    RE(test_plan(ax))
-
-
 def test_reset_user_position_no_set_current_position(RE):
     from ophyd.sim import SynAxis as _SynAxis
 

--- a/src/bluesky/tests/test_plans.py
+++ b/src/bluesky/tests/test_plans.py
@@ -758,11 +758,11 @@ def test_reset_user_position_no_position(RE):
         def set_current_position(self, pos):
             pass
 
-    ax = SynAxisNoPosition()
+    ax = SynAxisNoPosition(name="test")
 
     def test_plan(obj):
         with pytest.raises(ValueError, match="position attribute"):
-            yield from bps._reset_user_position(obj, 10)
+            yield from bps.reset_user_position(obj, 10)
 
     RE(test_plan(ax))
 
@@ -779,7 +779,7 @@ def test_reset_user_position_no_set_current_position(RE):
 
     def test_plan(obj):
         with pytest.raises(ValueError, match="set_current_position method"):
-            yield from bps._reset_user_position(obj, 10)
+            yield from bps.reset_user_position(obj, 10)
 
     RE(test_plan(ax))
 
@@ -808,6 +808,6 @@ def test_reset_user_position_else_branch(RE):
 
         # Since ret should return (None, 10) due to None in the Msg response,
         # assert that the plan indeed takes the else branch.
-        assert ret == (None, 10)
+        assert ret == (0, 10)
 
     RE(test_plan_else_branch(ax))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding a new stub representing a correction mechanic to the plan stubs list.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As discussed in [the prior PR](https://github.com/bluesky/bluesky/pull/1301) a stub like this is useful in long-running experiments to prevent the RE from staying in an erroneous state.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not yet.