### PR TITLE
DOC: fix typos and added import statement

### DIFF
--- a/docs/tiled-writer.rst
+++ b/docs/tiled-writer.rst
@@ -14,9 +14,9 @@ It implicitly distinguishes between "internal" and "external" data. The internal
 
 On the other hand, the external data are written by detectors directly on disk and usually take the form of images or multidimensional arrays. The references to the external files are provided in `StreamRsource` (`Resource` in legacy implementations) documents, which register the corresponding array-like `DataSources` in Tiled. `StreamDatum` (or `Datum`) documents are processed via the mechanism of `Consolidators` and determine the correspondence between the indexing within these external arrays and the physically-meaningful sequence of timestamps.
 
-The time dimension (or the sequence of measurements) is typically shared between the internal and external data, which in Tiled is enforced by writing all data from the same Bluesky stream into a specialized `Composite` container (node in the Tiled catalog). The metadata on each stream node contains the specifications for the related data keys and the relevavt configuration parameters supplied in the `EventDescriptor` document.
+The time dimension (or the sequence of measurements) is typically shared between the internal and external data, which in Tiled is enforced by writing all data from the same Bluesky stream into a specialized `Composite` container (node in the Tiled catalog). The metadata on each stream node contains the specifications for the related data keys and the relevant configuration parameters supplied in the `EventDescriptor` document.
 
-Finally, nodes for multiple streams are groupped together and placed into a container for the entire run; its metadata contains the `Start` and `Stop` documents. While the strcuture of the `streams` container is fixed, the parent Run allows for optional user-controlled namespaces within `views` and `aux` containers. The Run container created by TiledWriter is designated with the `BlueskyRun` version `3.0` spec to enable its back-compatibility with legacy code via bluesky-tiled-plugins.
+Finally, nodes for multiple streams are grouped together and placed into a container for the entire run; its metadata contains the `Start` and `Stop` documents. While the structure of the `streams` container is fixed, the parent Run allows for optional user-controlled namespaces within `views` and `aux` containers. The Run container created by TiledWriter is designated with the `BlueskyRun` version `3.0` spec to enable its back-compatibility with legacy code via bluesky-tiled-plugins.
 
 An example of the Tiled catalog structure for a Bluesky run might look like this:
 
@@ -131,6 +131,7 @@ A minimal simulated example of using TiledWriter in a Bluesky plan is shown belo
 
     from bluesky import RunEngine
     import bluesky.plans as bp
+    from bluesky.callbacks.tiled_writer import TiledWriter
     from tiled.server import SimpleTiledServer
     from tiled.client import from_uri
     from ophyd.sim import det


### PR DESCRIPTION
Fixed typos and added a required import statement for the TiledWriter tutorial