### PR TITLE
Add 'single_run_repeat_wrapper' and decorator

### DIFF
--- a/docs/plans.rst
+++ b/docs/plans.rst
@@ -660,12 +660,16 @@ a generator instance. The corresponding functions named
     monitor_during_wrapper
     relative_set_decorator
     relative_set_wrapper
+    repeat_as_stub_decorator
+    repeat_as_stub_wrapper
     reset_positions_decorator
     reset_positions_wrapper
     run_decorator
     run_wrapper
     stage_decorator
     stage_wrapper
+    stub_decorator
+    stub_wrapper
     subs_decorator
     subs_wrapper
     suspend_decorator

--- a/docs/plans.rst
+++ b/docs/plans.rst
@@ -660,12 +660,12 @@ a generator instance. The corresponding functions named
     monitor_during_wrapper
     relative_set_decorator
     relative_set_wrapper
-    repeat_as_stub_decorator
-    repeat_as_stub_wrapper
     reset_positions_decorator
     reset_positions_wrapper
     run_decorator
     run_wrapper
+    single_run_repeat_decorator
+    single_run_repeat_wrapper
     stage_decorator
     stage_wrapper
     stub_decorator

--- a/src/bluesky/preprocessors.py
+++ b/src/bluesky/preprocessors.py
@@ -1,3 +1,4 @@
+import pdb
 import uuid
 from collections import ChainMap, OrderedDict, deque
 from collections.abc import Iterable
@@ -952,6 +953,7 @@ def lazily_stage_wrapper(plan):
     devices_staged = []
 
     def inner(msg):
+        pdb.set_trace()
         if msg.command in COMMANDS and msg.obj not in devices_staged:
             root = root_ancestor(msg.obj)
 

--- a/src/bluesky/preprocessors.py
+++ b/src/bluesky/preprocessors.py
@@ -1253,11 +1253,11 @@ def baseline_wrapper(plan, devices, name="baseline"):
         return (yield from plan_mutator(plan, insert_baseline))
 
 
-def repeat_as_stub_wrapper(plan, num_repeats=1, md=None):
+def single_run_repeat_wrapper(plan, num_repeats=1, md=None):
     """
-    Wrap a plan to repeat it a given number of times as a stub plan.
+    Wrap a plan to repeat it a given number of times and wrap it in a single run.
 
-    Lazy staging so that the devices are only staged once for the entire plan.
+    Lazy staging so that the devices are only staged/unstaged once for the entire plan.
 
     Parameters
     ----------
@@ -1307,7 +1307,7 @@ run_decorator = make_decorator(run_wrapper)
 contingency_decorator = make_decorator(contingency_wrapper)
 stub_decorator = make_decorator(stub_wrapper)
 configure_count_time_decorator = make_decorator(configure_count_time_wrapper)
-repeat_as_stub_decorator = make_decorator(repeat_as_stub_wrapper)
+single_run_repeat_decorator = make_decorator(single_run_repeat_wrapper)
 
 
 class SupplementalData:

--- a/src/bluesky/preprocessors.py
+++ b/src/bluesky/preprocessors.py
@@ -1,11 +1,12 @@
 import uuid
 from collections import ChainMap, OrderedDict, deque
 from collections.abc import Iterable
-from functools import wraps, partial
+from functools import wraps
 
-from bluesky.protocols import Locatable, Stageable, HasName
+from bluesky.protocols import Locatable
 
 from .plan_stubs import (
+    caching_repeater,
     close_run,
     declare_stream,
     mv,
@@ -14,7 +15,6 @@ from .plan_stubs import (
     stage_all,
     trigger_and_read,
     unstage_all,
-    caching_repeater,
 )
 from .utils import (
     Msg,
@@ -1256,7 +1256,7 @@ def baseline_wrapper(plan, devices, name="baseline"):
 def repeat_as_stub_wrapper(plan, num_repeats=1, md=None):
     """
     Wrap a plan to repeat it a given number of times as a stub plan.
-    
+
     Lazy staging so that the devices are only staged once for the entire plan.
 
     Parameters

--- a/src/bluesky/tests/test_plans.py
+++ b/src/bluesky/tests/test_plans.py
@@ -748,3 +748,19 @@ def test_single_run_repeat(RE, hw):
         assert det_unstage.call_count == 1
 
     assert uid is not None
