### PR TITLE
handle ZeroDivisionError in fitting.py/center_of_mass()

### DIFF
--- a/src/bluesky/callbacks/fitting.py
+++ b/src/bluesky/callbacks/fitting.py
@@ -166,6 +166,8 @@ def center_of_mass(input, labels=None, index=None):
     [(0.33333333333333331, 1.3333333333333333), (3.5, 2.5)]
     """
     normalizer = np.sum(input, labels, index)
+    if normalizer == 0:
+        normalizer  = 1  # special case to avoid ZeroDivisionError
     grids = np.ogrid[[slice(0, i) for i in input.shape]]
 
     results = [np.sum(input * grids[dir].astype(float), labels, index) / normalizer for dir in range(input.ndim)]

--- a/src/bluesky/tests/test_center_of_mass.py
+++ b/src/bluesky/tests/test_center_of_mass.py
@@ -1,0 +1,18 @@
+import numpy as np
+from scipy import ndimage
+
+from bluesky.callbacks.fitting import center_of_mass
+
+
+def test_center_of_mass():
+    assert True
+
+    arr = np.array(([0, 0, 0, 0], [0, 1, 1, 0], [0, 1, 1, 0], [0, 1, 1, 0]))
+    result = ndimage.measurements.center_of_mass(arr)
+    assert result == (2.0, 1.5), f"{result=}"
+
+    # Calculation of multiple objects in an image
+    b_arr = np.array(([0, 1, 1, 0], [0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 1, 1], [0, 0, 1, 1]))
+    lbl = ndimage.label(b_arr)[0]
+    result = ndimage.measurements.center_of_mass(b_arr, lbl, [1, 2])
+    assert result == [(0.33333333333333331, 1.3333333333333333), (3.5, 2.5)]

--- a/src/bluesky/tests/test_center_of_mass.py
+++ b/src/bluesky/tests/test_center_of_mass.py
@@ -1,18 +1,30 @@
 import numpy as np
-from scipy import ndimage
+import pytest
 
 from bluesky.callbacks.fitting import center_of_mass
 
 
-def test_center_of_mass():
-    assert True
-
-    arr = np.array(([0, 0, 0, 0], [0, 1, 1, 0], [0, 1, 1, 0], [0, 1, 1, 0]))
-    result = ndimage.measurements.center_of_mass(arr)
-    assert result == (2.0, 1.5), f"{result=}"
-
-    # Calculation of multiple objects in an image
-    b_arr = np.array(([0, 1, 1, 0], [0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 1, 1], [0, 0, 1, 1]))
-    lbl = ndimage.label(b_arr)[0]
-    result = ndimage.measurements.center_of_mass(b_arr, lbl, [1, 2])
-    assert result == [(0.33333333333333331, 1.3333333333333333), (3.5, 2.5)]
+@pytest.mark.parametrize(
+    "arr, labels, index, expected",
+    [
+        # example from the source code
+        [[[0, 0, 0, 0], [0, 1, 1, 0], [0, 1, 1, 0], [0, 1, 1, 0]], None, None, (2.0, 1.5)],
+        # signal is all zero, does not raise ZeroDivisionError or other
+        [[[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], None, None, (0.0, 0.0)],
+        # multiple objects in an image
+        # # FIXME: TypeError: Field elements must be 2- or 3-tuples, got '1'
+        # [
+        #     [[0, 1, 1, 0], [0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 1, 1], [0, 0, 1, 1]],
+        #     [[0, 1, 1, 0], [0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 2, 2], [0, 0, 2, 2]],
+        #     [1, 2],
+        #     [(1.0 / 3, 4.0 / 3), (3.5, 2.5)],
+        # ],
+        # 1-D
+        [[0, 1, 1, 1, 0], None, None, (2.0,)],
+    ],
+)
+def test_center_of_mass(arr, labels, index, expected):
+    if labels is not None:
+        labels = np.array(labels)
+    result = center_of_mass(np.array(arr), labels=labels, index=index)
+    assert result == expected, f"{result=}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- #1541

## Description

- Avoids a `ZeroDivisionError` when computing a center of mass.
- Adds first unit tests for this function.

## Motivation and Context

When a signal is all zero, it provokes a `ZeroDivisionError` in the `center_of_mass()` function.  We know why this happens and want to ensure an exception is not raised in such cases.

## How Has This Been Tested?

Unit tests, including example data that provokes the exception.
