### PR TITLE
Add event_model to `RE.md` versions dict

### DIFF
--- a/src/bluesky/run_engine.py
+++ b/src/bluesky/run_engine.py
@@ -17,6 +17,7 @@ from inspect import iscoroutine
 from itertools import count
 from warnings import warn
 
+import event_model
 from event_model import DocumentNames
 from opentelemetry import trace
 from opentelemetry.trace import Span
@@ -467,6 +468,7 @@ class RunEngine:
         from ._version import __version__
 
         self.md["versions"]["bluesky"] = __version__
+        self.md["versions"]["event_model"] = event_model.__version__
 
         if preprocessors is None:
             preprocessors = []

--- a/src/bluesky/tests/test_metadata.py
+++ b/src/bluesky/tests/test_metadata.py
@@ -1,3 +1,4 @@
+import event_model
 import ophyd
 
 import bluesky
@@ -10,6 +11,10 @@ def test_blueskyversion(RE):
 
 def test_ophydversion(RE):
     assert RE.md["versions"].get("ophyd") == ophyd.__version__
+
+
+def test_eventmodelversion(RE):
+    assert RE.md["versions"].get("event_model") == event_model.__version__
 
 
 def test_old_md_validator(RE):


### PR DESCRIPTION
## Description

Adds `event_model` version to the `RE.md["versions"]` dict, similar to versions of `bluesky`, `ophyd` (if installed), `ophyd-async` (if installed).

## Motivation and Context

It can be useful for downstream consumers to know which `event_model` version was in use when documents in a scan were created (e.g. to know how to interpret those documents even as the event-model schemas might evolve over time).

## How Has This Been Tested?

CI and manual test with creating a new RunEngine and inspecting it's metadata.
