### PR TITLE
Fix a Regression Related External Data Present in Multiple Streams

### DIFF
--- a/src/bluesky/callbacks/tiled_writer.py
+++ b/src/bluesky/callbacks/tiled_writer.py
@@ -387,7 +387,8 @@ class RunNormalizer(CallbackBase):
         self._int_keys.update({k for k, v in data_keys.items() if "external" not in v.keys()})
         self._ext_keys.update({k for k, v in data_keys.items() if "external" in v.keys()})
         for key in self._ext_keys:
-            data_keys[key]["external"] = data_keys[key].pop("external", "")  # Make sure the value is not None
+            if key in data_keys:
+                data_keys[key]["external"] = data_keys[key].pop("external", "")  # Make sure the value is not None
 
         # Keep a reference to the descriptor name (stream) by its uid
         self._desc_name_by_uid[doc["uid"]] = doc["name"]

--- a/src/bluesky/tests/examples/external_assets.json
+++ b/src/bluesky/tests/examples/external_assets.json
@@ -8,7 +8,8 @@
             "plan_type": "generator",
             "plan_name": "count",
             "detectors": [
-                "det"
+                "det-obj1",
+                "det-obj2"
             ]
         }
     },
@@ -16,7 +17,7 @@
         "name": "descriptor",
         "doc": {
             "configuration": {
-                "det": {
+                "det-obj1": {
                     "data": {},
                     "timestamps": {},
                     "data_keys": {}
@@ -31,7 +32,7 @@
                         1
                     ],
                     "external": "STREAM:",
-                    "object_name": "det"
+                    "object_name": "det-obj1"
                 },
                 "det-key2": {
                     "source": "file",
@@ -43,32 +44,19 @@
                         17
                     ],
                     "external": "STREAM:",
-                    "object_name": "det"
-                },
-                "det-key3": {
-                    "source": "file",
-                    "dtype": "array",
-                    "dtype_numpy": "|u1",
-                    "shape": [
-                        1,
-                        10,
-                        15
-                    ],
-                    "external": "STREAM:",
-                    "object_name": "det"
+                    "object_name": "det-obj1"
                 }
             },
             "name": "primary",
             "object_keys": {
-                "det": [
+                "det-obj1": [
                     "det-key1",
-                    "det-key2",
-                    "det-key3"
+                    "det-key2"
                 ]
             },
             "run_start": "{{ uuid }}-9724b2201fe7",
             "time": 1745500521.79327,
-            "uid": "{{ uuid }}-8c00740d9771",
+            "uid": "{{ uuid }}-descriptor01",
             "hints": {}
         }
     },
