### PR TITLE
Handle enum and boolean values passed via event data to `LiveTable`

### DIFF
--- a/src/bluesky/callbacks/core.py
+++ b/src/bluesky/callbacks/core.py
@@ -428,7 +428,7 @@ class LiveTable(CallbackBase):
                 f.format(**{f"h{str(hash(k))}": str(data[k])})
                 if ((k in data) and isinstance(data[k], (bool)))
                 # If we have an enum, `str` the value
-                else f.format(**{f"h{str(hash(k))}": str(data[k].value)})
+                else f.format(**{f"h{str(hash(k))}": data[k].value})
                 if ((k in data) and isinstance(data[k], (Enum)))
                 else f.format(**{f"h{str(hash(k))}": data[k]})
                 # Show data[k] if k exists in this Event and is 'filled'.

--- a/src/bluesky/callbacks/core.py
+++ b/src/bluesky/callbacks/core.py
@@ -2,13 +2,13 @@
 Useful callbacks for the Run Engine
 """
 
-from enum import Enum
 import logging
 import os
 import time as ttime
 import warnings
 from collections import OrderedDict, defaultdict, deque, namedtuple
 from datetime import datetime
+from enum import Enum
 from functools import partial as _partial
 from functools import wraps as _wraps
 from itertools import count
@@ -368,7 +368,7 @@ class LiveTable(CallbackBase):
                 continue
 
             if dk_entry["dtype"] == "boolean":
-                prec = 5 # 5 is the length of the string "False"
+                prec = 5  # 5 is the length of the string "False"
             elif dk_entry["dtype"] == "string":
                 # If string, set precision to length of the key minus padding
                 prec = width - 1 - 2 * self._pad_len
@@ -426,10 +426,10 @@ class LiveTable(CallbackBase):
             cols = [
                 # If we have a bool, just `str` it.
                 f.format(**{f"h{str(hash(k))}": str(data[k])})
-                if isinstance(data[k], (bool))
+                if ((k in data) and isinstance(data[k], (bool)))
                 # If we have an enum, `str` the value
                 else f.format(**{f"h{str(hash(k))}": str(data[k].value)})
-                if isinstance(data[k], (Enum))
+                if ((k in data) and isinstance(data[k], (Enum)))
                 else f.format(**{f"h{str(hash(k))}": data[k]})
                 # Show data[k] if k exists in this Event and is 'filled'.
                 # (The latter is only applicable if the data is

--- a/src/bluesky/callbacks/core.py
+++ b/src/bluesky/callbacks/core.py
@@ -427,7 +427,7 @@ class LiveTable(CallbackBase):
                 # If we have a bool, just `str` it.
                 f.format(**{f"h{str(hash(k))}": str(data[k])})
                 if ((k in data) and isinstance(data[k], (bool)))
-                # If we have an enum, `str` the value
+                # If we have an enum, format with it's value
                 else f.format(**{f"h{str(hash(k))}": data[k].value})
                 if ((k in data) and isinstance(data[k], (Enum)))
                 else f.format(**{f"h{str(hash(k))}": data[k]})

--- a/src/bluesky/tests/test_callbacks.py
+++ b/src/bluesky/tests/test_callbacks.py
@@ -1,3 +1,4 @@
+from enum import Enum
 import time
 from collections import defaultdict
 from io import StringIO
@@ -245,6 +246,120 @@ def test_evil_table_names(RE):
 |         1  |  12:47:09.7  |     0  |     0  |     0  |     0  |
 |         2  |  12:47:09.7  |     0  |     0  |     0  |     0  |
 +------------+--------------+--------+--------+--------+--------+"""
