### PR TITLE
Support ophyd-async signals in Suspenders

### DIFF
--- a/docs/api_changes.rst
+++ b/docs/api_changes.rst
@@ -5,9 +5,29 @@
 Unreleased
 ==========
 
+Added
+-----
+
+- Suspenders accept signals implementing ``bluesky.protocols.Subscribable``,
+  such as ophyd-async signals, as well as ophyd ones.  ``install`` picks the
+  subscription style from the signal.  For a ``Subscribable`` it subscribes,
+  and ``remove`` unsubscribes, on the RunEngine's event loop, since a
+  subscription belongs to the loop that made it.  Passing a signal that is
+  neither now raises a ``RuntimeError`` from ``install`` rather than an
+  ``AttributeError``.
+
 Changed
 -------
 
+- Suspender justification messages report the last value the suspender was
+  called back with, rather than calling ``signal.get()`` when the message is
+  built.  As well as being readable for signals that cannot be read
+  synchronously, this reports the value that actually tripped the suspender
+  rather than whatever it has since become.
+- ``SuspendWhenChanged`` defaults ``expected_value`` to the first value it is
+  called back with for a ``Subscribable`` signal, since one cannot be read
+  synchronously when the suspender is created.  The default for ophyd signals
+  is unchanged: the value of the signal at creation.
 - The ``bluesky.protocols.Subscribable`` protocol now requires a
   ``subscribe_reading`` method rather than a ``subscribe`` method.  The
   protocol did not match the implementation it was written to describe:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ dev = [
     "pyepics",
     "pyqt5",
     "pytest",
-    "pytest-asyncio",
     "pytest-cov",
     "pytest-faulthandler",
     "pyyaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dev = [
     "pyepics",
     "pyqt5",
     "pytest",
+    "pytest-asyncio",
     "pytest-cov",
     "pytest-faulthandler",
     "pyyaml",

--- a/src/bluesky/suspenders.py
+++ b/src/bluesky/suspenders.py
@@ -42,6 +42,7 @@ class SuspenderBase(metaclass=ABCMeta):
         self._sig = signal
         self._pre_plan = pre_plan
         self._post_plan = post_plan
+        self._last_value = None
 
     def __repr__(self):
         return "{}({!r}, sleep={}, pre_plan={}, post_plan={}, tripped_message={})".format(  # noqa: UP032
@@ -131,7 +132,7 @@ class SuspenderBase(metaclass=ABCMeta):
             if self.RE is None:
                 return
             loop = self.RE._loop
-
+            self._last_value = value
             if self._should_suspend(value):
                 self._tripped = True
                 # this does dirty things with internal state
@@ -374,7 +375,7 @@ class SuspendFloor(_Threshold):
             return ""
 
         just = (
-            f"Signal {self._sig.name} = {self._sig.get()!r} "
+            f"Signal {self._sig.name} = {self._last_value!r} "
             + f"fell below {self._suspend_thresh} "
             + f"and has not yet crossed above {self._resume_thresh}."
         )
@@ -429,7 +430,7 @@ class SuspendCeil(_Threshold):
             return ""
 
         just = (
-            f"Signal {self._sig.name} = {self._sig.get()!r} "
+            f"Signal {self._sig.name} = {self._last_value!r} "
             + f"went above {self._suspend_thresh} "
             + f"and has not yet crossed below {self._resume_thresh}."
         )
@@ -490,7 +491,7 @@ class SuspendWhenOutsideBand(_SuspendBandBase):
             return ""
 
         just = "Signal {} = {!r} is outside of the range ({}, {})".format(  # noqa: UP032
-            self._sig.name, self._sig.get(), self._bot, self._top
+            self._sig.name, self._last_value, self._bot, self._top
         )
         return ": ".join(s for s in (just, self._tripped_message) if s)
 
@@ -547,7 +548,7 @@ class SuspendOutBand(_SuspendBandBase):
             return ""
 
         just = "Signal {} = {!r} is inside of the range ({}, {})".format(  # noqa: UP032
-            self._sig.name, self._sig.get(), self._bot, self._top
+            self._sig.name, self._last_value, self._bot, self._top
         )
         return ": ".join(s for s in (just, self._tripped_message) if s)
 
@@ -683,7 +684,7 @@ class SuspendWhenChanged(SuspenderBase):
         if not self.tripped:
             return ""
 
-        just = f'Signal {self._sig.name}, got "{self._sig.get()}", expected "{self.expected_value}"'
+        just = f'Signal {self._sig.name}, got "{self._last_value}", expected "{self.expected_value}"'
         if not self.allow_resume:
             just += '.  "RE.abort()" and then restart session to use new configuration.'
         return ": ".join(s for s in (just, self._tripped_message) if s)

--- a/src/bluesky/suspenders.py
+++ b/src/bluesky/suspenders.py
@@ -6,6 +6,8 @@ from datetime import datetime, timedelta
 from functools import partial
 from warnings import warn
 
+from bluesky.protocols import Subscribable
+
 
 class SuspenderBase(metaclass=ABCMeta):
     """An ABC to manage the callbacks between asyincio and pyepics.
@@ -30,12 +32,9 @@ class SuspenderBase(metaclass=ABCMeta):
     tripped_message : str, optional
         Message to include in the trip notification
 
-    is_async : bool, optional
-        Whether the signal is asynchronous and implements `subscribe_value`
-        or is synchronous and implements `subscribe`
     """
 
-    def __init__(self, signal, *, sleep=0, pre_plan=None, post_plan=None, tripped_message="", is_async=False):
+    def __init__(self, signal, *, sleep=0, pre_plan=None, post_plan=None, tripped_message=""):
         """ """
         self.RE = None
         self._ev = None
@@ -47,7 +46,8 @@ class SuspenderBase(metaclass=ABCMeta):
         self._pre_plan = pre_plan
         self._post_plan = post_plan
         self._last_value = None
-        self._is_async = is_async
+        # TODO also check if is ophyd-style of Subscribable
+        self._implements_protocol = isinstance(signal, Subscribable)
 
     def __repr__(self):
         return "{}({!r}, sleep={}, pre_plan={}, post_plan={}, tripped_message={})".format(  # noqa: UP032
@@ -75,8 +75,8 @@ class SuspenderBase(metaclass=ABCMeta):
         """
         with self._lock:
             self.RE = RE
-        if self._is_async:
-            self.RE.loop.call_soon_threadsafe(partial(self._sig.subscribe_value, self))
+        if self._implements_protocol:
+            self.RE.loop.call_soon_threadsafe(partial(self._sig.subscribe_reading, self))
         else:
             self._sig.subscribe(self, event_type=event_type, run=True)
 
@@ -140,6 +140,9 @@ class SuspenderBase(metaclass=ABCMeta):
             if self.RE is None:
                 return
             loop = self.RE._loop
+            if self._implements_protocol:
+                # TODO, handle signal name here properly
+                value = list(value.values())[0]["value"]
             self._last_value = value
             if self._should_suspend(value):
                 self._tripped = True

--- a/src/bluesky/suspenders.py
+++ b/src/bluesky/suspenders.py
@@ -2,11 +2,16 @@ import asyncio
 import operator
 import threading
 from abc import ABCMeta, abstractmethod, abstractproperty
+from concurrent.futures import Future
 from datetime import datetime, timedelta
 from functools import partial
 from warnings import warn
 
 from bluesky.protocols import Subscribable
+
+# How long install() and remove() wait for the RunEngine's event loop to
+# subscribe to a Subscribable signal, or unsubscribe from it, before giving up.
+SUBSCRIPTION_TIMEOUT = 10
 
 
 class SuspenderBase(metaclass=ABCMeta):
@@ -15,7 +20,7 @@ class SuspenderBase(metaclass=ABCMeta):
 
     Parameters
     ----------
-    signal : `ophyd.Signal`
+    signal : `ophyd.Signal` or `bluesky.protocols.Subscribable`
         The signal to watch for changes to determine if the
         scan should be suspended
 
@@ -31,7 +36,6 @@ class SuspenderBase(metaclass=ABCMeta):
 
     tripped_message : str, optional
         Message to include in the trip notification
-
     """
 
     def __init__(self, signal, *, sleep=0, pre_plan=None, post_plan=None, tripped_message=""):
@@ -46,7 +50,6 @@ class SuspenderBase(metaclass=ABCMeta):
         self._pre_plan = pre_plan
         self._post_plan = post_plan
         self._last_value = None
-        # TODO also check if is ophyd-style of Subscribable
         self._implements_protocol = isinstance(signal, Subscribable)
 
     def __repr__(self):
@@ -76,16 +79,53 @@ class SuspenderBase(metaclass=ABCMeta):
         with self._lock:
             self.RE = RE
         if self._implements_protocol:
-            self.RE.loop.call_soon_threadsafe(partial(self._sig.subscribe_reading, self))
-        else:
+            self.__on_loop(RE, partial(self._sig.subscribe_reading, self))
+        elif callable(getattr(self._sig, "subscribe", None)):
             self._sig.subscribe(self, event_type=event_type, run=True)
+        else:
+            raise RuntimeError(
+                "%s does not implement Subscribable protocol or adhere to ophyd subscription pattern." % self._sig
+            )
+
+    def __on_loop(self, RE, func):
+        """Call ``func`` on the RunEngine's event loop, and wait for it.
+
+        Subscribing to a Subscribable signal, and unsubscribing from it, both
+        have to happen on the thread its event loop runs in: an EPICS channel
+        access monitor, for one, belongs to the loop that made it.
+
+        Waiting also gives ``install`` the same guarantee as ophyd's
+        ``subscribe(..., run=True)``, since ``subscribe_reading`` calls back
+        with the current reading: the suspender knows whether it is already
+        tripped by the time ``install`` returns.
+        """
+        if threading.get_ident() == getattr(RE._loop, "_thread_id", "unknown"):
+            func()
+            return
+
+        future: Future = Future()
+
+        def call():
+            try:
+                future.set_result(func())
+            except BaseException as exc:
+                future.set_exception(exc)
+
+        RE._loop.call_soon_threadsafe(call)
+        future.result(timeout=SUBSCRIPTION_TIMEOUT)
 
     def remove(self):
         """Disable the suspender
 
         Removes the callback at the pyepics level
         """
-        self._sig.clear_sub(self)
+        if self._implements_protocol:
+            # Nothing was subscribed if we were never installed, and there is
+            # no event loop to unsubscribe on either.
+            if self.RE is not None:
+                self.__on_loop(self.RE, partial(self._sig.clear_sub, self))
+        else:
+            self._sig.clear_sub(self)
         with self._lock:
             if self.RE is not None:
                 self.__set_event(self.RE._loop)
@@ -141,8 +181,8 @@ class SuspenderBase(metaclass=ABCMeta):
                 return
             loop = self.RE._loop
             if self._implements_protocol:
-                # TODO, handle signal name here properly
-                value = list(value.values())[0]["value"]
+                # Subscribable calls back with {name: Reading}
+                value = value[self._sig.name]["value"]
             self._last_value = value
             if self._should_suspend(value):
                 self._tripped = True
@@ -600,14 +640,16 @@ class SuspendWhenChanged(SuspenderBase):
     Parameters
     ----------
 
-    signal : `ophyd.Signal`
+    signal : `ophyd.Signal` or `bluesky.protocols.Subscribable`
         The signal to watch for changes to determine if the
         scan should be suspended
 
     expected_value : str, float, or int
         RunEngine operations will be suspended when signal deviates
         from this value.  If `None` (default), set to value of
-        ``signal`` when object is created.
+        ``signal`` when object is created.  A `~bluesky.protocols.Subscribable`
+        signal cannot be read synchronously, so for those it is instead set to
+        the first value received, when the object is installed on a RunEngine.
 
     allow_resume : bool
         Should RunEngine be allowed to resume once ``signal.value == expected``
@@ -679,13 +721,19 @@ class SuspendWhenChanged(SuspenderBase):
         tripped_message="",
         **kwargs,
     ):
-        self.expected_value = signal.value if expected_value is None else expected_value
+        if expected_value is None and not isinstance(signal, Subscribable):
+            expected_value = signal.value
+        self.expected_value = expected_value
         self.allow_resume = allow_resume
         super().__init__(
             signal, sleep=sleep, pre_plan=pre_plan, post_plan=post_plan, tripped_message=tripped_message, **kwargs
         )
 
     def _should_suspend(self, value):
+        if self.expected_value is None:
+            # A Subscribable signal cannot be read synchronously in __init__, so
+            # take the value it calls back with on install as the expected one.
+            self.expected_value = value
         return value != self.expected_value
 
     def _should_resume(self, value):

--- a/src/bluesky/suspenders.py
+++ b/src/bluesky/suspenders.py
@@ -29,9 +29,13 @@ class SuspenderBase(metaclass=ABCMeta):
 
     tripped_message : str, optional
         Message to include in the trip notification
+
+    is_async : bool, optional
+        Whether the signal is asynchronous and implements `subscribe_value`
+        or is synchronous and implements `subscribe`
     """
 
-    def __init__(self, signal, *, sleep=0, pre_plan=None, post_plan=None, tripped_message=""):
+    def __init__(self, signal, *, sleep=0, pre_plan=None, post_plan=None, tripped_message="", is_async=False):
         """ """
         self.RE = None
         self._ev = None
@@ -43,6 +47,7 @@ class SuspenderBase(metaclass=ABCMeta):
         self._pre_plan = pre_plan
         self._post_plan = post_plan
         self._last_value = None
+        self._is_async = is_async
 
     def __repr__(self):
         return "{}({!r}, sleep={}, pre_plan={}, post_plan={}, tripped_message={})".format(  # noqa: UP032
@@ -70,7 +75,10 @@ class SuspenderBase(metaclass=ABCMeta):
         """
         with self._lock:
             self.RE = RE
-        self._sig.subscribe(self, event_type=event_type, run=True)
+        if self._is_async:
+            self.RE.loop.call_soon_threadsafe(partial(self._sig.subscribe_value, self))
+        else:
+            self._sig.subscribe(self, event_type=event_type, run=True)
 
     def remove(self):
         """Disable the suspender

--- a/src/bluesky/tests/test_suspenders.py
+++ b/src/bluesky/tests/test_suspenders.py
@@ -20,6 +20,7 @@ from bluesky.suspenders import (
     SuspendWhenOutsideBand,
 )
 from bluesky.tests.utils import MsgCollector
+from bluesky.tests import requires_ophyd_async
 
 from .utils import _fabricate_asycio_event
 
@@ -86,8 +87,8 @@ def test_suspender(klass, sc_args, start_val, fail_val, resume_val, wait_time, R
     assert delta > 0.4 + wait_time + 0.2
 
 
-@pytest.mark.skipif(not ophyd_async_imported, reason="Could not import ophyd-async")
 @parametrize_suspenders
+@requires_ophyd_async
 @pytest.mark.asyncio
 async def test_suspender_async_signal(klass, sc_args, start_val, fail_val, resume_val, wait_time, RE):
     fail_time = 0.1

--- a/src/bluesky/tests/test_suspenders.py
+++ b/src/bluesky/tests/test_suspenders.py
@@ -5,6 +5,7 @@ from functools import partial
 
 import pytest
 
+import bluesky.plan_stubs as bps
 from bluesky import Msg
 from bluesky.preprocessors import suspend_wrapper
 from bluesky.run_engine import RunEngineInterrupted
@@ -22,8 +23,17 @@ from bluesky.tests.utils import MsgCollector
 
 from .utils import _fabricate_asycio_event
 
+try:
+    import asyncio
 
-@pytest.mark.parametrize(
+    from ophyd_async.core import soft_signal_rw
+
+    ophyd_async_imported = True
+
+except ImportError:
+    ophyd_async_imported = False
+
+parametrize_suspenders = pytest.mark.parametrize(
     "klass,sc_args,start_val,fail_val,resume_val,wait_time",
     [
         (SuspendBoolHigh, (), 0, 1, 0, 0.2),
@@ -35,6 +45,9 @@ from .utils import _fabricate_asycio_event
         ((SuspendOutBand, True), (0.5, 1.5), 0, 1, 0, 0.2),
     ],
 )  # deprecated
+
+
+@parametrize_suspenders
 def test_suspender(klass, sc_args, start_val, fail_val, resume_val, wait_time, RE, hw):
     sig = hw.bool_sig
     try:
@@ -71,6 +84,50 @@ def test_suspender(klass, sc_args, start_val, fail_val, resume_val, wait_time, R
     print(delta)
     # The suspension time is actually 0.5 - 0.1 = 0.4 seconds as timers run in parallel
     assert delta > 0.4 + wait_time + 0.2
+
+
+@pytest.mark.skipif(not ophyd_async_imported, reason="Could not import ophyd-async")
+@parametrize_suspenders
+@pytest.mark.asyncio
+async def test_suspender_async_signal(klass, sc_args, start_val, fail_val, resume_val, wait_time, RE):
+    fail_time = 0.1
+    resume_time = 0.5
+    sleep_time = 0.2
+    sig = soft_signal_rw(float, start_val)
+    await sig.connect()
+    try:
+        klass, deprecated = klass
+    except TypeError:
+        deprecated = False
+    if deprecated:
+        with pytest.warns(UserWarning):
+            my_suspender = klass(sig, *sc_args, sleep=wait_time, is_async=True)
+    else:
+        my_suspender = klass(sig, *sc_args, sleep=wait_time, is_async=True)
+    my_suspender.install(RE)
+
+    async def _set_after_time(delay, value):
+        await asyncio.sleep(delay)
+        await sig.set(value)
+
+    tasks = []
+
+    RE.install_suspender(my_suspender)
+
+    def _plan():
+        # set up tasks to cause suspension during sleep, then resume
+        tasks.append(asyncio.create_task(_set_after_time(fail_time, fail_val)))
+        tasks.append(asyncio.create_task(_set_after_time(resume_time, resume_val)))
+        yield from bps.checkpoint()
+        yield from bps.sleep(sleep_time)
+
+    start = time.time()
+    RE(_plan())
+    stop = time.time()
+    for task in tasks:
+        await task
+    delta = stop - start
+    assert delta >= resume_time + sleep_time + wait_time
 
 
 def test_pretripped(RE, hw):

--- a/src/bluesky/tests/test_suspenders.py
+++ b/src/bluesky/tests/test_suspenders.py
@@ -1,3 +1,4 @@
+import asyncio
 import threading
 import time
 import time as ttime
@@ -5,7 +6,6 @@ from functools import partial
 
 import pytest
 
-import bluesky.plan_stubs as bps
 from bluesky import Msg
 from bluesky.preprocessors import suspend_wrapper
 from bluesky.run_engine import RunEngineInterrupted
@@ -19,20 +19,13 @@ from bluesky.suspenders import (
     SuspendWhenChanged,
     SuspendWhenOutsideBand,
 )
-from bluesky.tests import requires_ophyd_async
+from bluesky.tests import ophyd_async, requires_ophyd_async
 from bluesky.tests.utils import MsgCollector
 
 from .utils import _fabricate_asycio_event
 
-try:
-    import asyncio
-
+if ophyd_async:
     from ophyd_async.core import soft_signal_rw
-
-    ophyd_async_imported = True
-
-except ImportError:
-    ophyd_async_imported = False
 
 parametrize_suspenders = pytest.mark.parametrize(
     "klass,sc_args,start_val,fail_val,resume_val,wait_time",
@@ -48,9 +41,7 @@ parametrize_suspenders = pytest.mark.parametrize(
 )  # deprecated
 
 
-@parametrize_suspenders
-def test_suspender(klass, sc_args, start_val, fail_val, resume_val, wait_time, RE, hw):
-    sig = hw.bool_sig
+def _check_suspender(klass, sc_args, sig, putter, start_val, fail_val, resume_val, wait_time, RE):
     try:
         klass, deprecated = klass
     except TypeError:
@@ -61,9 +52,6 @@ def test_suspender(klass, sc_args, start_val, fail_val, resume_val, wait_time, R
     else:
         my_suspender = klass(sig, *sc_args, sleep=wait_time)
     my_suspender.install(RE)
-
-    def putter(val):
-        sig.put(val)
 
     # make sure we start at good value!
     putter(start_val)
@@ -88,47 +76,123 @@ def test_suspender(klass, sc_args, start_val, fail_val, resume_val, wait_time, R
 
 
 @parametrize_suspenders
-@requires_ophyd_async
-@pytest.mark.asyncio
-async def test_suspender_async_signal(klass, sc_args, start_val, fail_val, resume_val, wait_time, RE):
-    fail_time = 0.1
-    resume_time = 0.5
-    sleep_time = 0.2
-    sig = soft_signal_rw(float, start_val)
-    await sig.connect()
-    try:
-        klass, deprecated = klass
-    except TypeError:
-        deprecated = False
-    if deprecated:
-        with pytest.warns(UserWarning):
-            my_suspender = klass(sig, *sc_args, sleep=wait_time)
-    else:
-        my_suspender = klass(sig, *sc_args, sleep=wait_time)
-    my_suspender.install(RE)
+def test_suspender(klass, sc_args, start_val, fail_val, resume_val, wait_time, RE, hw):
+    sig = hw.bool_sig
 
-    async def _set_after_time(delay, value):
-        await asyncio.sleep(delay)
+    def putter(val):
+        sig.put(val)
+
+    _check_suspender(klass, sc_args, sig, putter, start_val, fail_val, resume_val, wait_time, RE)
+
+
+class _RecordingSignal:
+    """A minimal Subscribable that records where it was called from."""
+
+    name = "sig"
+
+    def __init__(self):
+        self.threads = {}
+
+    def subscribe_reading(self, function):
+        self.threads["subscribe_reading"] = threading.get_ident()
+        function({self.name: {"value": 0, "timestamp": 0}})
+
+    def clear_sub(self, function):
+        self.threads["clear_sub"] = threading.get_ident()
+
+
+@pytest.mark.parametrize("via_plan", [False, True])
+def test_subscribes_on_run_engine_thread(RE, via_plan):
+    "Subscriptions belong to the event loop that made them, e.g. CA monitors"
+    sig = _RecordingSignal()
+    susp = SuspendBoolHigh(sig)
+
+    if via_plan:
+        # install/remove are reached from the event loop thread this way
+        RE([Msg("install_suspender", None, susp), Msg("remove_suspender", None, susp)])
+    else:
+        susp.install(RE)
+        susp.remove()
+
+    loop_thread = _loop_thread_ident(RE)
+    assert sig.threads == {"subscribe_reading": loop_thread, "clear_sub": loop_thread}
+
+
+def test_remove_without_install_does_not_need_a_loop():
+    sig = _RecordingSignal()
+
+    SuspendBoolHigh(sig).remove()
+
+    assert sig.threads == {}
+
+
+def _loop_thread_ident(RE):
+    """The ident of the thread the RunEngine's event loop runs in."""
+
+    async def ident():
+        return threading.get_ident()
+
+    return asyncio.run_coroutine_threadsafe(ident(), RE.loop).result()
+
+
+def _connected_soft_signal(RE, initial_value):
+    """Make a soft signal connected on the RunEngine's event loop."""
+    sig = soft_signal_rw(float, initial_value, "sig")
+    asyncio.run_coroutine_threadsafe(sig.connect(), RE.loop).result()
+    return sig
+
+
+def _set_on_loop(RE, sig, value):
+    """Set a signal from another thread.
+
+    ``set`` makes an ``AsyncStatus`` as soon as it is called, so it has to be
+    called on the event loop rather than merely awaited there.
+    """
+
+    async def set_it():
         await sig.set(value)
 
-    tasks = []
+    asyncio.run_coroutine_threadsafe(set_it(), RE.loop).result()
 
-    RE.install_suspender(my_suspender)
 
-    def _plan():
-        # set up tasks to cause suspension during sleep, then resume
-        tasks.append(asyncio.create_task(_set_after_time(fail_time, fail_val)))
-        tasks.append(asyncio.create_task(_set_after_time(resume_time, resume_val)))
-        yield from bps.checkpoint()
-        yield from bps.sleep(sleep_time)
+@parametrize_suspenders
+@requires_ophyd_async
+def test_suspender_async_signal(klass, sc_args, start_val, fail_val, resume_val, wait_time, RE):
+    sig = _connected_soft_signal(RE, start_val)
 
-    start = time.time()
-    RE(_plan())
-    stop = time.time()
-    for task in tasks:
-        await task
-    delta = stop - start
-    assert delta >= resume_time + sleep_time + wait_time
+    def putter(val):
+        _set_on_loop(RE, sig, val)
+
+    _check_suspender(klass, sc_args, sig, putter, start_val, fail_val, resume_val, wait_time, RE)
+
+
+@requires_ophyd_async
+def test_pretripped_async_signal(RE):
+    "Tests that install() sees the current value, as ophyd's subscribe(run=True) does"
+    sig = _connected_soft_signal(RE, 1)
+    susp = SuspendBoolHigh(sig)
+
+    susp.install(RE)
+
+    assert susp.tripped
+
+
+@requires_ophyd_async
+def test_suspend_when_changed_async_signal(RE):
+    "expected_value cannot be read from a Subscribable signal until it is installed"
+    sig = _connected_soft_signal(RE, 1)
+    susp = SuspendWhenChanged(sig, allow_resume=True)
+    assert susp.expected_value is None
+
+    susp.install(RE)
+
+    assert susp.expected_value == 1
+    assert not susp.tripped
+
+    _set_on_loop(RE, sig, 2)
+
+    assert susp.tripped
+    assert susp._get_justification() == 'Signal sig, got "2.0", expected "1.0"'
 
 
 def test_pretripped(RE, hw):

--- a/src/bluesky/tests/test_suspenders.py
+++ b/src/bluesky/tests/test_suspenders.py
@@ -19,8 +19,8 @@ from bluesky.suspenders import (
     SuspendWhenChanged,
     SuspendWhenOutsideBand,
 )
-from bluesky.tests.utils import MsgCollector
 from bluesky.tests import requires_ophyd_async
+from bluesky.tests.utils import MsgCollector
 
 from .utils import _fabricate_asycio_event
 
@@ -102,9 +102,9 @@ async def test_suspender_async_signal(klass, sc_args, start_val, fail_val, resum
         deprecated = False
     if deprecated:
         with pytest.warns(UserWarning):
-            my_suspender = klass(sig, *sc_args, sleep=wait_time, is_async=True)
+            my_suspender = klass(sig, *sc_args, sleep=wait_time)
     else:
-        my_suspender = klass(sig, *sc_args, sleep=wait_time, is_async=True)
+        my_suspender = klass(sig, *sc_args, sleep=wait_time)
     my_suspender.install(RE)
 
     async def _set_after_time(delay, value):

--- a/src/bluesky/tests/test_suspenders.py
+++ b/src/bluesky/tests/test_suspenders.py
@@ -178,6 +178,32 @@ def test_pretripped_async_signal(RE):
 
 
 @requires_ophyd_async
+def test_suspender_plans_async_signal(RE):
+    "Tests that an async suspender can be installed and removed via Msg"
+    sig = _connected_soft_signal(RE, 0)
+    my_suspender = SuspendBoolHigh(sig, sleep=0.2)
+    scan = [Msg("checkpoint"), Msg("sleep", None, 0.2)]
+
+    def trip_then_clear():
+        threading.Timer(0.1, _set_on_loop, (RE, sig, 1)).start()
+        threading.Timer(0.5, _set_on_loop, (RE, sig, 0)).start()
+
+    # installed from inside a plan, it suspends and resumes
+    trip_then_clear()
+    start = ttime.time()
+    RE([Msg("install_suspender", None, my_suspender)] + scan)
+    assert ttime.time() - start > 0.4 + 0.2 + 0.2
+    assert my_suspender in RE.suspenders
+
+    # removed from inside a plan, it no longer does
+    trip_then_clear()
+    start = ttime.time()
+    RE([Msg("remove_suspender", None, my_suspender)] + scan)
+    assert ttime.time() - start < 0.5
+    assert my_suspender not in RE.suspenders
+
+
+@requires_ophyd_async
 def test_suspend_when_changed_async_signal(RE):
     "expected_value cannot be read from a Subscribable signal until it is installed"
     sig = _connected_soft_signal(RE, 1)


### PR DESCRIPTION
Addresses https://github.com/bluesky/bluesky/issues/1789

Pre-requisite for ophyd-async PR coming soon, setting as draft until I have tested this includes sufficient changes needed for https://github.com/bluesky/ophyd-async/issues/508

---

**Stacked on #1923** — this PR is based on `subscribable-protocol` rather than `main`, so the diff shows only the suspender changes. Review #1923 first; GitHub will retarget this PR to `main` automatically when that one merges.
