### PR TITLE
DOC: Updated example usage in the docstring for ``make_decorator``.

### DIFF
--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -1234,11 +1234,14 @@ def make_decorator(wrapper):
 
     Example of a decorator:
     >>> some_decorator = make_decorator(some_wrapper)  # returns decorator
-    >>> customized_count = some_decorator(count)  # returns generator func
+    >>> customized_count = some_decorator()(count)  # returns generator func
     >>> plan = customized_count([det])  # returns a generator instance
 
     This turns a 'wrapper' into a decorator, which accepts a generator
-    function and returns a generator function.
+    function and returns a generator function. Additional arguments
+    given to ``some_decorator(arg0, kwarg0=...)(count)`` will be
+    passed to the wrapper as ``some_wrapper(plan, arg0, kwarg0=...)``.
+
     """
 
     @wraps(wrapper)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The docstring to the utility function ``make_decorator`` provides the example of ``customized_count = some_decorator(count)``. However, the correct usage should be ``customized_count = some_decorator()(count)`` otherwise we actually get ``dec(gen_func)`` as the decorated function, rather than ``dec_inner(...)`` as intended.

## Description
<!--- Describe your changes in detail -->

The equivalent syntactic-sugar version of ``customized_count = some_decorator(count)`` would be

```python
@some_decorator
def customized_count(...):
   ...
```

This is a common python pattern for decorators that do not require arguments.

However, the wrappers that are turned into decorators **may** accept additional arguments and so what comes back from ``make_decorator`` needs to be a decorator factory. The syntactic-sugar version would then be something like:

```python
@some_decorator(arg0, kwargs0=...)
def customized_count(...):
   ...
```

This is the version that ``make_decorator()`` produces, and is also how the usage is described in the curated documentation for plans: [``@relative_set_decorator([motor])``](https://blueskyproject.io/bluesky/main/plans.html#preprocessor-wrappers-and-decorators).

The equivalent without the sugar is ``customized_count = some_decorator()(count)``.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR will update the docstring for ``make_decorator`` to match the curated documentation, and provide the correct usage for the resulting decorators.

If the instructions are followed as previously written, there is no mechanism to provide arguments to the original wrapper, and any attempt to call the decorated plan results in the following error:

```python
>>> plan = customized_count([], num=6)
TypeError: make_decorator.<locals>.dec_outer.<locals>.dec() got an unexpected keyword argument 'num'
```

(the original plan accepts a keyword argument *num*).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I added wrappers to some common functions. If I use ``count = baseline_decorator(count)`` I get the error described above. If I change this to ``count = baseline_decorator(devices=[...])(count, ...)``. I do not get the error.

I have not tested whether the messages for the baseline are actually applied.

<!--
## Screenshots (if appropriate):
-->
