### PR TITLE
ENH: Support async scan_id_source functions

### DIFF
--- a/docs/api_changes.rst
+++ b/docs/api_changes.rst
@@ -2,6 +2,14 @@
  Release History
 =================
 
+v1.14.3 (yyyy-mm-dd)
+====================
+
+Changed
+-------
+
+- RunEngine now supports both sync and async functions as a `scan_id_source`
+
 v1.14.1 (2025-05-21)
 ====================
 

--- a/src/bluesky/run_engine.py
+++ b/src/bluesky/run_engine.py
@@ -38,6 +38,7 @@ from .protocols import (
     Status,
     Stoppable,
     T,
+    SyncOrAsync,
     Triggerable,
     check_supports,
 )
@@ -269,7 +270,7 @@ class RunEngine:
         completely up to the user.
         Expected return: normalized metadata
 
-    scan_id_source : callable, optional
+    scan_id_source : callable
         a function that will be used to calculate scan_id. Default is to
         increment scan_id by 1 each time. However you could pass in a
         customized function to get a scan_id from any source.
@@ -418,7 +419,7 @@ class RunEngine:
         context_managers: typing.Optional[list] = None,
         md_validator: typing.Optional[typing.Callable] = None,
         md_normalizer: typing.Optional[typing.Callable] = None,
-        scan_id_source: typing.Optional[typing.Callable] = default_scan_id_source,
+        scan_id_source: typing.Callable[[dict], SyncOrAsync[int]] = default_scan_id_source,
         during_task: typing.Optional[DuringTask] = None,
         call_returns_result: bool = False,
     ):
@@ -1857,7 +1858,7 @@ class RunEngine:
             raise IllegalMessageSequence("A 'close_run' message was not received before the 'open_run' message")
 
         # Run scan_id calculation method
-        self.md["scan_id"] = self.scan_id_source(self.md)
+        self.md["scan_id"] = await maybe_await(self.scan_id_source(self.md))
 
         # For metadata below, info about plan passed to self.__call__ for.
         plan_type = type(self._plan).__name__

--- a/src/bluesky/run_engine.py
+++ b/src/bluesky/run_engine.py
@@ -37,8 +37,8 @@ from .protocols import (
     Stageable,
     Status,
     Stoppable,
-    T,
     SyncOrAsync,
+    T,
     Triggerable,
     check_supports,
 )

--- a/src/bluesky/run_engine.py
+++ b/src/bluesky/run_engine.py
@@ -270,10 +270,10 @@ class RunEngine:
         completely up to the user.
         Expected return: normalized metadata
 
-    scan_id_source : callable
-        a function that will be used to calculate scan_id. Default is to
-        increment scan_id by 1 each time. However you could pass in a
-        customized function to get a scan_id from any source.
+    scan_id_source : callable, optional
+        a (possibly async) function that will be used to calculate scan_id.
+        Default is to increment scan_id by 1 each time. However you could pass
+        in a customized function to get a scan_id from any source.
         Expected signature: f(md)
         Expected return: updated scan_id value
 

--- a/src/bluesky/tests/test_run_engine.py
+++ b/src/bluesky/tests/test_run_engine.py
@@ -2129,16 +2129,20 @@ def test_configure_multiple_descritpors(RE):
 
     assert stop["num_events"]["primary"] == 2
 
+
 def test_sync_scan_id_source(RE):
     def sync_scan_source(md: dict) -> int:
         return 314159
+
     RE.scan_id_source = sync_scan_source
     RE([Msg("open_run")])
-    assert RE.md['scan_id'] == 314159
+    assert RE.md["scan_id"] == 314159
+
 
 def test_async_scan_id_source(RE):
     async def async_scan_source(md: dict) -> int:
         return 42
+
     RE.scan_id_source = async_scan_source
     RE([Msg("open_run")])
-    assert RE.md['scan_id'] == 42
+    assert RE.md["scan_id"] == 42

--- a/src/bluesky/tests/test_run_engine.py
+++ b/src/bluesky/tests/test_run_engine.py
@@ -2128,3 +2128,17 @@ def test_configure_multiple_descritpors(RE):
         assert len(d.event[desc["uid"]]) == 1
 
     assert stop["num_events"]["primary"] == 2
+
+def test_sync_scan_id_source(RE):
+    def sync_scan_source(md: dict) -> int:
+        return 314159
+    RE.scan_id_source = sync_scan_source
+    RE([Msg("open_run")])
+    assert RE.md['scan_id'] == 314159
+
+def test_async_scan_id_source(RE):
+    async def async_scan_source(md: dict) -> int:
+        return 42
+    RE.scan_id_source = async_scan_source
+    RE([Msg("open_run")])
+    assert RE.md['scan_id'] == 42


### PR DESCRIPTION
Allow scan_id_source functions to be async

## Description
If the scan id is determined by an external service (as is the case at DLS), it
would be useful to not block on the request.

## Motivation and Context
See #1895

## How Has This Been Tested?
New tests asserting scan id is updated correctly on `open_run` with both sync
and async source functions
