### PR TITLE
[ENH] `bps.locate` typing

### DIFF
--- a/src/bluesky/plan_stubs.py
+++ b/src/bluesky/plan_stubs.py
@@ -34,6 +34,7 @@ from .protocols import (
     Stageable,
     Status,
     Stoppable,
+    T,
     Triggerable,
     check_supports,
 )
@@ -169,9 +170,9 @@ def read(obj: Readable) -> MsgGenerator[Reading]:
 
 
 @typing.overload
-def locate(*objs: Locatable, squeeze: bool = True) -> MsgGenerator[list[Location[Any]]]: ...
+def locate(*objs: Locatable, squeeze: bool = True) -> MsgGenerator[list[Location[T]]]: ...
 @typing.overload
-def locate(obj: Locatable, squeeze: Literal[True] = True) -> MsgGenerator[Location[Any]]: ...
+def locate(obj: Locatable, squeeze: Literal[True] = True) -> MsgGenerator[Location[T]]: ...
 @plan
 def locate(*objs, squeeze=True):
     """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix type hints for `bps.locate`.

## Motivation and Context
Originally it returned `Location | list[Location]`, when it should be returning `MsgGenerator[Location] | MsgGenerator[list[Location]]`. The return type is hinted `Location[T]` (`T` being imported from `bluesky.protocols`). The overloaded signatures have been swapped to make mypy happy.

## How Has This Been Tested?

Ran locally

```
mypy .
```

And then

```
pytest
```

to ensure no regression.