### PR TITLE
Update subscribable protocol to use subscribe_reading

### DIFF
--- a/docs/api_changes.rst
+++ b/docs/api_changes.rst
@@ -2,6 +2,28 @@
  Release History
 =================
 
+Unreleased
+==========
+
+Changed
+-------
+
+- The ``bluesky.protocols.Subscribable`` protocol now requires a
+  ``subscribe_reading`` method rather than a ``subscribe`` method.  The
+  protocol did not match the implementation it was written to describe:
+  ophyd's ``subscribe`` calls back with the ``obj`` that changed, whereas
+  ``Subscribable`` documented a callback taking a mapping of
+  ``{name: Reading}``.  Renaming makes the two subscription styles
+  distinct, so an object can implement either (or both) unambiguously.
+- ophyd objects therefore no longer satisfy
+  ``isinstance(obj, Subscribable)``.  The ``monitor`` and ``unmonitor``
+  messages still support them: ``monitor`` calls ``subscribe_reading`` if
+  the object implements ``Subscribable``, and otherwise falls back to
+  calling ``subscribe`` and reading the object back in the callback.
+  Devices that implemented the old ``Subscribable`` protocol should rename
+  ``subscribe`` to ``subscribe_reading``; users of ophyd-async need at
+  least v0.13.5.
+
 v1.15.1 (2026-05-05)
 ====================
 
@@ -42,9 +64,6 @@ Changed
 
 v1.14.6 (2025-10-08)
 ====================
-
-Added
------
 
 Fixed
 -----
@@ -100,7 +119,37 @@ Fixed
 v1.14.2 (2025-06-10)
 ====================
 
-TO DO
+Added
+-----
+
+- ``bluesky.callbacks.buffer.BufferingWrapper``, which runs a wrapped
+  callback on its own thread behind a queue so that slow consumers do not
+  block the ``RunEngine``.  It raises if the queue fills up rather than
+  growing without bound.
+- ``bluesky.callbacks.json_writer.JSONWriter`` and ``JSONLinesWriter``,
+  which serialize a run's documents to JSON and JSONLines respectively.
+- ``TiledWriter`` accepts ``spec_to_mimetype`` to extend or override the
+  mapping used when converting legacy ``Resource`` documents to
+  ``StreamResource``, and ``patches`` to fix up documents before they are
+  normalized.
+- ``TiledWriter`` accepts ``backup_directory``; runs that fail to be
+  written to Tiled are written there in JSONLines format for recovery.
+- ``TiledWriter`` accepts ``batch_size``, the number of ``Event`` or
+  ``StreamDatum`` documents to collect before writing.  Larger values cut
+  down the number of write operations for bulk work such as database
+  migration; for streaming use, keep it at ``<= 1``.
+
+Changed
+-------
+
+- The document normalizer used by ``TiledWriter`` is now public as
+  ``bluesky.callbacks.tiled_writer.RunNormalizer`` (was
+  ``_RunNormalizer``), so it can be reused to feed updated documents to
+  other consumers.
+- ``MIMETYPE_LOOKUP`` moved from ``bluesky.callbacks.core`` to
+  ``bluesky.callbacks.tiled_writer``.
+- ``StreamResource`` documents are now emitted in the current
+  event-model schema.
 
 v1.14.1 (2025-05-21)
 ====================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
     "numpydoc",
     "opentelemetry-sdk",
     "ophyd",
-    "ophyd-async[ca];python_version>='3.10'",
+    "ophyd-async;python_version>='3.11'",
     "orjson",
     "packaging",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
     "numpydoc",
     "opentelemetry-sdk",
     "ophyd",
+    "ophyd-async[ca];python_version>='3.10'",
     "orjson",
     "packaging",
     "pandas",

