### PR TITLE
make rel_adaptive_scan docstring a bit clearer

### DIFF
--- a/src/bluesky/plans.py
+++ b/src/bluesky/plans.py
@@ -825,9 +825,9 @@ def rel_adaptive_scan(
     motor : object
         any 'settable' object (motor, temp controller, etc.)
     start : float
-        starting position of motor
+        starting position of motor, relative to the current position.
     stop : float
-        ending position of motor
+        ending position of motor, relative to the current position.
     min_step : float
         smallest step for fast-changing regions
     max_step : float


### PR DESCRIPTION
## Description
This updates the rel_adaptive_scan docstring to make it clearer that the start and stop are relative to the current position. This might be obvious as the name of the class starts with `rel`, but i think it doesn't harm to make it clear. 

## Motivation and Context

We wanted to use a relative adaptive scan but weren't 100% on the behaviour just based on the docstrings. 

## How Has This Been Tested?
No functional changes here.
