### PR TITLE
Mnt/move return out of finally

### DIFF
--- a/src/bluesky/run_engine.py
+++ b/src/bluesky/run_engine.py
@@ -1114,9 +1114,11 @@ class RunEngine:
                             plan_return = self._task_fut.result()
                         except concurrent.futures.CancelledError:
                             plan_return = self.NO_PLAN_RETURN
-                        return plan_return  # noqa: B012
                     else:
-                        return self.NO_PLAN_RETURN
+                        plan_return = self.NO_PLAN_RETURN
+                else:
+                    plan_return = None
+            return plan_return
 
     def install_suspender(self, suspender):
         """

--- a/src/bluesky/run_engine.py
+++ b/src/bluesky/run_engine.py
@@ -1103,10 +1103,6 @@ class RunEngine:
                         exc = self._task_fut.exception()
                     except (asyncio.CancelledError, concurrent.futures.CancelledError):
                         exc = None
-                    # if the main task exception is not None, re-raise
-                    # it (unless it is a canceled error)
-                    if exc is not None and not isinstance(exc, _RunEnginePanic):
-                        raise exc
                     # Only try to get a result if there wasn't an error,
                     # (other than a cancelled error)
                     if exc is None:
@@ -1114,8 +1110,14 @@ class RunEngine:
                             plan_return = self._task_fut.result()
                         except concurrent.futures.CancelledError:
                             plan_return = self.NO_PLAN_RETURN
+                    # we have something in exc
                     else:
-                        plan_return = self.NO_PLAN_RETURN
+                        # special case the panic exception that we put in above
+                        if isinstance(exc, _RunEnginePanic):
+                            plan_return = self.NO_PLAN_RETURN
+                        # otherwise re-raise it
+                        else:
+                            raise exc
                 else:
                     plan_return = None
             return plan_return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Make sure we do not eat exceptions in a finally block 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Bug reported in #1838 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Just the existing test suite.  I'm not sure how to generate the conditions we would need to be in to generate this error and ran out of time before meetings started for the day.

<!--
## Screenshots (if appropriate):
-->