--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -470,18 +470,11 @@ class RunBundler:
         where kwargs are passed through to ``obj.subscribe()``
         """
         obj = msg.obj
-        subscribable = False
-        try:
-            check_supports(obj, Subscribable)
-            subscribable = True
-        except AssertionError:
-            assert callable(getattr(obj, "subscribe", None)), (
-                "%s does not implement Subscribable protocol or adhere to ophyd subscription pattern." % obj
-            )
         if msg.args:
             raise ValueError("The 'monitor' Msg does not accept positional arguments.")
         kwargs = dict(msg.kwargs)
         name = kwargs.pop("name", short_uid("monitor"))
+        assert not kwargs, "If subscribe callback called with readings, kwargs are not supported."
         if obj in self._monitor_params:
             raise IllegalMessageSequence(f"A 'monitor' message was sent for {obj} which is already monitored")
 
@@ -490,21 +483,7 @@ class RunBundler:
         stream_bundle = await self._prepare_stream(name, {obj: self._current_stream_cache.describe_cache[obj]})
         compose_event = stream_bundle[1]
 
-        def emit_event(readings: dict[str, Reading] | None = None, *args, **kwargs):
-            if readings is not None:
-                # We were passed something we can use, but check no args or kwargs
-                assert not args and not kwargs, (
-                    "If subscribe callback called with readings, args and kwargs are not supported."
-                )
-            else:
-                # Ignore the inputs. Use this call as a signal to call read on the
-                # object, a crude way to be sure we get all the info we need.
-                readable_obj = check_supports(obj, Readable)  # type: ignore
-                readings = readable_obj.read()  # type: ignore
-                assert not inspect.isawaitable(readings), (
-                    f"{readable_obj} has async read() method and the callback "
-                    "passed to subscribe() was not called with Dict[str, Reading]"
-                )
+        def emit_event(readings: dict[str, Reading]):
             data, timestamps = _rearrange_into_parallel_dicts(readings)
             doc = compose_event(
                 data=data,
@@ -512,12 +491,29 @@ class RunBundler:
             )
             self.emit_sync(DocumentNames.event, doc)
 
-        self._monitor_params[obj] = emit_event, kwargs
-        # TODO: deprecate **kwargs when Ophyd.v2 is available
-        if subscribable:
-            obj.subscribe_reading(emit_event, **kwargs)
+        if isinstance(obj, Subscribable):
+            self._monitor_params[obj] = emit_event, kwargs
+            obj.subscribe_reading(emit_event)
+        elif callable(getattr(obj, "subscribe", None)) is not None:
+
+            def emit_event_readable(readings: Optional[dict[str, Reading]] = None, *args, **kwargs):
+                if readings is None:
+                    # Ignore the inputs. Use this call as a signal to call read on the
+                    # object, a crude way to be sure we get all the info we need.
+                    readable_obj = check_supports(obj, Readable)  # type: ignore
+                    readings = readable_obj.read()  # type: ignore
+                    assert not inspect.isawaitable(readings), (
+                        f"{readable_obj} has async read() method and the callback "
+                        "passed to subscribe() was not called with Dict[str, Reading]"
+                    )
+                emit_event(readings)
+
+            self._monitor_params[obj] = emit_event_readable, kwargs
+            obj.subscribe(emit_event_readable, **kwargs)
         else:
-            obj.subscribe(emit_event, **kwargs)
+            raise RuntimeError(  # must be a better error
+                "%s does not implement Subscribable protocol or adhere to ophyd subscription pattern." % obj
+            )
 
     def record_interruption(self, content):
         """

--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -511,7 +511,7 @@ class RunBundler:
                 emit_event_from_readings(readings)
 
             self._monitor_params[obj] = emit_event_for_subscribe, kwargs
