### PR TITLE
TST: skip all of the PersitentDict tests

### DIFF
--- a/src/bluesky/tests/test_persistent_dict.py
+++ b/src/bluesky/tests/test_persistent_dict.py
@@ -10,12 +10,12 @@ from ..plans import count
 from ..utils import PersistentDict
 
 zict = pytest.importorskip("zict")
-
-
-@pytest.mark.xfail(
+pytestmark = pytest.mark.skipif(
     condition=Version(zict.__version__) >= Version("3"),
     reason="Version 3 does not support multiple instances looking at same files",
 )
+
+
 def test_persistent_dict(tmp_path):
     d = PersistentDict(tmp_path)
     d["a"] = 1


### PR DESCRIPTION
The issue is that:
 - zict3 adds an incrementing number to the file names
 - each instance manages its counts independently
 - the test tend to create 2 instances looking at the same files
 - on object delete (via a weakref callback) the contents are flushed to disk
 - the second one to fire fails because it can not remove a file already removed by the first
 - this happens when gc runs so the failure shows up in some later test

Not completely clear why this does not _always_ happen, however because we are planning to move away from suggesting using these classes, it is not worth the effort to re-write the tests.

This pulls the zict related changes out of #1857 which can hopefully be merged with less review.