### PR TITLE
API: add `configure` to `Configurable`

### DIFF
--- a/src/bluesky/protocols.py
+++ b/src/bluesky/protocols.py
@@ -188,9 +188,21 @@ class WritesStreamAssets(Protocol):
 
 
 @runtime_checkable
-class Configurable(Protocol[T]):
+class Configurable(Protocol):
     @abstractmethod
-    def read_configuration(self) -> SyncOrAsync[dict[str, Reading[T]]]:
+    def configure(self, *args: Any, **kwargs: Any) -> SyncOrAsync[tuple[Reading[Any], Reading[Any]]]:
+        """Configure an object.
+
+        The method returns a tuple of ``Reading``.
+        The first element is the old configuration value
+        and the second element is the new configuration value.
+
+        This can be a standard function or an ``async`` function.
+        """
+        ...
+
+    @abstractmethod
+    def read_configuration(self) -> SyncOrAsync[dict[str, Reading[Any]]]:
         """Same API as ``read`` but for slow-changing fields related to configuration.
         e.g., exposure time. These will typically be read only once per run.
 


### PR DESCRIPTION
## Description
- Add the `configure` method to `Configurable` protocol
- Remove the generic `T` from `Configurable` definition
- `read_configuration` and `describe_configuration` now return `Any` instead of `T`

Closes #1862 

## Motivation and Context
Although documented as a [message](https://blueskyproject.io/bluesky/main/msg.html#configure) and a [plan stub](https://blueskyproject.io/bluesky/main/generated/bluesky.plan_stubs.configure.html#bluesky.plan_stubs.configure), there is no  proper definition in the `Configurable` protocol for said method. This PR introduces it as part of the protocol for better clarity and enhanced type hinting.

Furthermore, as configuration parameters are not tied to a specific type, `Configurable` now is a non-generic protocol and all the methods return type `Any`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally via

```
pytest
```

Test reported a couple of failures. I wanted to run them on the CI in order to attempt to resolve them since they're related to the `test_flyer` module.

<!--
## Screenshots (if appropriate):
-->
