### PR TITLE
Windows: fix unit tests & enable CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     if: needs.check.outputs.branch-pr == ''
     strategy:
       matrix:
-        runs-on: ["ubuntu-latest"] # can add windows-latest, macos-latest
+        runs-on: ["ubuntu-latest", "windows-latest"] # can add macos-latest
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           # Include one that runs in the dev environment

--- a/src/bluesky/tests/__init__.py
+++ b/src/bluesky/tests/__init__.py
@@ -1,3 +1,4 @@
+import os
 from types import ModuleType
 from typing import Optional
 
@@ -17,3 +18,7 @@ except ImportError as ie:
 
 # define a skip condition based on if ophyd is available or not
 requires_ophyd = pytest.mark.skipif(ophyd is None, reason=reason)
+
+uses_os_kill_sigint = pytest.mark.skipif(
+    os.name == "nt", reason="os.kill on windows ignores signal argument and kills the entire process."
+)

--- a/src/bluesky/tests/test_examples.py
+++ b/src/bluesky/tests/test_examples.py
@@ -22,6 +22,7 @@ from bluesky.examples import (
     wait_multiple,
     wait_one,
 )
+from bluesky.tests import uses_os_kill_sigint
 
 from .utils import _careful_event_set, _fabricate_asycio_event
 
@@ -310,6 +311,7 @@ def test_suspend(RE, hw):
     assert RE.state == "idle"
 
 
+@uses_os_kill_sigint
 def test_pause_resume(RE):
     from bluesky.utils import ts_msg_hook
 
@@ -354,6 +356,7 @@ def test_pause_resume(RE):
     assert stop - start > 2
 
 
+@uses_os_kill_sigint
 def test_pause_abort(RE):
     ev = _fabricate_asycio_event(RE.loop)
 
@@ -397,6 +400,7 @@ def test_pause_abort(RE):
     assert stop - start < 1
 
 
+@uses_os_kill_sigint
 def test_abort(RE):
     ev = _fabricate_asycio_event(RE.loop)
 

--- a/src/bluesky/tests/test_magics.py
+++ b/src/bluesky/tests/test_magics.py
@@ -7,6 +7,7 @@ import pytest
 import bluesky.plan_stubs as bps
 import bluesky.plans as bp
 from bluesky.magics import BlueskyMagics
+from bluesky.tests import uses_os_kill_sigint
 
 
 class FakeIPython:
@@ -148,6 +149,7 @@ def test_magics_missing_ns_key(RE, hw):
     sm.mov("motor1 5")
 
 
+@uses_os_kill_sigint
 def test_interrupted(RE, hw):
     motor = hw.motor
     motor.delay = 10

--- a/src/bluesky/tests/test_new_examples.py
+++ b/src/bluesky/tests/test_new_examples.py
@@ -880,10 +880,18 @@ def test_stage_all_and_unstage_all(RE):
 
     def plan():
         yield from stage_all(olddummy1, olddummy2, newdummy1, newdummy2)
-        assert list(staged.keys()) == ["o1", "o2", "n1", "n2"]
+        staged_keys = list(staged.keys())
+        assert len(staged_keys) == 4
+        assert staged_keys[:2] == ["o1", "o2"]
+        assert "n1" in staged_keys[2:]
+        assert "n2" in staged_keys[2:]
 
         yield from unstage_all(olddummy1, olddummy2, newdummy1, newdummy2)
-        assert list(unstaged.keys()) == ["o1", "o2", "n1", "n2"]
+        unstaged_keys = list(unstaged.keys())
+        assert len(unstaged_keys) == 4
+        assert unstaged_keys[:2] == ["o1", "o2"]
+        assert "n1" in staged_keys[2:]
+        assert "n2" in staged_keys[2:]
 
     start = ttime.monotonic()
     RE(plan())

--- a/src/bluesky/tests/test_new_examples.py
+++ b/src/bluesky/tests/test_new_examples.py
@@ -890,8 +890,8 @@ def test_stage_all_and_unstage_all(RE):
         unstaged_keys = list(unstaged.keys())
         assert len(unstaged_keys) == 4
         assert unstaged_keys[:2] == ["o1", "o2"]
-        assert "n1" in staged_keys[2:]
-        assert "n2" in staged_keys[2:]
+        assert "n1" in unstaged_keys[2:]
+        assert "n2" in unstaged_keys[2:]
 
     start = ttime.monotonic()
     RE(plan())

--- a/src/bluesky/tests/test_run_engine.py
+++ b/src/bluesky/tests/test_run_engine.py
@@ -475,7 +475,7 @@ def test_stage_and_unstage_status_objects(RE):
     RE(my_plan())
     stop = ttime.monotonic()
 
-    assert 2 < stop - start < 3
+    assert 2 <= stop - start < 3
 
 
 def test_bad_call_args(RE):

--- a/src/bluesky/tests/test_run_engine.py
+++ b/src/bluesky/tests/test_run_engine.py
@@ -37,7 +37,7 @@ from bluesky.run_engine import (
     TransitionError,
     WaitForTimeoutError,
 )
-from bluesky.tests import requires_ophyd
+from bluesky.tests import requires_ophyd, uses_os_kill_sigint
 from bluesky.tests.utils import DocCollector, MsgCollector
 
 from .utils import _careful_event_set, _fabricate_asycio_event
