### PR TITLE
Add error bars for standard deviation in LivePlot

### DIFF
--- a/src/bluesky/callbacks/mpl_plotting.py
+++ b/src/bluesky/callbacks/mpl_plotting.py
@@ -125,7 +125,18 @@ class LivePlot(QtAwareCallback):
     """
 
     def __init__(
-        self, y, x=None, *, legend_keys=None, xlim=None, ylim=None, ax=None, fig=None, epoch="run", yerr=None, **kwargs
+        self,
+        y,
+        x=None,
+        *,
+        legend_keys=None,
+        xlim=None,
+        ylim=None,
+        ax=None,
+        fig=None,
+        epoch="run",
+        yerr=None,
+        **kwargs,
     ):
         super().__init__(use_teleporter=kwargs.pop("use_teleporter", None))
         self.__setup_lock = threading.Lock()
@@ -242,8 +253,7 @@ class LivePlot(QtAwareCallback):
         # Rescale and redraw.
         self.current_line.set_data(self.x_data, self.y_data)
         if self.yerr is not None:
-            self.ax.errorbar(x=self.x_data, y=self.y_data, yerr=self.yerr_data,
-                              fmt="none")
+            self.ax.errorbar(x=self.x_data, y=self.y_data, yerr=self.yerr_data, fmt="none")
         self.ax.relim(visible_only=True)
         self.ax.autoscale_view(tight=True)
         self.ax.figure.canvas.draw_idle()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
(linked to #1825 - please read that before this if you haven't already)
## Description
<!--- Describe your changes in detail -->
This PR adds a `yerr` argument, which is the name of a signal that provides standard deviation to the Y values, to the LivePlot callback to draw error bars when plotting new events.
This is optional and does nothing if not provided so it should be backwards-compatible.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #1825 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
We'll add some unit tests if this is deemed a good idea - please don't merge unless we have!
<!--
## Screenshots (if appropriate):
-->
