### PR TITLE
FIX: support baseline when using run keys

### DIFF
--- a/src/bluesky/preprocessors.py
+++ b/src/bluesky/preprocessors.py
@@ -1204,12 +1204,17 @@ def baseline_wrapper(plan, devices, name="baseline"):
 
     def insert_baseline(msg):
         if msg.command == "open_run":
-            return None, head()
-
+            if msg.run is not None:
+                return None, set_run_key_wrapper(head(), msg.run)
+            else:
+                return None, head()
         elif msg.command == "close_run":
 
             def post_baseline():
-                yield from trigger_and_read(devices, name=name)
+                if msg.run is not None:
+                    yield from set_run_key_wrapper(trigger_and_read(devices, name=name), run=msg.run)
+                else:
+                    yield from trigger_and_read(devices, name=name)
                 return (yield msg)
 
             return post_baseline(), None


### PR DESCRIPTION
closes #1529

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

in baseline wrapper use the `msg.run` from the open/close for the inserted messages.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The baseline wrapper was written before we adding the "run key" support for muliti run it was naive to it.  This means that the baseline wrapper always tries to put events into the "None" run (default) which is either not what you want or fails with invalid sequence orders.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added test based on @lsammut 's reproducer.

<!--
## Screenshots (if appropriate):
-->
