### PR TITLE
DOC: Add locate plan stub to plan stubs documentation

### DIFF
--- a/docs/plans.rst
+++ b/docs/plans.rst
@@ -480,6 +480,7 @@ Plans for interacting with hardware:
     trigger
     read
     rd
+    locate
     stage
     unstage
     configure


### PR DESCRIPTION
## Description

Add `locate` plan stub to plan_stubs documentation

## Motivation and Context
Because I wanted to cross-link to it from downstream documentation and found it didn't exist in docs

## How Has This Been Tested?

Local docs build