### PR TITLE
Update documents.rst

### DIFF
--- a/docs/documents.rst
+++ b/docs/documents.rst
@@ -165,7 +165,7 @@ The most commonly useful fields here are 'time' and 'exit_status'.
      'reason': '',  # The RunEngine can provide reason for failure here.
      'time': 1442521012.1021606,
      'uid': '<randomly-generated unique ID>',
-     'start': '<reference to the start document>',
+     'run_start': '<reference to the start document>',
      'num_events': {'primary': 16}
     }
 


### PR DESCRIPTION
The Stop document key that holds the reference to the start document is 'run_start', not 'start'. Updating documentation.
