### PR TITLE
[ENH] Add `bluesky.utils.ProcessQtEventsDuringTask`

### DIFF
--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -83,3 +83,4 @@ waiting for the plan to complete in the background thread
    DuringTask.block
 
    DefaultDuringTask
+   ProcessQtEventsDuringTask

--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -1849,6 +1849,56 @@ class DefaultDuringTask(DuringTask):
                 # We are not using matplotlib + Qt. Just wait on the Event.
                 blocking_event.wait()
 
+class ProcessQtEventsDuringTask(DuringTask):
+    """This class runs the Qt main loop while waiting for the plan to finish.
+    
+    Differently from "DefaultDuringTask", this class directly invokes the 
+    QApplication "processEvents" method, which effectively acts as a 
+    "kicker" for the Qt event loop. This happens "in-process", and assumes that
+    the Qt loop is in the main thread, while the Bluesky event loop is in the
+    background thread.
+
+    The Qt application is assumed to be created by said separate logic;
+    this class will **not** generate a new QApplication instance.
+
+    Parameters
+    ----------
+    refresh_rate : float, optional
+        Refresh rate in seconds. Default is 0.03 seconds (30 Hz approx.).
+
+    Notes
+    -----
+    This implementation of DuringTask **does not** give control to the user to
+    suspend the plan execution by using SIGINT. It assumes that there's a separate
+    logic implemented by the Qt application to handle the interruption via the
+    Bluesky public API.
+    """
+    
+    def __init__(self, refresh_rate: float = 0.03) -> None:
+
+        self.refresh_rate = refresh_rate
+        if "matplotlib" in sys.modules:
+            import matplotlib
+
+            backend = matplotlib.get_backend().lower()
+            if "qt" in backend:
+                from matplotlib.backends.qt_compat import QtWidgets
+
+                self.app = QtWidgets.QApplication.instance()
+    
+    def block(self, blocking_event):
+        if self.app is None:
+            # We are not using matplotlib + Qt, or there is no active
+            # QApplication instance. Just wait on the Event.
+            blocking_event.wait()
+        else:
+            while True:
+                done = blocking_event(wait=self.refresh_rate)
+                self.app.processEvents()
+                if done:
+                    break
+
+    
 
 def _rearrange_into_parallel_dicts(readings):
     data = {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- An implementation of `DuringTask` that kicks a Qt event loop with a fixed refresh rate.
- This implementation follows these assumptions:
  - The Qt event loop and the Bluesky event loop are in the same process.
  - The Qt event loop is the main thread.
- Does not implement any logic for checking SIGINT at this time.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The PR was requested in ticket #1847 by @tacaswell. It implements a logic similar to the one described in the ticket, where the only changes are in how the `QApplication.instance` is recovered (in my original example I simply called QApplication.instance() without importing any package; in this `matplotlib` is checked to see if a Qt backend is currently present).

It provides an alternative implementation to `DefaultDuringTask` as it takes the assumption that both event loops are in the same process.

There's currently no way of handling interruption signal. To be honest, I do believe that when using this approach the interruption should be handled by the Qt event loop by injecting a signal that calls the public API when necessary. I'd be happy to receive feedback about this or pointers on how to address this if necessary.

I don't know if this is true but I believe this is somewhat similar to what the original `install_qt_kicker` implementation, just in the perspective of a  `DefaultTask`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I only managed to test this locally as there are no UTs available for `DuringTask`. My machine specs:

- OS: Windows 11
- Python 3.10 (mamba environment)
- Bluesky version: 1.13
- Frontend: qtpy with PyQt6 installed

<!--
## Screenshots (if appropriate):
-->
