### PR TITLE
Add private attribute for aiding in identifying if a function is a bluesky plan

### DIFF
--- a/src/bluesky/tests/test_utils.py
+++ b/src/bluesky/tests/test_utils.py
@@ -7,11 +7,13 @@ import pytest
 from cycler import cycler
 
 from bluesky import RunEngine
+from bluesky.plan_stubs import complete_all, mv
 from bluesky.utils import (
     CallbackRegistry,
     Msg,
     ensure_generator,
     is_movable,
+    is_plan,
     merge_cycler,
     plan,
     warn_if_msg_args_or_kwargs,
@@ -536,3 +538,17 @@ def test_warning_behavior(gen_func, iterated):
     else:
         with pytest.warns(RuntimeWarning, match=r".*was never iterated.*"):
             RE(gen_func())
+
+
+@pytest.mark.parametrize(
+    "func, is_plan_result",
+    [
+        (print, False),
+        (mv, True),
+        (complete_all, True),
+        (iterating_plan, True),
+        (sample_plan, True),
+    ],
+)
+def test_check_if_func_is_plan(func, is_plan_result):
+    assert is_plan(func) == is_plan_result

--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -1986,7 +1986,4 @@ def is_plan(bs_plan):
         True if bs_plan arg is a generator, or the __is_plan__ attribute exists and is True.
     """
 
-    if inspect.isgeneratorfunction(bs_plan) or getattr(bs_plan, "_is_plan_", False):
-        return True
-    else:
-        return False
+    return inspect.isgeneratorfunction(bs_plan) or getattr(bs_plan, "_is_plan_", False)

--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -1967,7 +1967,7 @@ def plan(bs_plan):
     def wrapper(*args, **kwargs) -> Plan:
         return Plan(bs_plan, *args, **kwargs)
 
-    wrapper.__is_plan__ = True
+    wrapper._is_plan_ = True
 
     return wrapper
 
@@ -1986,7 +1986,7 @@ def is_plan(bs_plan):
         True if bs_plan arg is a generator, or the __is_plan__ attribute exists and is True.
     """
 
-    if inspect.isgeneratorfunction(bs_plan) or getattr(bs_plan, "__is_plan__", False):
+    if inspect.isgeneratorfunction(bs_plan) or getattr(bs_plan, "_is_plan_", False):
         return True
     else:
         return False

--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -2,7 +2,6 @@ import abc
 import asyncio
 import collections.abc
 import datetime
-import functools
 import inspect
 import itertools
 import operator
@@ -1964,26 +1963,13 @@ def plan(bs_plan):
         Wrapped plans
     """
 
-    @wraps_plan(bs_plan, plan)
+    @wraps(bs_plan)
     def wrapper(*args, **kwargs) -> Plan:
         return Plan(bs_plan, *args, **kwargs)
 
+    wrapper.__is_plan__ = True
+
     return wrapper
-
-
-def mark_as_plan(wrapper, wrapped, decorator, **kwargs):
-    """Function that adds attr if plan decorator is applied"""
-
-    wrapper = functools.update_wrapper(wrapper, wrapped, **kwargs)
-    if decorator is plan:
-        wrapper.__is_plan__ = True
-    return wrapper
-
-
-def wraps_plan(wrapped, decorator, **kwargs):
-    """Modified wraps that marks decorated function as bs plan"""
-
-    return functools.partial(mark_as_plan, wrapped=wrapped, decorator=decorator, **kwargs)
 
 
 def is_plan(bs_plan):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds helper functions that can identify if a function is either a generator co-routine, or has been marked with the `@plan` decorator.

## Motivation and Context
Addresses need for checking whether or not a function is a plan as described in: #1779 


## How Has This Been Tested?
Added a parametrized unit test that passes & checks both positive and negative expected results. All other tests pass without issue (locally, waiting on CI).

```
(venv) [jwlodek@dell-rhel8 bluesky]$ git checkout main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.

(venv) [jwlodek@dell-rhel8 bluesky]$ python
Python 3.11.9 (main, Jun 19 2024, 10:02:06) [GCC 8.5.0 20210514 (Red Hat 8.5.0-22)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import inspect
>>> from bluesky.plan_stubs import mv
>>> inspect.isgeneratorfunction(mv)
False
>>> exit()

(venv) [jwlodek@dell-rhel8 bluesky]$ git checkout custom-wrapper-identify-plan 
Switched to branch 'custom-wrapper-identify-plan'

(venv) [jwlodek@dell-rhel8 bluesky]$ python
Python 3.11.9 (main, Jun 19 2024, 10:02:06) [GCC 8.5.0 20210514 (Red Hat 8.5.0-22)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from bluesky.utils import is_plan
>>> from bluesky.plan_stubs import mv
>>> is_plan(mv)
True
>>> is_plan(print)
False
>>> exit()
```