### PR TITLE
Bring Back Tests for TiledWriter

### DIFF
--- a/src/bluesky/callbacks/tiled_writer.py
+++ b/src/bluesky/callbacks/tiled_writer.py
@@ -610,6 +610,8 @@ class _RunWriter(CallbackBase):
         self.data_keys.update(doc.get("data_keys", {}))
 
         # Create a new Container with "composite" spec for the stream if it does not exist
+        # Since the data_keys are guaranteed to be unique, we don't need to perform client-side validation of the
+        # "composite" spec constraints and can use the `.base` (Container) client directly.
         if desc_name not in self._desc_nodes.keys():
             metadata = {k: v for k, v in doc.items() if k not in {"name", "object_keys", "run_start"}}
             desc_node = self._streams_node.create_container(
@@ -617,7 +619,7 @@ class _RunWriter(CallbackBase):
                 metadata=truncate_json_overflow(metadata),
                 specs=[Spec("BlueskyEventStream", version="3.0"), Spec("composite")],
                 access_tags=self.access_tags,
-            )
+            ).base
         else:
             # Rare Case: This new descriptor likely updates stream configs mid-experiment
             # We assume tha the full descriptor has been already received, so we don't need to store everything

--- a/src/bluesky/tests/test_tiled_writer.py
+++ b/src/bluesky/tests/test_tiled_writer.py
@@ -490,7 +490,6 @@ def test_streams_with_no_events(client, external_assets_folder):
 @pytest.mark.parametrize("include_data_sources", [True, False])
 @pytest.mark.parametrize("fname", ["internal_events", "external_assets", "external_assets_legacy"])
 def test_zero_gets(client, external_assets_folder, fname, include_data_sources):
-    pytest.xfail("Broken after Tiled 0.1.0-b38 release")
     client = client.new_variation(include_data_sources=include_data_sources)
     assert client._include_data_sources == include_data_sources
     tw = TiledWriter(client)


### PR DESCRIPTION
This brings back tests for TiledWriter to check that it doesn't send unnecessary GET requests; this test has been x-failed in #1947. This PR makes TW bypass the usual client-side checks when writing to a composite-spec'ed node because they are unnecessary (the Bluesky run that is being written satisfy the composite constaraints by definition).

This will pass CI once [Tiled PR](https://github.com/bluesky/tiled/pull/1169) is merged and released.