### PR TITLE
Fix type hints on bps.mv

### DIFF
--- a/src/bluesky/plan_stubs.py
+++ b/src/bluesky/plan_stubs.py
@@ -361,7 +361,7 @@ def rel_set(
 
 @plan
 def mv(
-    *args: Tuple[Union[Movable, NamedMovable, Any], ...],
+    *args: Union[Movable, NamedMovable, Any],
     group: Optional[Hashable] = None,
     **kwargs,
 ) -> MsgGenerator[Tuple[Status, ...]]:


### PR DESCRIPTION
Fix errors like in: https://github.com/bluesky/ophyd-async/actions/runs/11239938915/job/31248151842?pr=606#step:4:36
```
/home/runner/work/ophyd-async/ophyd-async/src/ophyd_async/plan_stubs/_nd_attributes.py
  /home/runner/work/ophyd-async/ophyd-async/src/ophyd_async/plan_stubs/_nd_attributes.py:48:23 - error: Argument of type "SignalRW[str]" cannot be assigned to parameter "args" of type "Tuple[Movable | NamedMovable | Any, ...]" in function "mv"
    "SignalRW[str]" is not assignable to "Tuple[Movable | NamedMovable | Any, ...]" (reportArgumentType)
  /home/runner/work/ophyd-async/ophyd-async/src/ophyd_async/plan_stubs/_nd_attributes.py:48:50 - error: Argument of type "Element" cannot be assigned to parameter "args" of type "Tuple[Movable | NamedMovable | Any, ...]" in function "mv"
    "Element" is not assignable to "Tuple[Movable | NamedMovable | Any, ...]" (reportArgumentType)
2 errors, 0 warnings, 0 informations 
```