### PR TITLE
ENH - RunEngine._wait will now accept a list of status objects as a group in-lieu of a group name. See #1410

### DIFF
--- a/src/bluesky/run_engine.py
+++ b/src/bluesky/run_engine.py
@@ -2323,12 +2323,18 @@ class RunEngine:
         true when all triggered objects are done. When the keyword argument
         `move_on=<MOVE_ON>` is true, this method can return before all objects are done
         after a flush period given by the `timeout=<TIMEOUT>` keyword argument.
+        
+        Optionally, the `group` keyword argument can be a list of status objects passed
+        in the same way. A temporary group is created for them and the function is 
+        processed as normal.
 
-        Expected message object is:
+        Expected message objects are:
 
             Msg('wait', group=<GROUP>, move_on=<MOVE_ON>)
+            Msg('wait', group=[<STATUS_OBJECTS>], move_on=<MOVE_ON>)
 
-        where ``<GROUP>`` is any hashable key and ``<MOVE_ON>`` is a boolean.
+        where ``<GROUP>`` is any hashable key, ``<MOVE_ON>`` is a boolean, and
+        ``[<STATUS_OBJECTS>]`` is a list of status objects.
         """
         _set_span_msg_attributes(trace.get_current_span(), msg)
         done = False  # boolean that tracks whether waiting is complete
@@ -2338,6 +2344,13 @@ class RunEngine:
         else:
             group = msg.kwargs["group"]
             move_on = msg.kwargs.get("move_on", False)
+            
+        if isinstance(group, list):
+            status_objs = group
+            group = "__status_group__"
+            for status in status_objs:
+                self._add_status_to_group(obj=None, status_object=status, group=group, action="wait")
+                
         if group:
             trace.get_current_span().set_attribute("group", group)
         else:

--- a/src/bluesky/tests/test_run_engine.py
+++ b/src/bluesky/tests/test_run_engine.py
@@ -1957,6 +1957,33 @@ def test_wait_with_timeout(set_finished, RE):
             RE(plan())
 
 
+@pytest.mark.parametrize("set_finished", [True, False])
+def test_wait_with_statuses(set_finished, RE):
+    from ophyd import StatusBase
+    from ophyd.device import Device
+
+    class MockDevice(Device):
+        def stage(self):
+            status = StatusBase()
+            if set_finished:
+                status.set_finished()
+            return status
+
+    mock_device_a = MockDevice(name="mock_device_a")
+    mock_device_b = MockDevice(name="mock_device_b")
+
+    def plan():
+        status_a = yield Msg("stage", mock_device_a)
+        status_b = yield Msg("stage", mock_device_b)
+        yield from wait(group=[status_a, status_b], timeout=0.1)
+
+    if set_finished:
+        RE(plan())
+    else:
+        with pytest.raises(TimeoutError):
+            RE(plan())
+
+
 async def passing_coroutine():
     await asyncio.sleep(0.001)
     return 1080


### PR DESCRIPTION
RunEngine._wait will now accept a list of status objects as a group in-lieu of a group name. See #1410

## Description
RunEngine._wait can be passed a list of status objects. It will then create a new group label called '__status_group__'
and add each status to this group. The method then proceeds as normal.

## Motivation and Context
Being able to wait on a status object is an intuitive use of the 'wait' plan stub. 

## How Has This Been Tested?
In a Jupyter notebook I passed multiple status objects in-lieu of group and the operation seemed to process correctly.
I wrote a test but for some reason I can't seem to run tests properly on my machine as many other tests seems to throw
thread exceptions.