-            obj.subscribe(emit_event_for_subscribe, **kwargs)
+            obj.subscribe(emit_event_for_subscribe)
         else:
             raise RuntimeError(
                 "%s does not implement Subscribable protocol or adhere to ophyd subscription pattern." % obj

--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -806,9 +806,9 @@ class RunBundler:
         def is_data_key(obj: Any) -> bool:
             return isinstance(obj, dict) and {"dtype", "shape", "source"}.issubset(frozenset(obj.keys()))
 
-        assert all(
-            not is_data_key(value) for value in describe_collect.values()
-        ), "Single nested data keys should be pre-declared"
+        assert all(not is_data_key(value) for value in describe_collect.values()), (
+            "Single nested data keys should be pre-declared"
+        )
 
         # Make sure you can't use identical data keys in multiple streams
         # Data structure is assumed to be dict[stream_name, dictionary of key -> data_key]
@@ -1119,9 +1119,9 @@ class RunBundler:
         # If a stream name was provided in the message, check the stream has been declared
         # If one was not provided, but a single stream has been declared, then use that stream.
         if message_stream_name:
-            assert (
-                message_stream_name in declared_stream_names
-            ), "If a message stream name is provided declare stream needs to be called first."
+            assert message_stream_name in declared_stream_names, (
+                "If a message stream name is provided declare stream needs to be called first."
+            )
             stream_name = message_stream_name
         elif declared_stream_names:
             assert len(frozenset(declared_stream_names)) == 1  # Allow duplicate declarations

--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -494,7 +494,7 @@ class RunBundler:
         if isinstance(obj, Subscribable):
             self._monitor_params[obj] = emit_event, kwargs
             obj.subscribe_reading(emit_event)
-        elif callable(getattr(obj, "subscribe", None)) is not None:
+        elif callable(getattr(obj, "subscribe", None)):
 
             def emit_event_readable(readings: Optional[dict[str, Reading]] = None, *args, **kwargs):
                 if readings is None:

--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -474,8 +474,6 @@ class RunBundler:
             raise ValueError("The 'monitor' Msg does not accept positional arguments.")
         kwargs = dict(msg.kwargs)
         name = kwargs.pop("name", short_uid("monitor"))
-        if kwargs:
-            raise RuntimeError("If subscribe callback called with readings, kwargs are not supported.")
         if obj in self._monitor_params:
             raise IllegalMessageSequence(f"A 'monitor' message was sent for {obj} which is already monitored")
 
@@ -497,21 +495,20 @@ class RunBundler:
             obj.subscribe_reading(emit_event_from_readings)
         elif callable(getattr(obj, "subscribe", None)):
 
-            def emit_event_for_subscribe(readings: Optional[dict[str, Reading]] = None, *args, **kwargs):
-                if readings is None:
-                    # Ignore the inputs. Use this call as a signal to call read on the
-                    # object, a crude way to be sure we get all the info we need.
-                    readable_obj = check_supports(obj, Readable)
-                    readings = readable_obj.read()
-                    if inspect.isawaitable(readings):
-                        raise RuntimeError(
-                            f"{readable_obj} has async read() method and the callback "
-                            "passed to subscribe() was not called with Dict[str, Reading]"
-                        )
+            def read_and_emit(*args, **kwargs):
+                # Ignore the inputs. Use this call as a signal to call read on the
+                # object, a crude way to be sure we get all the info we need.
+                readable_obj = check_supports(obj, Readable)
+                readings = readable_obj.read()
+                if inspect.isawaitable(readings):
+                    raise RuntimeError(
+                        f"{readable_obj} has async read() method and the callback "
+                        "passed to subscribe() was not called with Dict[str, Reading]"
+                    )
                 emit_event_from_readings(readings)
 
-            self._monitor_params[obj] = emit_event_for_subscribe, kwargs
-            obj.subscribe(emit_event_for_subscribe)
+            self._monitor_params[obj] = read_and_emit, kwargs
+            obj.subscribe(read_and_emit, **kwargs)
         else:
             raise RuntimeError(
                 "%s does not implement Subscribable protocol or adhere to ophyd subscription pattern." % obj

--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -469,7 +469,15 @@ class RunBundler:
 
         where kwargs are passed through to ``obj.subscribe()``
         """
-        obj = check_supports(msg.obj, Subscribable)
+        obj = msg.obj
+        subscribable = False
+        try:
+            check_supports(obj, Subscribable)
+            subscribable = True
+        except AssertionError:
+            assert callable(getattr(obj, "subscribe", None)), (
+                "%s does not implement Subscribable protocol or adhere to ophyd subscription pattern." % obj
+            )
         if msg.args:
             raise ValueError("The 'monitor' Msg does not accept positional arguments.")
         kwargs = dict(msg.kwargs)
@@ -506,7 +514,10 @@ class RunBundler:
 
         self._monitor_params[obj] = emit_event, kwargs
         # TODO: deprecate **kwargs when Ophyd.v2 is available
-        obj.subscribe(emit_event, **kwargs)
+        if subscribable:
+            obj.subscribe_reading(emit_event, **kwargs)
+        else:
+            obj.subscribe(emit_event, **kwargs)
 
     def record_interruption(self, content):
         """
@@ -547,7 +558,14 @@ class RunBundler:
 
             Msg('unmonitor', obj)
         """
-        obj = check_supports(msg.obj, Subscribable)
+        try:
+            obj = check_supports(msg.obj, Subscribable)
+        except AssertionError:
+            # sync ophyd doesn't implement full Subscribable protocol but has clear_sub
+            obj = msg.obj
+            assert callable(getattr(obj, "clear_sub", None)), (
+                "%s does not implement Subscribable protocol or adhere to ophyd subscription pattern." % obj
+            )
         if obj not in self._monitor_params:
             raise IllegalMessageSequence(f"Cannot 'unmonitor' {obj}; it is not being monitored.")
         cb, kwargs = self._monitor_params[obj]

--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -474,7 +474,8 @@ class RunBundler:
             raise ValueError("The 'monitor' Msg does not accept positional arguments.")
         kwargs = dict(msg.kwargs)
         name = kwargs.pop("name", short_uid("monitor"))
-        assert not kwargs, "If subscribe callback called with readings, kwargs are not supported."
+        if kwargs:
+            raise RuntimeError("If subscribe callback called with readings, kwargs are not supported.")
         if obj in self._monitor_params:
             raise IllegalMessageSequence(f"A 'monitor' message was sent for {obj} which is already monitored")
 
@@ -502,10 +503,11 @@ class RunBundler:
                     # object, a crude way to be sure we get all the info we need.
                     readable_obj = check_supports(obj, Readable)
                     readings = readable_obj.read()
-                    assert not inspect.isawaitable(readings), (
-                        f"{readable_obj} has async read() method and the callback "
-                        "passed to subscribe() was not called with Dict[str, Reading]"
-                    )
+                    if inspect.isawaitable(readings):
+                        raise RuntimeError(
+                            f"{readable_obj} has async read() method and the callback "
+                            "passed to subscribe() was not called with Dict[str, Reading]"
+                        )
                 emit_event(readings)
 
             self._monitor_params[obj] = emit_event_readable, kwargs

--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -556,12 +556,9 @@ class RunBundler:
 
             Msg('unmonitor', obj)
         """
-        try:
-            obj = check_supports(msg.obj, Subscribable)
-        except AssertionError:
-            # sync ophyd doesn't implement full Subscribable protocol but has clear_sub
-            obj = msg.obj
-            assert callable(getattr(obj, "clear_sub", None)), (
+        obj = msg.obj
+        if not callable(getattr(obj, "clear_sub", None)):
+            raise RuntimeError(
                 "%s does not implement Subscribable protocol or adhere to ophyd subscription pattern." % obj
             )
         if obj not in self._monitor_params:

--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -500,8 +500,8 @@ class RunBundler:
                 if readings is None:
                     # Ignore the inputs. Use this call as a signal to call read on the
                     # object, a crude way to be sure we get all the info we need.
-                    readable_obj = check_supports(obj, Readable)  # type: ignore
-                    readings = readable_obj.read()  # type: ignore
+                    readable_obj = check_supports(obj, Readable)
+                    readings = readable_obj.read()
                     assert not inspect.isawaitable(readings), (
                         f"{readable_obj} has async read() method and the callback "
                         "passed to subscribe() was not called with Dict[str, Reading]"

--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -490,26 +490,25 @@ class RunBundler:
             )
             self.emit_sync(DocumentNames.event, doc)
 
+        def emit_event_for_subscribe(*args, **kwargs):
+            # Ignore the inputs. Use this call as a signal to call read on the
+            # object, a crude way to be sure we get all the info we need.
+            readable_obj = check_supports(obj, Readable)
+            readings = readable_obj.read()
+            if inspect.isawaitable(readings):
+                raise RuntimeError(
+                    f"{readable_obj} has a subscribe() method rather than a "
+                    "subscribe_readings() method and an async read() method. "
+                    "If using ophyd-async, make sure you are using at least v0.13.5."
+                )
+            emit_event_from_readings(readings)
+
         if isinstance(obj, Subscribable):
             self._monitor_params[obj] = emit_event_from_readings, kwargs
             obj.subscribe_reading(emit_event_from_readings)
         elif callable(getattr(obj, "subscribe", None)):
-
-            def read_and_emit(*args, **kwargs):
-                # Ignore the inputs. Use this call as a signal to call read on the
-                # object, a crude way to be sure we get all the info we need.
-                readable_obj = check_supports(obj, Readable)
-                readings = readable_obj.read()
-                if inspect.isawaitable(readings):
-                    raise RuntimeError(
-                        f"{readable_obj} has a subscribe() method rather than a "
-                        "subscribe_readings() method and an async read() method. "
-                        "If using ophyd-async, make sure you are using at least v0.13.5."
-                    )
-                emit_event_from_readings(readings)
-
-            self._monitor_params[obj] = read_and_emit, kwargs
-            obj.subscribe(read_and_emit, **kwargs)
+            self._monitor_params[obj] = emit_event_for_subscribe, kwargs
+            obj.subscribe(emit_event_for_subscribe, **kwargs)
         else:
             raise RuntimeError(
                 "%s does not implement Subscribable protocol or adhere to ophyd subscription pattern." % obj

--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -484,7 +484,7 @@ class RunBundler:
         stream_bundle = await self._prepare_stream(name, {obj: self._current_stream_cache.describe_cache[obj]})
         compose_event = stream_bundle[1]
 
-        def emit_event(readings: dict[str, Reading]):
+        def emit_event_from_readings(readings: dict[str, Reading]):
             data, timestamps = _rearrange_into_parallel_dicts(readings)
             doc = compose_event(
                 data=data,
@@ -493,11 +493,11 @@ class RunBundler:
             self.emit_sync(DocumentNames.event, doc)
 
         if isinstance(obj, Subscribable):
-            self._monitor_params[obj] = emit_event, kwargs
-            obj.subscribe_reading(emit_event)
+            self._monitor_params[obj] = emit_event_from_readings, kwargs
+            obj.subscribe_reading(emit_event_from_readings)
         elif callable(getattr(obj, "subscribe", None)):
 
-            def emit_event_readable(readings: Optional[dict[str, Reading]] = None, *args, **kwargs):
+            def emit_event_for_subscribe(readings: Optional[dict[str, Reading]] = None, *args, **kwargs):
                 if readings is None:
                     # Ignore the inputs. Use this call as a signal to call read on the
                     # object, a crude way to be sure we get all the info we need.
@@ -508,10 +508,10 @@ class RunBundler:
                             f"{readable_obj} has async read() method and the callback "
                             "passed to subscribe() was not called with Dict[str, Reading]"
                         )
-                emit_event(readings)
+                emit_event_from_readings(readings)
 
-            self._monitor_params[obj] = emit_event_readable, kwargs
-            obj.subscribe(emit_event_readable, **kwargs)
+            self._monitor_params[obj] = emit_event_for_subscribe, kwargs
+            obj.subscribe(emit_event_for_subscribe, **kwargs)
         else:
             raise RuntimeError(
                 "%s does not implement Subscribable protocol or adhere to ophyd subscription pattern." % obj

--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -511,7 +511,7 @@ class RunBundler:
             self._monitor_params[obj] = emit_event_readable, kwargs
             obj.subscribe(emit_event_readable, **kwargs)
         else:
-            raise RuntimeError(  # must be a better error
+            raise RuntimeError(
                 "%s does not implement Subscribable protocol or adhere to ophyd subscription pattern." % obj
             )
 
@@ -806,9 +806,9 @@ class RunBundler:
         def is_data_key(obj: Any) -> bool:
             return isinstance(obj, dict) and {"dtype", "shape", "source"}.issubset(frozenset(obj.keys()))
 
-        assert all(not is_data_key(value) for value in describe_collect.values()), (
-            "Single nested data keys should be pre-declared"
-        )
+        assert all(
+            not is_data_key(value) for value in describe_collect.values()
+        ), "Single nested data keys should be pre-declared"
 
         # Make sure you can't use identical data keys in multiple streams
         # Data structure is assumed to be dict[stream_name, dictionary of key -> data_key]
@@ -1119,9 +1119,9 @@ class RunBundler:
         # If a stream name was provided in the message, check the stream has been declared
         # If one was not provided, but a single stream has been declared, then use that stream.
         if message_stream_name:
-            assert message_stream_name in declared_stream_names, (
-                "If a message stream name is provided declare stream needs to be called first."
-            )
+            assert (
+                message_stream_name in declared_stream_names
+            ), "If a message stream name is provided declare stream needs to be called first."
             stream_name = message_stream_name
         elif declared_stream_names:
             assert len(frozenset(declared_stream_names)) == 1  # Allow duplicate declarations

--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -502,8 +502,9 @@ class RunBundler:
                 readings = readable_obj.read()
                 if inspect.isawaitable(readings):
                     raise RuntimeError(
-                        f"{readable_obj} has async read() method and the callback "
-                        "passed to subscribe() was not called with Dict[str, Reading]"
+                        f"{readable_obj} has a subscribe() method rather than a "
+                        "subscribe_readings() method and an async read() method. "
+                        "If using ophyd-async, make sure you are using at least v0.13.5."
                     )
                 emit_event_from_readings(readings)
 

--- a/src/bluesky/protocols.py
+++ b/src/bluesky/protocols.py
@@ -473,17 +473,6 @@ class Subscribable(HasName, Protocol[T]):
         ...
 
     @abstractmethod
-    def subscribe_value(self, function: Callable[[T], None]) -> None:
-        """Subscribe to updates in value of a device.
-
-        When the device has a new value ready, it should call ``function`` with
-        that value.
-
-        Needed for :doc:`monitored <async>`.
-        """
-        ...
-
-    @abstractmethod
     def clear_sub(self, function: Callback[T]) -> None:
         """Remove a subscription."""
         ...

--- a/src/bluesky/protocols.py
+++ b/src/bluesky/protocols.py
@@ -462,11 +462,22 @@ Callback = Callable[[dict[str, Reading[T]]], None]
 @runtime_checkable
 class Subscribable(HasName, Protocol[T]):
     @abstractmethod
-    def subscribe(self, function: Callback[T]) -> None:
+    def subscribe_reading(self, function: Callback[T]) -> None:
         """Subscribe to updates in value of a device.
 
         When the device has a new value ready, it should call ``function``
         with something that looks like the output of ``read()``.
+
+        Needed for :doc:`monitored <async>`.
+        """
+        ...
+
+    @abstractmethod
+    def subscribe_value(self, function: Callable[[T], None]) -> None:
+        """Subscribe to updates in value of a device.
+
+        When the device has a new value ready, it should call ``function`` with
+        that value.
 
         Needed for :doc:`monitored <async>`.
         """

--- a/src/bluesky/tests/__init__.py
+++ b/src/bluesky/tests/__init__.py
@@ -6,17 +6,29 @@ import pytest
 # some module level globals.
 ophyd: ModuleType | None
 ophyd = None
-reason = ""
+ophyd_reason = ""
+ophyd_async: Optional[ModuleType]
+ophyd_async = None
+ophyd_async_reason = ""
 
 try:
     import ophyd  # type: ignore
 except ImportError as ie:
     # pytestmark = pytest.mark.skip
     ophyd = None
-    reason = str(ie)
+    ophyd_reason = str(ie)
 
 # define a skip condition based on if ophyd is available or not
-requires_ophyd = pytest.mark.skipif(ophyd is None, reason=reason)
+requires_ophyd = pytest.mark.skipif(ophyd is None, reason=ophyd_reason)
+
+try:  # type: ignore
+    import ophyd_async
+except ImportError as ie:
+    # pytestmark = pytest.mark.skip
+    ophyd_async = None
+    ophyd_async_reason = str(ie)
+
+requires_ophyd_async = pytest.mark.skipif(ophyd_async is None, reason=ophyd_async_reason)
 
 uses_os_kill_sigint = pytest.mark.skipif(
     os.name == "nt", reason="os.kill on windows ignores signal argument and kills the entire process."

--- a/src/bluesky/tests/__init__.py
+++ b/src/bluesky/tests/__init__.py
@@ -21,8 +21,8 @@ except ImportError as ie:
 # define a skip condition based on if ophyd is available or not
 requires_ophyd = pytest.mark.skipif(ophyd is None, reason=ophyd_reason)
 
-try:  # type: ignore
-    import ophyd_async
+try:
+    import ophyd_async  # type: ignore
 except ImportError as ie:
     # pytestmark = pytest.mark.skip
     ophyd_async = None

--- a/src/bluesky/tests/__init__.py
+++ b/src/bluesky/tests/__init__.py
@@ -7,7 +7,7 @@ import pytest
 ophyd: ModuleType | None
 ophyd = None
 ophyd_reason = ""
-ophyd_async: Optional[ModuleType]
+ophyd_async: ModuleType | None
 ophyd_async = None
 ophyd_async_reason = ""
 

--- a/src/bluesky/tests/test_devices.py
+++ b/src/bluesky/tests/test_devices.py
@@ -1,5 +1,5 @@
 import itertools
-from time import monotonic, time
+from time import time
 from unittest.mock import ANY
 
 import pytest
@@ -120,7 +120,6 @@ def test_monitor(RE, ophyd):
     }
 
 
-@pytest.mark.skip("ophyd-async must be updated to implement Subscribable protocol")
 @requires_ophyd_async
 def test_monitor_async(RE):
     docs = []
@@ -142,7 +141,7 @@ def test_monitor_async(RE):
         "descriptor": ANY,
         "seq_num": 1,
         "time": pytest.approx(time(), rel=0.1),
-        "timestamps": {"soft_signal": pytest.approx(monotonic(), rel=0.1)},
+        "timestamps": {"soft_signal": pytest.approx(time(), rel=0.1)},
         "filled": ANY,
         "uid": ANY,
     }

--- a/src/bluesky/tests/test_devices.py
+++ b/src/bluesky/tests/test_devices.py
@@ -120,6 +120,7 @@ def test_monitor(RE, ophyd):
     }
 
 
+@pytest.mark.skip("ophyd-async must be updated to implement Subscribable protocol")
 @requires_ophyd_async
 def test_monitor_async(RE):
     docs = []

--- a/src/bluesky/tests/test_devices.py
+++ b/src/bluesky/tests/test_devices.py
@@ -1,5 +1,5 @@
 import itertools
-from time import time
+from time import monotonic, time
 from unittest.mock import ANY
 
 import pytest
@@ -8,7 +8,7 @@ from bluesky import Msg, RunEngineInterrupted
 from bluesky.plan_stubs import declare_stream, trigger_and_read
 from bluesky.preprocessors import run_decorator
 from bluesky.protocols import Callback, Descriptor, Reading
-from bluesky.tests import ophyd, requires_ophyd
+from bluesky.tests import ophyd, ophyd_async, requires_ophyd, requires_ophyd_async
 from bluesky.utils import ancestry, separate_devices, share_ancestor
 
 from .utils import DocCollector
@@ -28,6 +28,10 @@ if ophyd:
     class DCM(Device):
         th = Cpt(Signal, value=0)
         x = Cpt(Signal, value=0)
+
+
+if ophyd_async:
+    from ophyd_async.core import soft_signal_rw
 
 
 class SigNew:
@@ -111,6 +115,33 @@ def test_monitor(RE, ophyd):
         "seq_num": 1,
         "time": pytest.approx(time(), rel=0.1),
         "timestamps": {"a_s1": pytest.approx(time(), rel=0.1)},
+        "filled": ANY,
+        "uid": ANY,
+    }
+
+
+@requires_ophyd_async
+def test_monitor_async(RE):
+    docs = []
+
+    def collect(name, doc):
+        docs.append(doc)
+
+    sig = soft_signal_rw(float, 0.0, "soft_signal")
+
+    def plan():
+        yield Msg("open_run")
+        yield Msg("monitor", sig)
+        yield Msg("close_run")
+
+    RE(plan(), collect)
+    assert len(docs) == 4
+    assert docs[2] == {
+        "data": {"soft_signal": 0.0},
+        "descriptor": ANY,
+        "seq_num": 1,
+        "time": pytest.approx(time(), rel=0.1),
+        "timestamps": {"soft_signal": pytest.approx(monotonic(), rel=0.1)},
         "filled": ANY,
         "uid": ANY,
     }

--- a/src/bluesky/tests/test_devices.py
+++ b/src/bluesky/tests/test_devices.py
@@ -45,7 +45,7 @@ class SigNew:
     def describe(self) -> dict[str, Descriptor]:
         return {self.name: dict(source="", dtype="number", shape=[])}  # noqa: C408
 
-    def subscribe(self, function: Callback) -> None:
+    def subscribe_reading(self, function: Callback) -> None:
         self._callbacks.append(function)
 
     def clear_sub(self, function: Callback) -> None:

--- a/src/bluesky/tests/test_protocols.py
+++ b/src/bluesky/tests/test_protocols.py
@@ -54,16 +54,6 @@ def test_pausable():
     assert isinstance(sim.det1, bs_protocols.Pausable)
 
 
-@pytest.mark.xfail(
-    reason="Subscribable Protocol was not written to match ophyd's implementation. "
-    "Future ophyd will implement new Protocol"
-)
-def test_subscribable():
-    assert isinstance(sim.det1, bs_protocols.Subscribable)
-    assert isinstance(sim.motor1, bs_protocols.Subscribable)
-    assert not isinstance(sim.flyer1, bs_protocols.Subscribable)
-
-
 def test_checkable():
     assert isinstance(sim.motor1, bs_protocols.Checkable)
 

--- a/src/bluesky/tests/test_protocols.py
+++ b/src/bluesky/tests/test_protocols.py
@@ -54,7 +54,10 @@ def test_pausable():
     assert isinstance(sim.det1, bs_protocols.Pausable)
 
 
-@pytest.mark.skip("ophyd signals do not properly implement Subscribable protocol")
+@pytest.mark.xfail(
+    reason="Subscribable Protocol was not written to match ophyd's implementation. "
+    "Future ophyd will implement new Protocol"
+)
 def test_subscribable():
     assert isinstance(sim.det1, bs_protocols.Subscribable)
     assert isinstance(sim.motor1, bs_protocols.Subscribable)

--- a/src/bluesky/tests/test_protocols.py
+++ b/src/bluesky/tests/test_protocols.py
@@ -54,6 +54,7 @@ def test_pausable():
     assert isinstance(sim.det1, bs_protocols.Pausable)
 
 
+@pytest.mark.skip("ophyd signals do not properly implement Subscribable protocol")
 def test_subscribable():
     assert isinstance(sim.det1, bs_protocols.Subscribable)
     assert isinstance(sim.motor1, bs_protocols.Subscribable)


### PR DESCRIPTION
Closes https://github.com/bluesky/bluesky/issues/1915, prerequisite for https://github.com/bluesky/bluesky/issues/1789

ophyd signals explicitly fail to implement Subscribable now (previously, signature on `subscribe` method was wrong, but still passed an `isinstance` check)
monitor updated to work with Subscribable, and ophyd signals which implement `subscribe`.

Also adds ophyd-async as an optional dev dependency, though the test is currently skipped.

ophyd-async will need updating to pin to a released bluesky, then to be updated to implement the new Subscribable protocol (rename subscribe to `subscibe_reading`, implement `subscribe_value` where necessary) after this is merged/released

dodal doesn't seem to require any changes to its codebase but may also need to be pinned to a release of bluesky and ophyd-async until all those PRs are through. 
