### PR TITLE
Drop Python 3.8 from CI matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         runs-on: ["ubuntu-latest", "windows-latest"] # can add macos-latest
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         include:
           # Include one that runs in the dev environment
           - runs-on: "ubuntu-latest"

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -12,14 +12,14 @@ Before You Begin
     software, and you can skip the rest of this section.  Go to
     `https://try.nsls2.bnl.gov <https://try.nsls2.bnl.gov>`_.
 
-* You will need Python 3.8 or newer. From a shell ("Terminal" on OSX,
+* You will need Python 3.9 or newer. From a shell ("Terminal" on OSX,
   "Command Prompt" on Windows), check your current Python version.
 
   .. code-block:: bash
 
     python3 --version
 
-  If that version is less than 3.8, you must update it.
+  If that version is less than 3.9, you must update it.
 
   We recommend install bluesky into a "virtual environment" so this
   installation will not interfere with any existing Python software:
@@ -35,7 +35,7 @@ Before You Begin
 
   .. code-block:: bash
 
-    conda create -n bluesky-tutorial "python>=3.8"
+    conda create -n bluesky-tutorial "python>=3.9"
     conda activate bluesky-tutorial
 
 * Install the latest versions of bluesky and ophyd. Also install the databroker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 dynamic = ["version"]
 license.file = "LICENSE"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ name = "bluesky"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Python 3.8 reached its end-of-life (per [Python upstream](https://devguide.python.org/versions/)) on October 7, a week ago today.