@@ -92,7 +80,7 @@
         "name": "stream_datum",
         "doc": {
             "stream_resource": "det-key1-uid",
-            "descriptor": "{{ uuid }}-8c00740d9771",
+            "descriptor": "{{ uuid }}-descriptor01",
             "uid": "det-key1-uid/0",
             "indices": {
                 "start": 0,
@@ -126,7 +114,7 @@
         "name": "stream_datum",
         "doc": {
             "stream_resource": "det-key2-uid",
-            "descriptor": "{{ uuid }}-8c00740d9771",
+            "descriptor": "{{ uuid }}-descriptor01",
             "uid": "det-key2-uid/0",
             "indices": {
                 "start": 0,
@@ -136,6 +124,42 @@
                 "start": 1,
                 "stop": 2
             }
+        }
+    },
+    {
+        "name": "descriptor",
+        "doc": {
+            "configuration": {
+                "det-obj2": {
+                    "data": {},
+                    "timestamps": {},
+                    "data_keys": {}
+                }
+            },
+            "data_keys": {
+                "det-key3": {
+                    "source": "file",
+                    "dtype": "array",
+                    "dtype_numpy": "|u1",
+                    "shape": [
+                        1,
+                        10,
+                        15
+                    ],
+                    "external": "STREAM:",
+                    "object_name": "det-obj2"
+                }
+            },
+            "name": "secondary",
+            "object_keys": {
+                "det-obj2": [
+                    "det-key3"
+                ]
+            },
+            "run_start": "{{ uuid }}-9724b2201fe7",
+            "time": 1745500521.79337,
+            "uid": "{{ uuid }}-descriptor02",
+            "hints": {}
         }
     },
     {
@@ -161,7 +185,7 @@
         "name": "stream_datum",
         "doc": {
             "stream_resource": "det-key3-uid",
-            "descriptor": "{{ uuid }}-8c00740d9771",
+            "descriptor": "{{ uuid }}-descriptor02",
             "uid": "det-key3-uid/0",
             "indices": {
                 "start": 0,
@@ -182,14 +206,14 @@
             "timestamps": {},
             "seq_num": 1,
             "filled": {},
-            "descriptor": "{{ uuid }}-8c00740d9771"
+            "descriptor": "{{ uuid }}-descriptor01"
         }
     },
     {
         "name": "stream_datum",
         "doc": {
             "stream_resource": "det-key1-uid",
-            "descriptor": "{{ uuid }}-8c00740d9771",
+            "descriptor": "{{ uuid }}-descriptor01",
             "uid": "det-key1-uid/1",
             "indices": {
                 "start": 1,
@@ -205,7 +229,7 @@
         "name": "stream_datum",
         "doc": {
             "stream_resource": "det-key2-uid",
-            "descriptor": "{{ uuid }}-8c00740d9771",
+            "descriptor": "{{ uuid }}-descriptor01",
             "uid": "det-key2-uid/1",
             "indices": {
                 "start": 1,
@@ -221,7 +245,7 @@
         "name": "stream_datum",
         "doc": {
             "stream_resource": "det-key3-uid",
-            "descriptor": "{{ uuid }}-8c00740d9771",
+            "descriptor": "{{ uuid }}-descriptor02",
             "uid": "det-key3-uid/1",
             "indices": {
                 "start": 1,
@@ -242,14 +266,14 @@
             "timestamps": {},
             "seq_num": 2,
             "filled": {},
-            "descriptor": "{{ uuid }}-8c00740d9771"
+            "descriptor": "{{ uuid }}-descriptor01"
         }
     },
     {
         "name": "stream_datum",
         "doc": {
             "stream_resource": "det-key1-uid",
-            "descriptor": "{{ uuid }}-8c00740d9771",
+            "descriptor": "{{ uuid }}-descriptor01",
             "uid": "det-key1-uid/2",
             "indices": {
                 "start": 2,
@@ -265,7 +289,7 @@
         "name": "stream_datum",
         "doc": {
             "stream_resource": "det-key2-uid",
-            "descriptor": "{{ uuid }}-8c00740d9771",
+            "descriptor": "{{ uuid }}-descriptor01",
             "uid": "det-key2-uid/2",
             "indices": {
                 "start": 2,
@@ -281,7 +305,7 @@
         "name": "stream_datum",
         "doc": {
             "stream_resource": "det-key3-uid",
-            "descriptor": "{{ uuid }}-8c00740d9771",
+            "descriptor": "{{ uuid }}-descriptor02",
             "uid": "det-key3-uid/2",
             "indices": {
                 "start": 2,
@@ -302,7 +326,7 @@
             "timestamps": {},
             "seq_num": 3,
             "filled": {},
-            "descriptor": "{{ uuid }}-8c00740d9771"
+            "descriptor": "{{ uuid }}-descriptor01"
         }
     },
     {
@@ -314,7 +338,8 @@
             "exit_status": "success",
             "reason": "",
             "num_events": {
-                "primary": 3
+                "primary": 3,
+                "secondary": 0
             }
         }
     }


### PR DESCRIPTION
Fix a Regression to Allow Multiple Streams with External Data

## Description
This fixes a bug in `TiledWriter` that prevented a BlueskyRun to include multiple streams (descriptors) with distinct external data keys. An existence check has been added before accessing any of those keys in a descriptor document.

## Motivation and Context
Found while running tests in databroker.

## How Has This Been Tested?
Example documents used for testing expanded to cover this case.

