### PR TITLE
Remove debug(?) print statements from `plot_peak_stats`

### DIFF
--- a/src/bluesky/callbacks/mpl_plotting.py
+++ b/src/bluesky/callbacks/mpl_plotting.py
@@ -721,14 +721,12 @@ def plot_peak_stats(peak_stats, ax=None):
     vlines = []
     styles = iter(cycler("color", "krgbm"))
     for style, attr in zip(styles, ["cen", "com"]):
-        print(style, attr)
         val = getattr(ps, attr)
         if val is None:
             continue
         vlines.append(ax.axvline(val, label=attr, **style))
 
     for style, attr in zip(styles, ["max", "min"]):
-        print(style, attr)
         val = getattr(ps, attr)
         if val is None:
             continue


### PR DESCRIPTION
## Description

Removes some debug-style prints from `plot_peak_stats` - I can't see that these would be useful for a typical end-user?

Example of what it would have printed:

```
{'color': 'k'} cen
{'color': 'r'} com
{'color': 'b'} max
{'color': 'm'} min
```

## Motivation and Context

Cleaning up the output for an interactive session, after `PeakStats` have been plotted using `plot_peak_stats`

## How Has This Been Tested?

Tested interactively. Unit test not added for a `print` statement deletion.
