### PR TITLE
Do not leak StreamResource in metadata.

### DIFF
--- a/src/bluesky/callbacks/tiled_writer.py
+++ b/src/bluesky/callbacks/tiled_writer.py
@@ -258,7 +258,7 @@ class _RunWriter(CallbackBase):
                 key=handler.data_key,
                 structure_family=StructureFamily.array,
                 data_sources=[handler.get_data_source()],
-                metadata=sres_doc,
+                metadata={},
                 specs=[],
             )
 


### PR DESCRIPTION
Watching @jwlodek demo Area Detector integration with ophyd-async, bluesky, and Tiled, I notice that

```py
c.values().last()["primary"]["data"][{field}].metadata
```

contained the Stream Resource. I believe that

```py
c.values().last()["primary"]["data"][{field}].data_source()
```

is the canonical location of this information. I think it should be preferred because:

1. It contains the complete filepaths, not templates (as in TIFF).
2. In the future we will add support for moving assets. (You could do this today with a SQL query; in the future I expect we'll add an HTTP API for it.) When we do, `data_sources()` will automatically reflect the new location. But `metadata` would need to be updated separately, and I think it would be easy for this to drift out of sync.

I propose leaving the `metadata` empty. If this introduces challenges for "replaying" documents, perhaps we could retain _some_ of the information, but I hope it's possible to get what we need purely from assets and data sources without any supplemental `metadata` here.