### PR TITLE
made `Reading` generic on the type of `Reading.value`

### DIFF
--- a/src/bluesky/consolidators.py
+++ b/src/bluesky/consolidators.py
@@ -95,14 +95,12 @@ class ConsolidatorBase:
         # 3. Get 'dtype', required by the schema, which is a fuzzy JSON spec like 'number'
         #    and make a best effort to convert it to a numpy spec like '<u8'.
         # 4. If unable to do any of the above, pass through whatever string is in 'dtype'.
-        self.dtype = (
-            np.dtype(
-                data_desc.get("dtype_numpy")  # standard location
-                or data_desc.get(
-                    "dtype_str",  # legacy location
-                    # try to guess numpy dtype from JSON type
-                    DTYPE_LOOKUP.get(data_desc["dtype"], data_desc["dtype"])
-                )
+        self.dtype = np.dtype(
+            data_desc.get("dtype_numpy")  # standard location
+            or data_desc.get(
+                "dtype_str",  # legacy location
+                # try to guess numpy dtype from JSON type
+                DTYPE_LOOKUP.get(data_desc["dtype"], data_desc["dtype"]),
             )
         )
         self.chunk_size = self._sres_parameters.get("chunk_size", None)

--- a/src/bluesky/protocols.py
+++ b/src/bluesky/protocols.py
@@ -50,11 +50,15 @@ class ReadingOptional(TypedDict, total=False):
     message: str
 
 
-class Reading(ReadingOptional):
+T = TypeVar("T")
+P = ParamSpec("P")
+
+
+class Reading(Generic[T], ReadingOptional):
     """A dictionary containing the value and timestamp of a piece of scan data"""
 
     #: The current value, as a JSON encodable type or numpy array
-    value: Any
+    value: T
     #: Timestamp in seconds since the UNIX epoch
     timestamp: float
 
@@ -71,8 +75,6 @@ StreamAsset = Union[
 ]
 
 
-T = TypeVar("T")
-P = ParamSpec("P")
 SyncOrAsync = Union[T, Awaitable[T]]
 SyncOrAsyncIterator = Union[Iterator[T], AsyncIterator[T]]
 


### PR DESCRIPTION
Closes #1800

I believe this means `Reading` will be typed as `Reading[Any]` but will double check.

### EDIT

Ah pyright sees an unannotated `Reading` as `Reading[Unknown]` which is actually very nice. Whatever `Reading`'s are allowed.