### PR TITLE
Remove erroneous comment

### DIFF
--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -823,7 +823,6 @@ class RunBundler:
 
         return indices_difference
 
-    # message strem name here?
     async def _pack_external_assets(
         self, asset_docs: Iterable[Asset | StreamAsset], message_stream_name: str | None
     ):


### PR DESCRIPTION
Removing a (misspelled) comment I accidentally left in the run bundler two years ago.