### PR TITLE
Allow Locatable in bps.rd

### DIFF
--- a/src/bluesky/plan_stubs.py
+++ b/src/bluesky/plan_stubs.py
@@ -450,7 +450,7 @@ movr = mvr  # synonym
 
 
 @plan
-def rd(obj: Readable, *, default_value: Any = 0) -> MsgGenerator[Any]:
+def rd(obj: Union[Readable, Locatable], *, default_value: Any = 0) -> MsgGenerator[Any]:
     """Reads a single-value non-triggered object
 
     This is a helper plan to get the scalar value out of a Device


### PR DESCRIPTION
## Description

Allow passing a `Locatable` object which isn't `Readable` to `bps.rd()`.

## Motivation and Context

As far as I can tell from the implementation, this should be supported, but the type hint (and therefore pyright) weren't allowing it.

## How Has This Been Tested?

Type hint change only
