### PR TITLE
[MNT] Remove non 3.9 dependencies and adjust some typing mechanisms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,15 +17,13 @@ dependencies = [
     "cycler",
     "event-model>=1.19.8",
     "historydict",
-    "importlib-resources;python_version<'3.9'",
     "msgpack",
     "msgpack-numpy",
     "numpy",
     "opentelemetry-api",
     "toolz",
     "tqdm>=4.44",
-    "typing-extensions>=4.0.0;python_version<'3.11'",
-    "dataclasses;python_version<'3.7'",
+    "typing-extensions>=4.10.0",
 ]
 dynamic = ["version"]
 license.file = "LICENSE"

--- a/src/bluesky/protocols.py
+++ b/src/bluesky/protocols.py
@@ -1,3 +1,4 @@
+import sys
 from abc import abstractmethod
 from collections.abc import AsyncIterator, Awaitable, Iterator
 from typing import (
@@ -24,10 +25,10 @@ from typing_extensions import TypedDict, Unpack
 # Squashes warning
 Dtype = Dtype  # type: ignore
 
-try:
+if sys.version_info >= (3, 10):
     from typing import ParamSpec
-except ImportError:
-    from typing_extensions import ParamSpec  # type: ignore
+else:
+    from typing_extensions import ParamSpec
 
 
 # TODO: these are not placed in Events by RE yet

--- a/src/bluesky/protocols.py
+++ b/src/bluesky/protocols.py
@@ -1,4 +1,3 @@
-import sys
 from abc import abstractmethod
 from collections.abc import AsyncIterator, Awaitable, Iterator
 from typing import (
@@ -20,15 +19,10 @@ from event_model.documents.event import PartialEvent
 from event_model.documents.event_descriptor import DataKey, Dtype
 from event_model.documents.event_page import PartialEventPage
 from event_model.documents.resource import PartialResource
-from typing_extensions import TypedDict, Unpack
+from typing_extensions import ParamSpec, TypedDict, Unpack
 
 # Squashes warning
 Dtype = Dtype  # type: ignore
-
-if sys.version_info >= (3, 10):
-    from typing import ParamSpec
-else:
-    from typing_extensions import ParamSpec
 
 
 # TODO: these are not placed in Events by RE yet

--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -1927,8 +1927,10 @@ async def maybe_collect_asset_docs(
         async for doc in iterate_maybe_async(obj.collect_asset_docs(*args, **kwargs)):
             yield doc
 
+
 def _isawaitable(value: SyncOrAsync[T]) -> TypeIs[Awaitable[T]]:
     return inspect.isawaitable(value)
+
 
 async def maybe_await(ret: SyncOrAsync[T]) -> T:
     if _isawaitable(ret):

--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -15,7 +15,7 @@ import types
 import uuid
 import warnings
 from collections import namedtuple
-from collections.abc import AsyncIterable, AsyncIterator, Generator, Iterable
+from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Generator, Iterable
 from collections.abc import Iterable as TypingIterable
 from functools import partial, reduce, wraps
 from inspect import Parameter, Signature
@@ -34,6 +34,7 @@ import numpy as np
 from cycler import Cycler, cycler
 from tqdm import tqdm
 from tqdm.utils import _screen_shape_wrapper, _term_move_up, _unicode
+from typing_extensions import TypeIs
 
 from bluesky._vendor.super_state_machine.errors import TransitionError
 from bluesky.protocols import (
@@ -1926,14 +1927,14 @@ async def maybe_collect_asset_docs(
         async for doc in iterate_maybe_async(obj.collect_asset_docs(*args, **kwargs)):
             yield doc
 
+def _isawaitable(value: SyncOrAsync[T]) -> TypeIs[Awaitable[T]]:
+    return inspect.isawaitable(value)
 
 async def maybe_await(ret: SyncOrAsync[T]) -> T:
-    if inspect.isawaitable(ret):
+    if _isawaitable(ret):
         return await ret
     else:
-        # Mypy does not understand how to narrow type to non-awaitable in this
-        # instance, see https://github.com/python/mypy/issues/15520
-        return ret  # type: ignore
+        return ret
 
 
 class Plan:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Drop dependencies requiring `Python < 3.9`, use `TypeIs` in `utils.maybe_await` and use `sys.version_info` to import `ParamSpec` in `protocols`.

## Motivation and Context
- Since Bluesky supports `Python >= 3.9`, I removed some dependencies from `pyproject.toml` required for lower versions.
- [PEP 742](https://peps.python.org/pep-0742/) introduced `TypeIs` to narrow types and addresses the [issue](https://github.com/python/mypy/issues/15520) originally mentioned in `utils.maybe_await`. For `Python < 3.13`, this is backported in `typing_extensions >= 4.10.0`, which is bumped in `pyproject.toml`.
- Rather than using `try-except` to import `ParamSpec`, I used `sys.version_info` which is suggested in [this guide](https://learn.scientific-python.org/development/patterns/backports/#conditional-usage) from the Scientific Python community.

## How Has This Been Tested?
I ran

```
mypy src\bluesky
```

locally on my machine.

Note that it also reported the following errors in the `tracing` module:

```
src\bluesky\tracing.py:12: error: The first argument to Callable must be a list of types, parameter specification, or "..."  [valid-type]
src\bluesky\tracing.py:12: note: See https://mypy.readthedocs.io/en/stable/kinds_of_types.html#callable-types-and-lambdas
src\bluesky\tracing.py:15: error: The first argument to Callable must be a list of types, parameter specification, or "..."  [valid-type]
src\bluesky\tracing.py:15: note: See https://mypy.readthedocs.io/en/stable/kinds_of_types.html#callable-types-and-lambdas
src\bluesky\tracing.py:21: error: The first argument to Callable must be a list of types, parameter specification, or "..."  [valid-type]
src\bluesky\tracing.py:21: note: See https://mypy.readthedocs.io/en/stable/kinds_of_types.html#callable-types-and-lambdas
```

<!--
## Screenshots (if appropriate):
-->
