### PR TITLE
fix: serialise msg.args with json.dumps to avoid OTel WARNING for num #1989

### DIFF
--- a/src/bluesky/run_engine.py
+++ b/src/bluesky/run_engine.py
@@ -2813,7 +2813,7 @@ http://nsls-ii.github.io/bluesky/plans_intro.html#combining-plans
 
 def _set_span_msg_attributes(span, msg):
     span.set_attribute("msg.command", msg.command)
-    span.set_attribute("msg.args", msg.args)
+    span.set_attribute("msg.args", json.dumps(msg.args, default=repr))
     span.set_attribute("msg.kwargs", json.dumps(msg.kwargs, default=repr))
     span.set_attribute("msg.obj", repr(msg.obj)) if msg.obj else span.set_attribute("msg.no_obj_given", True)
 


### PR DESCRIPTION
## Description
Serialise msg.args using json.dumps(..., default=repr) to match the existing handling of msg.kwargs

## Motivation and Context
msg.args contains numpy.float64 values. OTel validates attribute values using exact type checks and rejects numpy.float64 even though it behaves like a float, causing the following warning on every set message and silently dropping the attribute:
https://github.com/bluesky/bluesky/issues/1989

## How Has This Been Tested?
Ran the full bluesky test suite, also ran the changes again blueapi tests and the changes removed the error message.
