### PR TITLE
TST: split the RE fixture

### DIFF
--- a/src/bluesky/tests/conftest.py
+++ b/src/bluesky/tests/conftest.py
@@ -9,10 +9,15 @@ from bluesky.run_engine import RunEngine, TransitionError
 
 
 @pytest.fixture(scope="function", params=[False, True])
-def RE(request):
+def call_returns_result(request):
+    return request.param
+
+
+@pytest.fixture(scope="function")
+def RE(request, call_returns_result):
     loop = asyncio.new_event_loop()
     loop.set_debug(True)
-    RE = RunEngine({}, call_returns_result=request.param, loop=loop)
+    RE = RunEngine({}, call_returns_result=call_returns_result, loop=loop)
 
     def clean_event_loop():
         if RE.state not in ("idle", "panicked"):


### PR DESCRIPTION
This is to simplify re-using the RE fixture in downstream projects.  To use the projects can import the RE fixture from bluesky.tests.conftest and either import the `call_returns_results` fixture to test both modes or provide their own version that only tests one mode or the other.
