### PR TITLE
Add `timeout` argument to `mv` and `mvr`

### DIFF
--- a/src/bluesky/plan_stubs.py
+++ b/src/bluesky/plan_stubs.py
@@ -351,6 +351,7 @@ def rel_set(
 def mv(
     *args: Union[Movable, Any],
     group: Optional[Hashable] = None,
+    timeout: Optional[float] = None,
     **kwargs,
 ) -> MsgGenerator[tuple[Status, ...]]:
     """
@@ -364,6 +365,8 @@ def mv(
         device1, value1, device2, value2, ...
     group : string, optional
         Used to mark these as a unit to be waited on.
+    timeout : float, optional
+        Specify a maximum time that the move(s) can be waited for.
     kwargs :
         passed to obj.set()
 
@@ -389,7 +392,7 @@ def mv(
     for obj, val in step.items():
         ret = yield Msg("set", obj, val, group=group, **kwargs)
         status_objects.append(ret)
-    yield Msg("wait", None, group=group)
+    yield Msg("wait", None, group=group, timeout=timeout)
     return tuple(status_objects)
 
 
@@ -398,7 +401,7 @@ mov = mv  # synonym
 
 @plan
 def mvr(
-    *args: Union[Movable, Any], group: Optional[Hashable] = None, **kwargs
+    *args: Union[Movable, Any], group: Optional[Hashable] = None, timeout: Optional[float] = None, **kwargs
 ) -> MsgGenerator[tuple[Status, ...]]:
     """
     Move one or more devices to a relative setpoint. Wait for all to complete.
@@ -411,6 +414,8 @@ def mvr(
         device1, value1, device2, value2, ...
     group : string, optional
         Used to mark these as a unit to be waited on.
+    timeout : float, optional
+        Specify a maximum time that the move(s) can be waited for.
     kwargs :
         passed to obj.set()
 
@@ -436,7 +441,7 @@ def mvr(
 
     @relative_set_decorator(objs)
     def inner_mvr():
-        return (yield from mv(*args, group=group, **kwargs))
+        return (yield from mv(*args, group=group, timeout=timeout, **kwargs))
 
     return (yield from inner_mvr())
 

--- a/src/bluesky/tests/test_new_examples.py
+++ b/src/bluesky/tests/test_new_examples.py
@@ -303,7 +303,7 @@ def test_mvr_with_timeout(hw):
     # move motors first to ensure that movement is absolute, not relative
     actual = list(mvr(hw.motor1, 1, hw.motor2, 2, timeout=42))
     for msg in actual[:2]:
-        msg.command == "set"  # noqa: B015
+        assert msg.command == "set"  # noqa: B015
 
     assert actual[2].kwargs["timeout"] == 42
 


### PR DESCRIPTION
This change is intended a shorthand for the following operation (and for `rel_set` / `mvr`):

```python
yield from bps.abs_set(obj, X, group=Y)
yield from bps.wait(group=Y, timeout=Z)
```

, so we can instead simply write

```python
yield from bps.mv(obj, X, timeout=Z)
```

## Motivation and Context
I've come across many cases like this, where I'm moving regular signals (i.e not Positioners or anything of that sort), but the IOC or the hardware sometimes gets stuck, usually during some pre-scan configuration. In these cases, having a timeout is useful to give the user a meaningful indication of what has failed.


