### PR TITLE
Replace Composite Clients with Containers

### DIFF
--- a/docs/tiled-writer.rst
+++ b/docs/tiled-writer.rst
@@ -12,9 +12,9 @@ The `TiledWriter` callback is designed specifically for converting Bluesky run d
 
 It implicitly distinguishes between "internal" and "external" data. The internal data are associated with the `Event` documents generated during a run; typically this represents scalar measurements from sensors, motor positions, etc, which is stored in a form of a table with columns corresponding to different data keys and each row representing a measurement at a single timestamp.
 
-On the other hand, the external data are written by detectors directly on disk and usually take the form of images or multidimensional arrays. The references to the external files are provided in `StreamRsource` (`Resource` in legacy implementations) documents, which register the corresponding array-like `DataSources` in Tiled. `StreamDatum` (or `Datum`) documents are processed via the mechanism of `Consolidators` and determine the correspondence between the indexing within these external arrays and the physically-meaningful sequence of timestamps.
+On the other hand, the external data are written by detectors directly on disk and usually take the form of images or multidimensional arrays. The references to the external files are provided in `StreamResource` (`Resource` in legacy implementations) documents, which register the corresponding array-like `DataSources` in Tiled. `StreamDatum` (or `Datum`) documents are processed via the mechanism of `Consolidators` and determine the correspondence between the indexing within these external arrays and the physically-meaningful sequence of timestamps.
 
-The time dimension (or the sequence of measurements) is typically shared between the internal and external data, which in Tiled is enforced by writing all data from the same Bluesky stream into a specialized `Composite` container (node in the Tiled catalog). The metadata on each stream node contains the specifications for the related data keys and the relevant configuration parameters supplied in the `EventDescriptor` document.
+The time dimension (that is, the sequence of measurements) is usually shared between internal and external data. Tiled handles this by writing all data from the same Bluesky stream into a container with a dedicated `"composite"` spec, which tells the Tiled client how the data are aligned. Each stream node's metadata includes the specifications for the related data keys as well as the configuration parameters provided in the `EventDescriptor` document.
 
 Finally, nodes for multiple streams are grouped together and placed into a container for the entire run; its metadata contains the `Start` and `Stop` documents. While the structure of the `streams` container is fixed, the parent Run allows for optional user-controlled namespaces within `views` and `aux` containers. The Run container created by TiledWriter is designated with the `BlueskyRun` version `3.0` spec to enable its back-compatibility with legacy code via bluesky-tiled-plugins.
 
@@ -25,17 +25,17 @@ An example of the Tiled catalog structure for a Bluesky run might look like this
     BlueskyRun_v3 <Container>
     │
     ├─ streams <Container>
-    │      ├─ baseline <Composite>
+    │      ├─ baseline <Container ("composite")>
     │      │       ├─ internal <Table>   -- written by Tiled
     │      │       ├─ image_1 <Array>    -- external data from files
     │      │       │      ...
     │      │       └─ image_n <Array>
-    │      ├─ primary <Composite>
+    │      ├─ primary <Container ("composite")>
     │      │       ├─ internal <Table>   -- written by Tiled
     │      │       ├─ image_1 <Array>    -- external data from files
     │      │       │      ...
     │      │       └─ image_n <Array>
-    │      └─ third_stream <Composite>
+    │      └─ third_stream <Container ("composite")>
     ├─ views <Container>    -- optional
     └─ aux <Container>      -- optional
 

--- a/src/bluesky/callbacks/tiled_writer.py
+++ b/src/bluesky/callbacks/tiled_writer.py
@@ -31,7 +31,6 @@ from event_model.documents.event_descriptor import DataKey
 from event_model.documents.stream_datum import StreamRange
 from tiled.client import from_profile, from_uri
 from tiled.client.base import BaseClient
-from tiled.client.composite import Composite
 from tiled.client.container import Container
 from tiled.client.dataframe import DataFrameClient
 from tiled.client.utils import handle_error
@@ -513,7 +512,7 @@ class _RunWriter(CallbackBase):
     def __init__(self, client: BaseClient, batch_size: int = BATCH_SIZE):
         self.client = client
         self.root_node: Union[None, Container] = None
-        self._desc_nodes: dict[str, Composite] = {}  # references to the descriptor nodes by their uid's and names
+        self._desc_nodes: dict[str, Container] = {}  # references to the descriptor nodes by their uid's and names
         self._sres_nodes: dict[str, BaseClient] = {}
         self._internal_tables: dict[str, DataFrameClient] = {}  # references to the internal tables by desc_names
         self._stream_resource_cache: dict[str, StreamResource] = {}
@@ -524,7 +523,7 @@ class _RunWriter(CallbackBase):
         self.data_keys: dict[str, DataKey] = {}
         self.access_tags = None
 
-    def _write_internal_data(self, data_cache: list[dict[str, Any]], desc_node: Composite):
+    def _write_internal_data(self, data_cache: list[dict[str, Any]], desc_node: Container):
         """Write the internal data table to Tiled and clear the cache."""
 
         desc_name = desc_node.item["id"]  # Name of the descriptor (stream)
@@ -610,13 +609,13 @@ class _RunWriter(CallbackBase):
         desc_name = doc["name"]  # Name of the descriptor/stream
         self.data_keys.update(doc.get("data_keys", {}))
 
-        # Create a new Composite node for the stream if it does not exist
+        # Create a new Container with "composite" spec for the stream if it does not exist
         if desc_name not in self._desc_nodes.keys():
             metadata = {k: v for k, v in doc.items() if k not in {"name", "object_keys", "run_start"}}
-            desc_node = self._streams_node.create_composite(
+            desc_node = self._streams_node.create_container(
                 key=desc_name,
                 metadata=truncate_json_overflow(metadata),
-                specs=[Spec("BlueskyEventStream", version="3.0")],
+                specs=[Spec("BlueskyEventStream", version="3.0"), Spec("composite")],
                 access_tags=self.access_tags,
             )
         else:


### PR DESCRIPTION
This PR reflects [the changes](https://github.com/bluesky/tiled/pull/1093) in Tiled: the `Composite` structure family has been demoted to a `"composite"` spec, and the corresponding client has been refactored accordingly.

## Description
References to `Composite` replaced with `Container` + `"composite"` spec in the `TiledWriter` callback.

## Motivation and Context
See [Issue](https://github.com/bluesky/tiled/issues/1081) in Tiled.

## How Has This Been Tested?

Existing tests are sufficient.
