### PR TITLE
DOC: updated tutorial doc to use conda-forge

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -53,7 +53,7 @@ Before You Begin
 
   .. code-block:: bash
 
-     conda install -c nsls2forge bluesky ophyd databroker matplotlib pyqt=5 ipython
+     conda install -c conda-forge bluesky ophyd databroker matplotlib pyqt=5 ipython
 
 * Start IPython:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed the bluesky tutorial documentation to include conda-forge instead of nsls2forge.

## Motivation and Context
Max noticed a slightly outdated command when preparing the conva environment. 

## How Has This Been Tested?
Followed bluesky tutorial and was able to successfully create the conda environment. Ipython terminal opened without previous issue of incompatible types with qt5 and matplotlib.

## Screenshots (if appropriate):

