### PR TITLE
FIX: account for CPython's deprecation of 3 arg throw signature

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,9 +127,6 @@ addopts = """
 # https://iscinumpy.gitlab.io/post/bound-version-constraints/#watch-for-warnings
 filterwarnings = [
     "error",
-    "ignore::PendingDeprecationWarning",
-    "ignore::UserWarning",
-    "ignore::DeprecationWarning",
 ]
 # Doctest python code in docs, python code in src docstrings, test functions in tests
 testpaths = "src/bluesky/tests"

--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -1966,9 +1966,12 @@ class Plan:
         self._stack = None
         return self._iter.send(value)
 
-    def throw(self, typ, val=None, tb=None):
+    def throw(self, *args, **kwargs):
+        # The 3 argument signature of throw is deprecated, just pass
+        # through any args/kwargs to avoid having to replicate any of
+        # that logic
         self._stack = None
-        return self._iter.throw(typ, val, tb)
+        return self._iter.throw(*args, **kwargs)
 
 
 def plan(bs_plan):


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

We had been passing all 3 arguments through and letting Python sort it out, but as of 3.12 the 3 argument version is deprecated so use *args, **kwargs to blindly forward through whatever the user gave us.  This make sure that we do not spuriously trigger the deprecation warning nor do we hide a warning the user should get.

closes #1817

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This was discovered when a DLS project ran their test suite.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


We were explicitly ignoring this warning on CI, that has also been fixed.  We will see if there are any others 🤣 

<!--
## Screenshots (if appropriate):
-->