+
+
+def test_single_run_repeat_duplicate_device(RE, hw):
+    det = hw.det
+    with (
+        patch.object(det, "stage", wraps=det.stage) as det_stage,
+        patch.object(det, "unstage", wraps=det.unstage) as det_unstage,
+    ):
+        plan = bpp.single_run_repeat_wrapper(bp.list_scan([det], det.sigma, [1, 2, 3]), num_repeats=2)
+        uid = RE(plan)
+
+        # Check that the stage and unstage methods were called exactly once for each distinct device
+        assert det_stage.call_count == 1
+        assert det_unstage.call_count == 1
+
+    assert uid is not None

--- a/src/bluesky/tests/test_plans.py
+++ b/src/bluesky/tests/test_plans.py
@@ -724,7 +724,7 @@ def test_input_plan(RE):
         RE(plan())
 
 
-def test_repeat_as_stub(RE, hw):
+def test_single_run_repeat(RE, hw):
     motor1 = hw.motor1
     motor2 = hw.motor2
     det = hw.det
@@ -736,7 +736,7 @@ def test_repeat_as_stub(RE, hw):
         patch.object(motor2, "unstage", wraps=motor2.unstage) as motor2_unstage,
         patch.object(det, "unstage", wraps=det.unstage) as det_unstage,
     ):
-        plan = bpp.repeat_as_stub_wrapper(bp.grid_scan([det], motor1, 1, 2, 3, motor2, 4, 5, 6), num_repeats=2)
+        plan = bpp.single_run_repeat_wrapper(bp.grid_scan([det], motor1, 1, 2, 3, motor2, 4, 5, 6), num_repeats=2)
         uid = RE(plan)
 
         # Check that the stage and unstage methods were called exactly once for each device

--- a/src/bluesky/tests/test_preprocessors.py
+++ b/src/bluesky/tests/test_preprocessors.py
@@ -7,8 +7,8 @@ from bluesky.preprocessors import (
     contingency_decorator,
     contingency_wrapper,
     msg_mutator,
-    repeat_as_stub_wrapper,
     run_decorator,
+    single_run_repeat_wrapper,
     stage_decorator,
 )
 from bluesky.protocols import HasName, HasParent, Movable, Stageable
@@ -122,7 +122,7 @@ def test_exceptions_through_msg_mutator():
     assert ["step 0+", "step 1+", "step 2+", "step 3+", "handle it+"] == [m.command for m in msgs]
 
 
-def test_repeat_as_stub_wrapper():
+def test_single_run_repeat_wrapper():
     class Device(Stageable, HasParent, HasName, Movable): ...
 
     stageable1 = MagicMock(spec=Device)
@@ -138,7 +138,7 @@ def test_repeat_as_stub_wrapper():
         yield from bps.mv(stageable1, 1)
         yield from bps.mv(stageable2, 2)
 
-    gen = repeat_as_stub_wrapper(plan(stageable1, stageable2), num_repeats=2)
+    gen = single_run_repeat_wrapper(plan(stageable1, stageable2), num_repeats=2)
 
     commands = []
     for msg in gen:

--- a/src/bluesky/tests/test_preprocessors.py
+++ b/src/bluesky/tests/test_preprocessors.py
@@ -8,10 +8,10 @@ from bluesky.preprocessors import (
     contingency_wrapper,
     msg_mutator,
     repeat_as_stub_wrapper,
-    stage_decorator,
     run_decorator,
+    stage_decorator,
 )
-from bluesky.protocols import Stageable, HasParent, HasName, Movable
+from bluesky.protocols import HasName, HasParent, Movable, Stageable
 from bluesky.run_engine import RequestStop, RunEngine
 
 
@@ -123,8 +123,7 @@ def test_exceptions_through_msg_mutator():
 
 
 def test_repeat_as_stub_wrapper():
-    class Device(Stageable, HasParent, HasName, Movable):
-        ...
+    class Device(Stageable, HasParent, HasName, Movable): ...
 
     stageable1 = MagicMock(spec=Device)
     stageable2 = MagicMock(spec=Device)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a new preprocessor: `single_run_repeat_wrapper` and `single_run_repeat_decorator`
Adds one test for desired functionality.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change makes it easy to repeat plans that have internal stage/unstage, open/close run behaviors and maintain that stage/unstage and open/close run only occur once.

The main use-case for this that was requested was to visit each point in a scan in order, but multiple times. For very long running scans, it is useful to acquire *some* data for each point before possible failure or uncontrollable change in the beamline. The eventual goal being to aggregate the data collected at each point after the full (or failed) run.

So, to accomplish this and keep all of the data in a single Bluesky run (and single file written by our detector), we needed to have this wrapper. I figured others may have use for it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] Unit test for desired functionality
- [x] Test with Ophyd 
- [x] Added to docs

<!--
## Screenshots (if appropriate):
-->
