### PR TITLE
Update the name of the path in HDF sres parameter

### DIFF
--- a/src/bluesky/consolidators.py
+++ b/src/bluesky/consolidators.py
@@ -236,7 +236,7 @@ class HDF5Consolidator(ConsolidatorBase):
     def adapter_parameters(self) -> Dict:
         """Parameters to be passed to the HDF5 adapter, a dictionary with the keys:
 
-        dataset: List[str] - file dataset represented as list split at `/`
+        dataset: List[str] - a path to the dataset within the hdf5 file represented as list split at `/`
         swmr: bool -- True to enable the single writer / multiple readers regime
         """
         return {"dataset": self._sres_parameters["dataset"].strip("/").split("/"), "swmr": self.swmr}

--- a/src/bluesky/consolidators.py
+++ b/src/bluesky/consolidators.py
@@ -236,10 +236,10 @@ class HDF5Consolidator(ConsolidatorBase):
     def adapter_parameters(self) -> Dict:
         """Parameters to be passed to the HDF5 adapter, a dictionary with the keys:
 
-        path: List[str] - file path represented as list split at `/`
+        dataset: List[str] - file dataset represented as list split at `/`
         swmr: bool -- True to enable the single writer / multiple readers regime
         """
-        return {"path": self._sres_parameters["path"].strip("/").split("/"), "swmr": self.swmr}
+        return {"dataset": self._sres_parameters["dataset"].strip("/").split("/"), "swmr": self.swmr}
 
 
 class TIFFConsolidator(ConsolidatorBase):