@@ -713,6 +713,7 @@ def test_exit_raise(RE, unpause_func, excp):
     assert flag
 
 
+@uses_os_kill_sigint
 def test_sigint_three_hits(RE, hw):
     import time
 
@@ -746,6 +747,7 @@ def test_sigint_three_hits(RE, hw):
     assert 0.3 < done_cleanup_time - end_time < 0.6
 
 
+@uses_os_kill_sigint
 def test_sigint_many_hits_pln(RE):
     pid = os.getpid()
 
@@ -774,6 +776,7 @@ def test_sigint_many_hits_pln(RE):
     timer.join()
 
 
+@uses_os_kill_sigint
 def test_sigint_many_hits_panic(RE):
     raise pytest.skip("hangs tests on exit")
     pid = os.getpid()
@@ -820,6 +823,7 @@ def test_sigint_many_hits_panic(RE):
         RE.request_pause()
 
 
+@uses_os_kill_sigint
 def test_sigint_many_hits_cb(RE):
     pid = os.getpid()
 
@@ -850,6 +854,7 @@ def test_sigint_many_hits_cb(RE):
     timer.join()
 
 
+@uses_os_kill_sigint
 def test_no_context_manager(RE):
     # Clear the context managers so that RE will not react to sigint
     RE.context_managers = []

--- a/src/bluesky/tests/test_scans.py
+++ b/src/bluesky/tests/test_scans.py
@@ -520,9 +520,9 @@ def test_wait_for(RE):
         ),
     ]
     RE.loop.call_soon_threadsafe(RE.loop.call_later, 2, done)
-    start = ttime.time()
+    start = ttime.monotonic()
     RE(scan)
-    stop = ttime.time()
+    stop = ttime.monotonic()
     assert stop - start >= 2
 
 

--- a/src/bluesky/tests/test_tiled_writer.py
+++ b/src/bluesky/tests/test_tiled_writer.py
@@ -1,3 +1,4 @@
+import os
 from typing import Dict, Iterator, Optional, Tuple
 
 import h5py
@@ -64,7 +65,7 @@ class StreamDatumReadableCollectable(Named, Readable, Collectable, WritesStreamA
     """Produces no events, but only StreamResources/StreamDatums and can be read or collected"""
 
     def _get_hdf5_stream(self, data_key: str, index: int) -> Tuple[StreamResource, StreamDatum]:
-        file_path = self.root + "/dataset.h5"
+        file_path = os.path.join(self.root, "dataset.h5")
         uid = f"{data_key}-uid"
         data_desc = self.describe()[data_key]  # Descriptor dictionary for the current data key
         data_shape = tuple(data_desc["shape"])
@@ -78,7 +79,7 @@ class StreamDatumReadableCollectable(Named, Readable, Collectable, WritesStreamA
                 data_key=data_key,
                 root=self.root,
                 resource_path="/dataset.h5",
-                uri="file://localhost" + file_path,
+                uri="file://localhost/" + file_path,
                 spec="AD_HDF5_SWMR_STREAM",
                 mimetype="application/x-hdf5",
                 uid=uid,
@@ -122,7 +123,7 @@ class StreamDatumReadableCollectable(Named, Readable, Collectable, WritesStreamA
                     parameters={"chunk_shape": (1, *data_shape), "template": "{:05d}.tif"},
                     data_key=data_key,
                     root=self.root,
-                    uri="file://localhost" + self.root + "/",
+                    uri="file://localhost/" + self.root + "/",
                     spec="AD_TIFF",
                     mimetype="multipart/related;type=image/tiff",
                     uid=uid,
@@ -139,7 +140,7 @@ class StreamDatumReadableCollectable(Named, Readable, Collectable, WritesStreamA
 
             # Write a tiff file
             data = np.random.randint(0, 255, data_shape, dtype="uint8")
-            tf.imwrite(file_path + f"/{self.counter:05}.tif", data)
+            tf.imwrite(os.path.join(file_path, f"{self.counter:05}.tif"), data)
 
         return stream_resource, stream_datum
 

--- a/src/bluesky/tests/test_zmq.py
+++ b/src/bluesky/tests/test_zmq.py
@@ -13,6 +13,7 @@ from event_model import sanitize_doc
 from bluesky import Msg
 from bluesky.callbacks.zmq import Proxy, Publisher, RemoteDispatcher
 from bluesky.plans import count
+from bluesky.tests import uses_os_kill_sigint
 
 
 def test_proxy_script():
@@ -91,6 +92,7 @@ def test_zmq(RE, hw):
     gc.collect()
 
 
+@uses_os_kill_sigint
 def test_zmq_proxy_blocks_sigint_exits():
     # The test `test_zmq` runs Proxy and RemoteDispatcher in a separate
     # process, which coverage misses.


### PR DESCRIPTION
## Description

- Fixes a number of unit tests which were either failing, inconsistent, or killing the pytest runner under windows
- Enable `windows-latest` as part of the testing CI matrix.

## Motivation and Context

At isis we're running on windows, we'd like to be able to run the unit tests.

Enabled CI on windows runners to prevent regressions, but if we feel this is adding too many builds, then from our perspective we'd probably be happy with just a python 3.11/12 windows build at the moment (we don't use 3.10 or lower at isis).

## How Has This Been Tested?

See the CI runs.
