### PR TITLE
Unpin numpy: support numpy 2.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "importlib-resources;python_version<'3.9'",
     "msgpack",
     "msgpack-numpy",
-    "numpy<2.0.0",
+    "numpy",
     "opentelemetry-api",
     "toolz",
     "tqdm>=4.44",


### PR DESCRIPTION
Question: Should we double our CI matrix to test against numpy 1.x and 2.x? I lean "no", it is good enough to test against latest numpy, particularly because bluesky itself does not have any deep numpy integrations or compiled code.