### PR TITLE
Remove implicit Pydantic v1 dependency

### DIFF
--- a/src/bluesky/callbacks/tiled_writer.py
+++ b/src/bluesky/callbacks/tiled_writer.py
@@ -13,7 +13,6 @@ from event_model.documents import (
     StreamDatum,
     StreamResource,
 )
-from pydantic.v1.utils import deep_update
 from tiled.client import from_profile, from_uri
 from tiled.client.base import BaseClient
 from tiled.client.container import Container
@@ -125,7 +124,7 @@ class _RunWriter(CallbackBase):
             desc_node = self.root_node[desc_name]
 
         # Update (add new values to) variable fields of the metadata
-        metadata = deep_update(dict(desc_node.metadata), var_fields)
+        metadata = copy.deepcopy(dict(desc_node.metadata), var_fields)
         desc_node.update_metadata(metadata)
 
         # Keep specifications for external and internal data_keys for faster access


### PR DESCRIPTION
Removes an implicit dependency on Pydantic v2 which used Pydantic v1 method that caused DeprecationWarnings

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
