### PR TITLE
FIX: do not re-order the objects when creating implicit descriptors

### DIFF
--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -559,7 +559,8 @@ class RunBundler:
 
         # we do not have the descriptor cached, make it
         if descriptor_doc is None or d_objs is None:
-            for obj in objs_read:
+            # use the dequeue not the set to preserve order
+            for obj in self._objs_read:
                 await self._ensure_cached(obj, collect=isinstance(obj, Collectable))
                 objs_dks[obj] = self._describe_cache[obj]
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Do not randomize object order when creating implicit descriptors

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

closes #1930 , alternative to #1931 .


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added unit test


<!--
## Screenshots (if appropriate):
-->
