### PR TITLE
Remove Struct and StructMeta

### DIFF
--- a/docs/api_changes.rst
+++ b/docs/api_changes.rst
@@ -91,6 +91,7 @@ Changed
 -------
 
 - RunEngine now supports both sync and async functions as a `scan_id_source`
+- Unused Struct and StructMeta base and metaclass removed.
 
 Fixed
 -----

--- a/docs/api_changes.rst
+++ b/docs/api_changes.rst
@@ -2,6 +2,13 @@
  Release History
 =================
 
+Unreleased
+==========
+
+Changed
+-------
+- Unused Struct and StructMeta base and metaclass removed.
+
 v1.15.1 (2026-05-05)
 ====================
 
@@ -91,7 +98,6 @@ Changed
 -------
 
 - RunEngine now supports both sync and async functions as a `scan_id_source`
-- Unused Struct and StructMeta base and metaclass removed.
 
 Fixed
 -----

--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -19,7 +19,6 @@ from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, G
 from collections.abc import Iterable as TypingIterable
 from enum import Enum
 from functools import partial, reduce, wraps
-from inspect import Parameter, Signature
 from typing import (
     Any,
     TypeAlias,
@@ -623,43 +622,6 @@ class _BoundMethodProxy:
 
     def __hash__(self):
         return self._hash
-
-
-# The following two code blocks are adapted from David Beazley's
-# 'Python 3 Metaprogramming' https://www.youtube.com/watch?v=sPiWg5jSoZI
-
-
-class StructMeta(type):
-    def __new__(cls, name, bases, clsdict):
-        clsobj = super().__new__(cls, name, bases, clsdict)
-        args_params = [Parameter(name, Parameter.POSITIONAL_OR_KEYWORD) for name in clsobj._fields]
-        kwargs_params = [Parameter(name, Parameter.KEYWORD_ONLY, default=None) for name in ["md"]]
-        sig = Signature(args_params + kwargs_params)
-        clsobj.__signature__ = sig
-        return clsobj
-
-
-class Struct(metaclass=StructMeta):
-    "The _fields of any subclass become its attritubes and __init__ args."
-
-    _fields: list[str] = []
-
-    def __init__(self, *args, **kwargs):
-        # Now bind default values of optional arguments.
-        # If it seems like there should be a cleaner way to do this, see
-        # http://bugs.python.org/msg221104
-        bound = self.__signature__.bind(*args, **kwargs)
-        for name, param in self.__signature__.parameters.items():
-            if name not in bound.arguments and param.default is not inspect._empty:
-                bound.arguments[name] = param.default
-        for name, val in bound.arguments.items():
-            setattr(self, name, val)
-        self.flyers = []
-
-    def set(self, **kwargs):
-        "Update attributes as keyword arguments."
-        for attr, val in kwargs.items():
-            setattr(self, attr, val)
 
 
 SUBS_NAMES = ["all", "start", "stop", "event", "descriptor"]


### PR DESCRIPTION
It looks like these two were left from previous implementations and are no longer used or referenced from anywhere in the project.

Noticed it was unused while trying to figure out what was going on with the signature handling in the `__call__` PR.