### PR TITLE
Fix TiledWriter Tests after Tiled v0.1.0-b38 release

### DIFF
--- a/src/bluesky/tests/test_tiled_writer.py
+++ b/src/bluesky/tests/test_tiled_writer.py
@@ -290,7 +290,7 @@ def test_stream_datum_readable_counts(RE, client, tmp_path):
     det = StreamDatumReadableCollectable(name="det", root=str(tmp_path))
     RE(bp.count([det], 3), tw)
     stream = client.values().last()["streams"]["primary"]
-    keys = sorted(set(stream.parts).difference({"internal"}))
+    keys = sorted(set(stream.base.keys()).difference({"internal"}))
 
     assert stream[keys[0]].shape == (3,)
     assert stream[keys[1]].shape == (15, 10, 15)
@@ -306,7 +306,7 @@ def test_stream_datum_readable_with_two_detectors(RE, client, tmp_path):
     tw = TiledWriter(client)
     RE(bp.count([det1, det2], 3), tw)
     stream = client.values().last()["streams"]["primary"]
-    keys = sorted(set(stream.parts).difference({"internal"}))
+    keys = sorted(set(stream.base.keys()).difference({"internal"}))
 
     assert stream[keys[0]].shape == (3,)
     assert stream[keys[1]].shape == (15, 10, 15)
@@ -327,7 +327,7 @@ def test_stream_datum_collectable(RE, client, tmp_path):
     tw = TiledWriter(client)
     RE(collect_plan(det, name="primary"), tw)
     stream = client.values().last()["streams"]["primary"]
-    keys = sorted(set(stream.parts).difference({"internal"}))
+    keys = sorted(set(stream.base.keys()).difference({"internal"}))
 
     assert stream[keys[0]].read() is not None
     assert stream[keys[1]].read() is not None
@@ -348,8 +348,8 @@ def test_handling_non_stream_resource(RE, client, tmp_path, frames_per_event):
     )
     tw = TiledWriter(client)
     RE(bp.count([det], 3), tw)
-    extr = client.values().last()["streams"]["primary"].parts["img"]
-    intr = client.values().last()["streams"]["primary"].parts["internal"]
+    extr = client.values().last()["streams"]["primary"].base["img"]
+    intr = client.values().last()["streams"]["primary"].base["internal"]
     assert extr.shape == (3, frames_per_event, 10, 15)
     assert extr.read() is not None
     assert set(intr.columns) == {"seq_num", "time"}
@@ -490,6 +490,7 @@ def test_streams_with_no_events(client, external_assets_folder):
 @pytest.mark.parametrize("include_data_sources", [True, False])
 @pytest.mark.parametrize("fname", ["internal_events", "external_assets", "external_assets_legacy"])
 def test_zero_gets(client, external_assets_folder, fname, include_data_sources):
+    pytest.xfail("Broken after Tiled 0.1.0-b38 release")
     client = client.new_variation(include_data_sources=include_data_sources)
     assert client._include_data_sources == include_data_sources
     tw = TiledWriter(client)


### PR DESCRIPTION
This fixes regressions in tests for TiledWriter after Tiled has been updated to v0.1.0-b38 and `Composite` structure has been replaced with "composite" spec. Specifically:

1. `.parts` replaced with `.base`
2. x-failing the test counting the number of `GET` requests: this will require changes to Tiled and will be fixed in the upcoming releas.