### PR TITLE
BUG: RunEngine._wait fails when waiting for a status times out

### DIFF
--- a/src/bluesky/run_engine.py
+++ b/src/bluesky/run_engine.py
@@ -2334,7 +2334,7 @@ class RunEngine:
                 await status_task
             except WaitForTimeoutError:
                 # We might wait to call wait again, so put the futures and status objects back in
-                self._groups[group] = futs
+                self._groups[group].update(futs)
                 self._status_objs[group] = status_objs
                 if error_on_timeout:
                     raise


### PR DESCRIPTION
I have encountered an error when I used the wait plan stub with a timeout that actually triggered. This is a simple bug.

## Description
In the RunEngine._wait method, the following line is incorrect
```python
# We might wait to call wait again, so put the futures and status objects back in
self._groups[group] = futs
```
because other parts of the same code relies on `self._groups[group]` being a `set` (e.g. in `self._groups[group].add(p_event.wait)`). This causes an Attribute error.

I fixed by changing the above line to 
```python
self._groups[group].update(futs)
```

Thanks! Big fan of the project so far. Really useful.