+    _compare_tables(fout, reference)
+    fout.close()
+
+
+class TableTestEnum(str, Enum):
+    """Enum for testing LiveTable with enum values."""
+
+    OK = "OK"
+    NOT_OK = "NOT_OK"
+
+_BOOL_ENUM_DOCS = [
+("descriptor", 
+{
+    "configuration": {},
+    "data_keys": {
+        "enum_test_sig": {
+            "dtype": "string",
+            "shape": [],
+            "dtype_numpy": "|S40",
+            "source": "ca://DEV:RBD9103:InRange_RBV",
+            "choices": [
+                "OK",
+                "Under",
+                "Over"
+            ],
+            "object_name": "rbd9103"
+        },
+        "bool_test_sig": {
+            "dtype": "boolean",
+            "shape": [],
+            "dtype_numpy": "|b1",
+            "source": "ca://DEV:RBD9103:Stable_RBV",
+            "object_name": "rbd9103"
+        }
+    },
+    "name": "primary",
+    "object_keys": {
+        "rbd9103": [
+            "enum_test_sig",
+            "bool_test_sig"
+        ]
+    },
+    "run_start": "d8e2afc6-2c79-4786-8a2e-b1245b2be578",
+    "time": 1746210217.2738924,
+    "uid": "2d29452a-a2e3-4697-8db2-423b8cae5065",
+    "hints": {
+        "rbd9103": {
+            "fields": [
+                "enum_test_sig",
+                "bool_test_sig"
+            ]
+        }
+    }
+}
+),
+('event',
+{
+    "uid": "69b921f3-6037-477b-8d76-731c330c654a",
+    "time": 1746210217.2745216,
+    "data": {
+        "enum_test_sig": TableTestEnum.OK,
+        "bool_test_sig": False
+    },
+    "timestamps": {
+        "enum_test_sig": 631152000.0,
+        "bool_test_sig": 631152000.0
+    },
+    "seq_num": 1,
+    "filled": {},
+    "descriptor": "2d29452a-a2e3-4697-8db2-423b8cae5065"
+}),
+('event',
+{
+    "uid": "69b921f3-6037-477b-8d76-731c330c654a",
+    "time": 1746210217.2745216,
+    "data": {
+        "enum_test_sig": TableTestEnum.NOT_OK,
+        "bool_test_sig": True
+    },
+    "timestamps": {
+        "enum_test_sig": 631152000.0,
+        "bool_test_sig": 631152000.0
+    },
+    "seq_num": 1,
+    "filled": {},
+    "descriptor": "2d29452a-a2e3-4697-8db2-423b8cae5065"
+}),
+('stop',
+{
+    "uid": "0c862732-f3a2-4ee6-8ef8-7aed0cf4a408",
+    "time": 1746210217.2791321,
+    "run_start": "d8e2afc6-2c79-4786-8a2e-b1245b2be578",
+    "exit_status": "success",
+    "reason": "",
+    "num_events": {
+        "primary": 1
+    }
+}),
+]
+
+
+def test_table_bool_enum_doc_inputs(RE):
+    table = LiveTable([s for s in _BOOL_ENUM_DOCS[0][1]["data_keys"]])
+    with _print_redirect() as fout:
+        print()  # get a blank line in camptured output
+        for name, doc in _BOOL_ENUM_DOCS:
+            table(name, doc)
+    reference = """
++-----------+------------+---------------+---------------+
+|   seq_num |       time | enum_test_sig | bool_test_sig |
++-----------+------------+---------------+---------------+
+|         1 | 14:23:37.2 |            OK |         False |
+|         2 | 14:23:37.2 |        NOT_OK |          True |
++-----------+------------+---------------+---------------+"""
     _compare_tables(fout, reference)
     fout.close()
 

--- a/src/bluesky/tests/test_callbacks.py
+++ b/src/bluesky/tests/test_callbacks.py
@@ -1,6 +1,6 @@
-from enum import Enum
 import time
 from collections import defaultdict
+from enum import Enum
 from io import StringIO
 from itertools import permutations
 from unittest.mock import MagicMock
@@ -256,99 +256,77 @@ class TableTestEnum(str, Enum):
     OK = "OK"
     NOT_OK = "NOT_OK"
 
