### PR TITLE
add mode pause on error

### DIFF
--- a/src/bluesky/tests/conftest.py
+++ b/src/bluesky/tests/conftest.py
@@ -76,3 +76,16 @@ def cleanup_any_figures(request):
 
     "Close any matplotlib figures that were opened during a test."
     plt.close("all")
+
+
+@pytest.fixture(scope="function", params=["NO", "YES"])
+def bluesky_pause_on_plan_exception_env_var(request):
+    tmpv = None
+    if "BLUESKY_PAUSE_ON_PLAN_EXCEPTION" in os.environ:
+        tmpv = os.environ["BLUESKY_PAUSE_ON_PLAN_EXCEPTION"]
+    os.environ["BLUESKY_PAUSE_ON_PLAN_EXCEPTION"] = request.param
+    yield
+    if tmpv is None:
+        os.environ.pop("BLUESKY_PAUSE_ON_PLAN_EXCEPTION")
+    else:
+        os.environ["BLUESKY_PAUSE_ON_PLAN_EXCEPTION"] = tmpv


### PR DESCRIPTION
This PR introduces control over the behavior of a plan when it encounters an error state. 

## Description
If the environment variable `BLUESKY_PAUSE_ON_PLAN_EXCEPTION` is set to `YES`, the plan will transition to the pause state. If the variable is set to NO or is not set, the plan will proceed with the cleanup, which is the default behavior.
`finalize_wrapper` has been refactored to call `contingency_wrapper` with the `pause_for_debug` argument explicitly passed.


## Motivation and Context
This PR addresses issue #1755. The implementation is based on the discussion outlined in that issue.

## How Has This Been Tested?
The unit test verifies that the RunEngine swiches to `pause` state upon encountering an error if the `BLUESKY_PAUSE_ON_PLAN_EXCEPTION` environment variable is set to `YES`; otherwise, it ensures that the exception is processed without pausing.
