### PR TITLE
Include ophyd_async version in start doc version metadata

### DIFF
--- a/src/bluesky/run_engine.py
+++ b/src/bluesky/run_engine.py
@@ -466,6 +466,13 @@ class RunEngine:
         except ImportError:
             self.log.debug("Failed to import ophyd.")
 
+        try:
+            import ophyd_async
+
+            self.md["versions"]["ophyd_async"] = ophyd_async.__version__
+        except ImportError:
+            self.log.debug("Failed to import ophyd_async.")
+
         from ._version import __version__
 
         self.md["versions"]["bluesky"] = __version__


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As we start using ophyd async more in prod, it would be good to include its version in the start doc metadata.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran scan with change:

```
========= Emitting Doc =============
name = 'start'
{
    "uid": "3f79be77-edb9-4410-90bf-c24b0a9a3674",
    "time": 1744208682.0387623,
    "versions": {
        "ophyd": "1.10.0",
        "ophyd_async": "0.8.0a7.dev54+g46be3bf",
        "bluesky": "1.13.2.dev44+g0ed50c97"
    },
    "scan_id": 1,
    "plan_type": "generator",
    "plan_name": "software_flyscan"
}
============ Done ============
```

<!--
## Screenshots (if appropriate):
-->