+
 _BOOL_ENUM_DOCS = [
-("descriptor", 
-{
-    "configuration": {},
-    "data_keys": {
-        "enum_test_sig": {
-            "dtype": "string",
-            "shape": [],
-            "dtype_numpy": "|S40",
-            "source": "ca://DEV:RBD9103:InRange_RBV",
-            "choices": [
-                "OK",
-                "Under",
-                "Over"
-            ],
-            "object_name": "rbd9103"
+    (
+        "descriptor",
+        {
+            "configuration": {},
+            "data_keys": {
+                "enum_test_sig": {
+                    "dtype": "string",
+                    "shape": [],
+                    "dtype_numpy": "|S40",
+                    "source": "ca://DEV:RBD9103:InRange_RBV",
+                    "choices": ["OK", "Under", "Over"],
+                    "object_name": "rbd9103",
+                },
+                "bool_test_sig": {
+                    "dtype": "boolean",
+                    "shape": [],
+                    "dtype_numpy": "|b1",
+                    "source": "ca://DEV:RBD9103:Stable_RBV",
+                    "object_name": "rbd9103",
+                },
+            },
+            "name": "primary",
+            "object_keys": {"rbd9103": ["enum_test_sig", "bool_test_sig"]},
+            "run_start": "d8e2afc6-2c79-4786-8a2e-b1245b2be578",
+            "time": 1746210217.2738924,
+            "uid": "2d29452a-a2e3-4697-8db2-423b8cae5065",
+            "hints": {"rbd9103": {"fields": ["enum_test_sig", "bool_test_sig"]}},
         },
-        "bool_test_sig": {
-            "dtype": "boolean",
-            "shape": [],
-            "dtype_numpy": "|b1",
-            "source": "ca://DEV:RBD9103:Stable_RBV",
-            "object_name": "rbd9103"
-        }
-    },
-    "name": "primary",
-    "object_keys": {
-        "rbd9103": [
-            "enum_test_sig",
-            "bool_test_sig"
-        ]
-    },
-    "run_start": "d8e2afc6-2c79-4786-8a2e-b1245b2be578",
-    "time": 1746210217.2738924,
-    "uid": "2d29452a-a2e3-4697-8db2-423b8cae5065",
-    "hints": {
-        "rbd9103": {
-            "fields": [
-                "enum_test_sig",
-                "bool_test_sig"
-            ]
-        }
-    }
-}
-),
-('event',
-{
-    "uid": "69b921f3-6037-477b-8d76-731c330c654a",
-    "time": 1746210217.2745216,
-    "data": {
-        "enum_test_sig": TableTestEnum.OK,
-        "bool_test_sig": False
-    },
-    "timestamps": {
-        "enum_test_sig": 631152000.0,
-        "bool_test_sig": 631152000.0
-    },
-    "seq_num": 1,
-    "filled": {},
-    "descriptor": "2d29452a-a2e3-4697-8db2-423b8cae5065"
-}),
-('event',
-{
-    "uid": "69b921f3-6037-477b-8d76-731c330c654a",
-    "time": 1746210217.2745216,
-    "data": {
-        "enum_test_sig": TableTestEnum.NOT_OK,
-        "bool_test_sig": True
-    },
-    "timestamps": {
-        "enum_test_sig": 631152000.0,
-        "bool_test_sig": 631152000.0
-    },
-    "seq_num": 1,
-    "filled": {},
-    "descriptor": "2d29452a-a2e3-4697-8db2-423b8cae5065"
-}),
-('stop',
-{
-    "uid": "0c862732-f3a2-4ee6-8ef8-7aed0cf4a408",
-    "time": 1746210217.2791321,
-    "run_start": "d8e2afc6-2c79-4786-8a2e-b1245b2be578",
-    "exit_status": "success",
-    "reason": "",
-    "num_events": {
-        "primary": 1
-    }
-}),
+    ),
+    (
+        "event",
+        {
+            "uid": "69b921f3-6037-477b-8d76-731c330c654a",
+            "time": 1746210217.2745216,
+            "data": {"enum_test_sig": TableTestEnum.OK, "bool_test_sig": False},
+            "timestamps": {"enum_test_sig": 631152000.0, "bool_test_sig": 631152000.0},
+            "seq_num": 1,
+            "filled": {},
+            "descriptor": "2d29452a-a2e3-4697-8db2-423b8cae5065",
+        },
+    ),
+    (
+        "event",
+        {
+            "uid": "69b921f3-6037-477b-8d76-731c330c654a",
+            "time": 1746210217.2745216,
+            "data": {"enum_test_sig": TableTestEnum.NOT_OK, "bool_test_sig": True},
+            "timestamps": {"enum_test_sig": 631152000.0, "bool_test_sig": 631152000.0},
+            "seq_num": 2,
+            "filled": {},
+            "descriptor": "2d29452a-a2e3-4697-8db2-423b8cae5065",
+        },
+    ),
+    (
+        "stop",
+        {
+            "uid": "0c862732-f3a2-4ee6-8ef8-7aed0cf4a408",
+            "time": 1746210217.2791321,
+            "run_start": "d8e2afc6-2c79-4786-8a2e-b1245b2be578",
+            "exit_status": "success",
+            "reason": "",
+            "num_events": {"primary": 1},
+        },
+    ),
 ]
 
 
 def test_table_bool_enum_doc_inputs(RE):
-    table = LiveTable([s for s in _BOOL_ENUM_DOCS[0][1]["data_keys"]])
+    table = LiveTable(list(_BOOL_ENUM_DOCS[0][1]["data_keys"]))
     with _print_redirect() as fout:
         print()  # get a blank line in camptured output
         for name, doc in _BOOL_ENUM_DOCS:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves #1900 

## Description
<!--- Describe your changes in detail -->
Without this change, attempting to use an in-process live table callback with ophyd async Enum or bool signals would not process correctly due to the document not being entirely serialized to a string. The existing `LiveTable` would print enum data as just the first three characters of the enum's class name, and boolean signals would not print at all.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Enum & boolean signals should be printed correctly in `LiveTable` output.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Included unit test
* Against a real ophyd async device.

<!--
## Screenshots (if appropriate):
-->
