### PR TITLE
API: make zict an optional dependency and update docs

### DIFF
--- a/docs/api_changes.rst
+++ b/docs/api_changes.rst
@@ -2,6 +2,21 @@
  Release History
 =================
 
+v1.13.1 (2024-12-12)
+====================
+
+Changed
+-------
+* ``zict`` is no longer a default dependency.  There is a breaking API change
+  between zict2 and zict3 that fixed a race condition between multiple threads
+  using the same instance but broke using multiple instances in the same
+  process or multiple processes sharing the same files.  ``PersistentDict`` is
+  not being removed, but is strongly discouraged for new use.  To get the old pinning use
+  ```pip install bluesky[old_persistentdict]`` or install ``zict<3``.
+
+
+
+
 v1.13.0a4 (2024-07-08)
 ======================
 

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -361,18 +361,22 @@ dictionary interface. The simplest is just a plain Python dictionary.
 
     RE.md = {}
 
-To persist metadata between sessions, bluesky recommends
+To persist metadata between sessions, bluesky provides
 :class:`bluesky.utils.PersistentDict` --- a Python dictionary synced with a
-directory of files on disk. Any changes made to ``RE.md`` are synced to the
-file, so the contents of ``RE.md`` can persist between sessions.
+directory of files on disk backed by ``zict``.  Any changes made to ``RE.md``
+are synced to the file, so the contents of ``RE.md`` can persist between
+sessions.
 
 .. code-block:: python
 
     from bluesky.utils import PersistentDict
     RE.md = PersistentDict('some/path/here')
 
-Bluesky does not provide a strong recommendation on that path; that a detail
-left to the local deployment.
+``zict`` v3 changed how the contents of are serialized to disk such that only
+one Python process can reliably interact with the files at a time, which is
+suitable for testing and small-scale applications.  Installing ``zict`` v2
+avoids this problem, but causes conflicts with other packages (such as
+``dask``).
 
 Bluesky formerly recommended using :class:`~historydict.HistoryDict` --- a
 Python dictionary backed by a sqlite database file. This approach proved

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "tqdm>=4.44",
     "typing-extensions>=4.0.0;python_version<'3.11'",
     "dataclasses;python_version<'3.7'",
-    "zict<3.0.0",
 ]
 dynamic = ["version"]
 license.file = "LICENSE"
@@ -89,6 +88,7 @@ dev = [
     "types-mock",
     "tiled[all]",
     "vendoring",
+    "zict",
 ]
 ipython = ["ipython"]
 zmq = ["pyzmq"]
@@ -98,6 +98,7 @@ streamz = ["streamz"]
 plotting = ["matplotlib"]
 cmd = ["colorama"]
 olog = ["jinja2"]
+old_persistentdict = ["zict<3"]
 all = ["bluesky[dev,ipython,zmq,common,tools,streamz,plotting,cmd,olog]"]
 
 [project.scripts]

--- a/src/bluesky/tests/test_persistent_dict.py
+++ b/src/bluesky/tests/test_persistent_dict.py
@@ -3,7 +3,6 @@ import gc
 
 import numpy
 import pytest
-
 from numpy.testing import assert_array_equal
 from packaging.version import Version
 

--- a/src/bluesky/tests/test_persistent_dict.py
+++ b/src/bluesky/tests/test_persistent_dict.py
@@ -3,12 +3,20 @@ import gc
 
 import numpy
 import pytest
+
 from numpy.testing import assert_array_equal
+from packaging.version import Version
 
 from ..plans import count
 from ..utils import PersistentDict
 
+zict = pytest.importorskip("zict")
 
+
+@pytest.mark.xfail(
+    condition=Version(zict.__version__) >= Version("3"),
+    reason="Version 3 does not support multiple instances looking at same files",
+)
 def test_persistent_dict(tmp_path):
     d = PersistentDict(tmp_path)
     d["a"] = 1

--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -31,7 +31,6 @@ from weakref import WeakKeyDictionary, ref
 import msgpack
 import msgpack_numpy
 import numpy as np
-
 from cycler import Cycler, cycler
 from tqdm import tqdm
 from tqdm.utils import _screen_shape_wrapper, _term_move_up, _unicode

--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -31,7 +31,7 @@ from weakref import WeakKeyDictionary, ref
 import msgpack
 import msgpack_numpy
 import numpy as np
-import zict
+
 from cycler import Cycler, cycler
 from tqdm import tqdm
 from tqdm.utils import _screen_shape_wrapper, _term_move_up, _unicode
@@ -824,6 +824,14 @@ class PersistentDict(collections.abc.MutableMapping):
     """
 
     def __init__(self, directory):
+        try:
+            import zict
+        except ImportError as e:
+            raise RuntimeError(
+                "In order to use PersistentDict you must install zict. "
+                "zict v3 has the limitation that only one Python process "
+                "can reliably work with the data files at a time."
+            ) from e
         self._directory = directory
         self._file = zict.File(directory)
         self._func = zict.Func(self._dump, self._load, self._file)


### PR DESCRIPTION
Also xfail the one bad test based on version gating.

closes #1577

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

zict 3 has a behavior change that breaks one of our tests (and using two bsui sessions), see #1577 for details (thank you @dmgav for sorting out the problem!).

Pinning back zict is causing other conflict with dask and we should start to move away from it all together.

@genematx I know you are working on document RedisJsonDict, hopefully this does not step on what you are doing too much.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

locally running tests

<!--
## Screenshots (if appropriate):
-->