--- a/src/bluesky/tests/test_tiled_writer.py
+++ b/src/bluesky/tests/test_tiled_writer.py
@@ -69,12 +69,12 @@ class StreamDatumReadableCollectable(Named, Readable, Collectable, WritesStreamA
         data_desc = self.describe()[data_key]  # Descriptor dictionary for the current data key
         data_shape = tuple(data_desc["shape"])
         data_shape = data_shape if data_shape != (1,) else ()
-        hdf5_path = f"/{data_key}/VALUE"
+        hdf5_dataset = f"/{data_key}/VALUE"
 
         stream_resource = None
         if self.counter == 0:
             stream_resource = StreamResource(
-                parameters={"path": hdf5_path, "chunk_size": False},
+                parameters={"dataset": hdf5_dataset, "chunk_size": False},
                 data_key=data_key,
                 root=self.root,
                 resource_path="/dataset.h5",
@@ -86,7 +86,7 @@ class StreamDatumReadableCollectable(Named, Readable, Collectable, WritesStreamA
             # Initialize an empty HDF5 dataset (3D: var 1 dim, fixed 2 and 3 dims)
             with h5py.File(file_path, "a") as f:
                 dset = f.require_dataset(
-                    hdf5_path,
+                    hdf5_dataset,
                     (0, *data_shape),
                     maxshape=(None, *data_shape),
                     dtype=np.dtype("double"),
@@ -104,7 +104,7 @@ class StreamDatumReadableCollectable(Named, Readable, Collectable, WritesStreamA
 
         # Write (append to) the hdf5 dataset
         with h5py.File(file_path, "a") as f:
-            dset = f[hdf5_path]
+            dset = f[hdf5_dataset]
             dset.resize([indx_max, *data_shape])
             dset[indx_min:indx_max, ...] = np.random.randn(indx_max - indx_min, *data_shape)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
During testing of ophyd-async devices, I was seeing a traceback caused by a KeyError on the `path` key. This is because in newer versions of ophyd-async the stream resource uses `dataset` as the parameter key name, rather than `path`: https://github.com/bluesky/ophyd-async/blob/5ac94e283b170b603df42a7d5fe33fd7f2786524/src/ophyd_async/core/_hdf_dataset.py#L64

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

```
doc = {'uid': '17a66a91-2b4a-40ae-b9be-97921a94bcd1', 'data_key': 'manta-cam1', 'mimetype': 'application/x-hdf5', 'uri': 'file://localhost/ns
ls2/data/tst/legacy/mock-proposals/2024-1/pass-000000/assets/proj_1b2430d3-2c75-48c2-8267-7bab4e20d63f.h5', 'parameters': {'dataset': '/entry
/data/data', 'swmr': False, 'multiplier': 1}, 'run_start': '98494492-75ff-49f2-a332-41d8e3fcd065'}                                           
```

Without this change, an `RE(count([manta]))` will fail with a KeyError:

```
    246 self._handlers[sres_uid] = handler                                                                                                   
    247 self._sres_nodes[sres_uid] = sres_node                                                                                               
                                                                                                                                             
File ~/.ipython/profile_collection_tst/overlays/bluesky/src/bluesky/consolidators.py:186, in ConsolidatorBase.get_data_source(self=<bluesky.c
onsolidators.HDF5Consolidator object>)                                                                                                       
    170 def get_data_source(self) -> DataSource:                                                                                             
    171     """Return a DataSource object reflecting the current state of the streamed dataset.                                              
    172                                                                                                                                      
    173     The returned DataSource is conceptually similar (and can be an instance of) tiled.structures.DataSource. In                      
    174     general, it describes associated Assets (filepaths, mimetype) along with their internal data structure                           
    175     (array shape, chunks, additional parameters) and should contain all information necessary to read the file.                      
    176     """                                                                                                                              
    177     return DataSource(                                                                                                               
    178         mimetype=self.mimetype,                                                                                                      
    179         assets=self.assets,                                                                                                          
    180         structure_family=StructureFamily.array,                                                                                      
    181         structure=ArrayStructure(                                                                                                    
    182             data_type=BuiltinDtype.from_numpy_dtype(self.dtype),                                                                     
    183             shape=self.shape,                                                                                                        
    184             chunks=self.chunks,                                                                                                      
    185         ),                                                                                                                           
--> 186         parameters=self.adapter_parameters,                                                                                          
        self.mimetype = 'application/x-hdf5'                                                                                                 
        self = <bluesky.consolidators.HDF5Consolidator object at 0x7f6ac7cd5a10>                                                             
        self.assets = [Asset(data_uri='file://localhost/nsls2/data/tst/legacy/mock-proposals/2024-1/pass-000000/assets/proj_92a13da7-bcb2-448
f-ac77-630d456d5c6e.h5', is_directory=False, parameter='data_uri', num=None, id=None)]                                                       
        StructureFamily.array = <StructureFamily.array: 'array'>                                                                             
        self.dtype = dtype('float64')                                                                                                        
        Management.external = <Management.external: 'external'>                                                                              
    187         management=Management.external,                                                                                              
    188     )                                                                                                                                
                                                                                                                                             
File ~/.ipython/profile_collection_tst/overlays/bluesky/src/bluesky/consolidators.py:242, in HDF5Consolidator.adapter_parameters(self=<bluesk
y.consolidators.HDF5Consolidator object>)                                                                                                    
    235 @property                                                                                                                            
    236 def adapter_parameters(self) -> Dict:                                                                                                
    237     """Parameters to be passed to the HDF5 adapter, a dictionary with the keys:                                                      
    238                                                                                                                                      
    239     path: List[str] - file path represented as list split at `/`                                                                     
    240     swmr: bool -- True to enable the single writer / multiple readers regime                                                         
    241     """                                                                                                                              
--> 242     return {"path": self._sres_parameters["path"].strip("/").split("/"), "swmr": self.swmr}                                          
        self.swmr = False                                                                                                                    
        self = <bluesky.consolidators.HDF5Consolidator object at 0x7f6ac7cd5a10>                                                             
        self._sres_parameters = {'dataset': '/entry/data/data', 'swmr': False, 'multiplier': 1}                                              
                                                                                                                                             
KeyError: 'path'                                                                                                                             

```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running unit tests, & running against a camera in our test lab.

<!--
## Screenshots (if appropriate):
-->
