### PR TITLE
Changes CoM behaviour & adds/adjusts unit tests

### DIFF
--- a/src/bluesky/callbacks/fitting.py
+++ b/src/bluesky/callbacks/fitting.py
@@ -290,7 +290,7 @@ class PeakStats(CollectThenCompute):
 
         fields["min"] = (x[argmin_y], y_orig[argmin_y])
         fields["max"] = (x[argmax_y], y_orig[argmax_y])
-        (fields["com"],) = np.interp(center_of_mass(y), np.arange(len(x)), x)
+        (fields["com"],) = np.interp(center_of_mass(y - np.min(y)), np.arange(len(x)), x)
         mid = (np.max(y) + np.min(y)) / 2
         crossings = np.where(np.diff((y > mid).astype(int)))[0]
         _cen_list = []

--- a/src/bluesky/tests/test_scientific.py
+++ b/src/bluesky/tests/test_scientific.py
@@ -16,7 +16,7 @@ def get_ps(x, y, shift=0.5):
     x = np.array(x)
     y = np.array(y)
 
-    COM = np.sum(x * y) / np.sum(y)
+    COM = np.sum(x * (y - np.min(y))) / np.sum(y - np.min(y))
     ps["com"] = COM
 
     # from Maksim: assume this is a peak profile:
@@ -134,3 +134,18 @@ def test_peak_statistics_with_derivatives(RE):
     assert len(ps.derivative_stats.x) == num_points - 1
     assert len(ps.derivative_stats.y) == num_points - 1
     assert np.allclose(np.diff(ps.y_data), ps.derivative_stats.y, atol=1e-10)
+
+@pytest.mark.parametrize("com,background", [(1, -1), (1, 1)])
+def test_peak_statistics_with_non_zero_background_and_non_symmetry_scan(RE, com, background):
+    """peak statistics calculation on a gaussian function with a non zero background and a non symmetrical scan"""
+
+    ps = PeakStats("x", "y")
+    
+    ps.start({})
+    ps.event({"data": {"x": 0, "y": background}})
+    ps.event({"data": {"x": 1, "y": background+1}})
+    ps.event({"data": {"x": 2, "y": background}})
+    ps.event({"data": {"x": 3, "y": background}})
+    ps.stop({})
+
+    assert ps["com"] == com


### PR DESCRIPTION
## Description
When calculating CoM, use `y - min(y)` instead of `y`. This is necessary so that the new background of the data is zero but the correlation between data points is maintained. The background must be made zero because otherwise all points of y value less than zero are forced positive in the calculation, meaning that the correlation between data is lost and the CoM is skewed.

Fixes #1877

## How Has This Been Tested?
Tested by running plans with data with non-negative backgrounds and checking that CoM is returned as expected.
Added a parameterised unit test that checks for data with non-negative backgrounds returns correct CoM.
Updated `get_ps` from `test_scientific.py` to reflect the changes made in `PeakStats` of `fitting.py`.
This should not affect other areas of code,