### PR TITLE
Fix PySide6 matplotlib backend TypeError

### DIFF
--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -1748,7 +1748,7 @@ class DefaultDuringTask(DuringTask):
 
                 app = QtWidgets.QApplication.instance()
                 if app is None:
-                    _qapp = app = QtWidgets.QApplication([b"bluesky"])
+                    _qapp = app = QtWidgets.QApplication(["bluesky"])
                 assert app is not None
                 event_loop = QtCore.QEventLoop()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Detailed description of the bug is in #1956 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Open issue is here #1956 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by reproducing the steps in the issue but with a local install of bluesky.

`pixi.toml` looks like this for PySide6 test:
```
[workspace]
authors = ["thomashopkins32 <thopkins1@bnl.gov>"]
channels = ["conda-forge"]
name = "bluesky-testing"
platforms = ["linux-64"]
version = "0.1.0"

[tasks]

[dependencies]
ophyd = ">=1.11.0,<2"
matplotlib = "==3.10.6"

[pypi-dependencies]
bluesky = { path = "../../public-repos/bluesky", editable = true }
```

`pixi.toml` looks like this for PyQt5 test:
```
[workspace]
authors = ["thomashopkins32 <thopkins1@bnl.gov>"]
channels = ["conda-forge"]
name = "bluesky-testing"
platforms = ["linux-64"]
version = "0.1.0"

[tasks]

[dependencies]
matplotlib-base = "==3.10.6"
ophyd = ">=1.11.0,<2"
pyqt = ">=5.15.11,<6"

[pypi-dependencies]
bluesky = { path = "../../public-repos/bluesky", editable = true }
```

Both environments ran the following Python script without error:
```python
from bluesky import RunEngine
from bluesky.plans import scan
from bluesky.callbacks import LivePlot
from ophyd.sim import SynAxis

RE = RunEngine()
RE.subscribe(LivePlot("motor"))
motor = SynAxis(name="motor")
RE(scan([motor], motor, 0, 10, 1))
```

<!--
## Screenshots (if appropriate):
-->
