### PR TITLE
Running RE and a QTGui under the captive python shell of pycharm with live updating plots 

### DIFF
--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -1663,8 +1663,8 @@ class DefaultDuringTask(DuringTask):
         """
         if "matplotlib" in sys.modules:
             import matplotlib
-
-            if _qt_is_imported_app_available():
+            backend = matplotlib.get_backend().lower()
+            if "qt" in backend:
                 from bluesky.callbacks.mpl_plotting import initialize_qt_teleporter
 
                 initialize_qt_teleporter()
@@ -1843,15 +1843,11 @@ class DefaultDuringTask(DuringTask):
 
 
 def _qt_is_imported_app_available():
-    qt_modules_names = ["PyQt6.QtCore", "PySide6.QtCore", "PyQt5.QtCore", "PySide2.QtCore"]
-    try:
-        qt_core, *_ = (mod for mod in [sys.modules.get(name) for name in qt_modules_names] if mod is not None)
-    except TypeError:
-        return False
-    qapp = qt_core.QAppliaction.instance()
-    if qapp is None:
-        return False
-    return True
+    qt_modules_names = ["PyQt6.QtWidgets", "PySide6.QtWidgets", "PyQt5.QtWidgets", "PySide2.QtWidgets"]
+    qt_widgets = next((sys.modules.get(name) for name in qt_modules_names if sys.modules.get(name)), None)
+
+    return qt_widgets is not None and qt_widgets.QApplication.instance() is not None
+
 
 def _rearrange_into_parallel_dicts(readings):
     data = {}

--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -1664,8 +1664,7 @@ class DefaultDuringTask(DuringTask):
         if "matplotlib" in sys.modules:
             import matplotlib
 
-            backend = matplotlib.get_backend().lower()
-            if "qt" in backend:
+            if _qt_is_imported_app_available():
                 from bluesky.callbacks.mpl_plotting import initialize_qt_teleporter
 
                 initialize_qt_teleporter()
@@ -1683,7 +1682,7 @@ class DefaultDuringTask(DuringTask):
 
             backend = matplotlib.get_backend().lower()
             # if with a Qt backend, do the scary thing
-            if "qt" in backend:
+            if _qt_is_imported_app_available():
                 import functools
 
                 from matplotlib.backends.qt_compat import QT_API, QtCore, QtWidgets
@@ -1842,6 +1841,17 @@ class DefaultDuringTask(DuringTask):
                 # We are not using matplotlib + Qt. Just wait on the Event.
                 blocking_event.wait()
 
+
+def _qt_is_imported_app_available():
+    qt_modules_names = ["PyQt6.QtCore", "PySide6.QtCore", "PyQt5.QtCore", "PySide2.QtCore"]
+    try:
+        qt_core, *_ = (mod for mod in [sys.modules.get(name) for name in qt_modules_names] if mod is not None)
+    except TypeError:
+        return False
+    qapp = qt_core.QAppliaction.instance()
+    if qapp is None:
+        return False
+    return True
 
 def _rearrange_into_parallel_dicts(readings):
     data = {}


### PR DESCRIPTION
## Description
Instead of checking for the mpl qt backend in the block function it is now checked if there is PyQt.QtWidgets or Pyside.QtWidgets imported and then checked if there is a QApplication (QT Gui). Then it proceeds as before.

## Motivation and Context
When using Pycharm the mpl backend is switched and checking for the qt backend isn't a good indicator. This results in the Qt Gui being blocked and freezing while executing a bluesky plan. 

## How Has This Been Tested?
Testing set of bluesky. Running Bluesky and PyQt in a few different setups.

