### PR TITLE
Fix lazily stage wrapper/decorator with child device usage

### DIFF
--- a/src/bluesky/preprocessors.py
+++ b/src/bluesky/preprocessors.py
@@ -951,24 +951,24 @@ def lazily_stage_wrapper(plan):
     devices_staged = []
 
     def inner(msg):
-        if msg.command in COMMANDS and msg.obj not in devices_staged:
+        if msg.command in COMMANDS:
             root = root_ancestor(msg.obj)
+            if root not in devices_staged:
 
-            def new_gen():
-                # Here we insert a 'stage' message
-                ret = yield Msg("stage", root)
-                # and cache the result
-                if ret is None:
-                    # The generator may be being list-ified.
-                    # This is a hack to make that possible.
-                    ret = [root]
-                devices_staged.extend(ret)
-                # and then proceed with our regularly scheduled programming
-                yield msg
+                def new_gen():
+                    # Here we insert a 'stage' message
+                    ret = yield Msg("stage", root)
+                    # and cache the result
+                    if ret is None:
+                        # The generator may be being list-ified.
+                        # This is a hack to make that possible.
+                        ret = [root]
+                    devices_staged.extend(ret)
+                    # and then proceed with our regularly scheduled programming
+                    yield msg
 
-            return new_gen(), None
-        else:
-            return None, None
+                return new_gen(), None
+        return None, None
 
     def inner_unstage_all():
         yield from unstage_all(*reversed(devices_staged))

--- a/src/bluesky/tests/test_preprocessors.py
+++ b/src/bluesky/tests/test_preprocessors.py
@@ -6,8 +6,10 @@ import bluesky.plan_stubs as bps
 from bluesky.preprocessors import (
     contingency_decorator,
     contingency_wrapper,
+    lazily_stage_decorator,
     msg_mutator,
 )
+from bluesky.protocols import HasHints, HasParent, Movable, Stageable
 from bluesky.run_engine import RequestStop, RunEngine
 
 
@@ -116,3 +118,45 @@ def test_exceptions_through_msg_mutator():
     else:
         raise False  # noqa: B016
     assert ["step 0+", "step 1+", "step 2+", "step 3+", "handle it+"] == [m.command for m in msgs]
+
+
+def test_lazily_stage_decorator():
+    class Device(Stageable, HasParent, HasHints, Movable): ...
+
+    device1 = MagicMock(spec=Device)
+    device2 = MagicMock(spec=Device)
+    device1.name = "device1"
+    device2.name = "device2"
+    device1.parent = None
+    device2.parent = None
+
+    @lazily_stage_decorator()
+    def plan():
+        yield from bps.mv(device1, 1)
+        yield from bps.mv(device2, 2)
+
+    commands = [m.command for m in plan()]
+    assert commands == ["stage", "set", "wait", "stage", "set", "wait", "unstage", "unstage"]
+
+
+def test_lazily_stage_decorator_with_nested_devices():
+    class Device(Stageable, HasParent, HasHints, Movable): ...
+
+    root_device = MagicMock(spec=Device)
+    root_device.name = "root_device"
+    root_device.parent = None
+    child1 = MagicMock(spec=Device)
+    child1.name = "child1"
+    child1.parent = root_device
+    child2 = MagicMock(spec=Device)
+    child2.name = "child2"
+    child2.parent = root_device
+
+    @lazily_stage_decorator()
+    def plan():
+        yield from bps.mv(child1, 1)
+        yield from bps.mv(child2, 2)
+        yield from bps.mv(root_device, 3)
+
+    commands = [m.command for m in plan()]
+    assert commands == ["stage", "set", "wait", "set", "wait", "set", "wait", "unstage"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Closes #1975 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug fix. The root device should only be staged once when using the `lazily_stage_wrapper`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] Unit tests
- [x] Ophyd sim test

<!--
## Screenshots (if appropriate):
-->
