### PR TITLE
BUG: fix TypeError from %wa for multi-axis PseudoPositioner (#2001)

### DIFF
--- a/src/bluesky/magics.py
+++ b/src/bluesky/magics.py
@@ -236,6 +236,19 @@ def is_positioner(dev):
     return hasattr(dev, "position")
 
 
+def _round(value, decimals):
+    """Round value; return str if np.round yields an ndarray.
+
+    PseudoPositioner positions and limits are namedtuples; np.round
+    converts them to ndarray, which rejects string format specs under
+    numpy 2.x.
+    """
+    result = np.round(value, decimals=decimals)
+    if isinstance(result, np.ndarray):
+        return str(result)
+    return result
+
+
 def _print_positioners(positioners, sort=True, precision=6, prefix=""):
     """
     This will take a list of positioners and try to print them.
@@ -272,20 +285,20 @@ def _print_positioners(positioners, sort=True, precision=6, prefix=""):
                 prec = int(p.precision)
             except Exception:
                 prec = precision
-            value = np.round(v, decimals=prec)
+            value = _round(v, decimals=prec)
             try:
                 low_limit, high_limit = p.limits
             except Exception as exc:
                 low_limit = high_limit = exc.__class__.__name__
             else:
-                low_limit = np.round(low_limit, decimals=prec)
-                high_limit = np.round(high_limit, decimals=prec)
+                low_limit = _round(low_limit, decimals=prec)
+                high_limit = _round(high_limit, decimals=prec)
             try:
                 offset = p.user_offset.get()
             except Exception as exc:
                 offset = exc.__class__.__name__
             else:
-                offset = np.round(offset, decimals=prec)
+                offset = _round(offset, decimals=prec)
         else:
             value = v.__class__.__name__  # e.g. 'DisconnectedError'
             low_limit = high_limit = offset = ""

--- a/src/bluesky/tests/test_magics.py
+++ b/src/bluesky/tests/test_magics.py
@@ -3,11 +3,28 @@ import signal
 from types import SimpleNamespace
 
 import pytest
+from ophyd import Component as Cpt
+from ophyd import PseudoPositioner, PseudoSingle, SoftPositioner
 
 import bluesky.plan_stubs as bps
 import bluesky.plans as bp
-from bluesky.magics import BlueskyMagics
+from bluesky.magics import BlueskyMagics, _print_positioners
 from bluesky.tests import uses_os_kill_sigint
+
+
+class TwoAxisPseudo(PseudoPositioner):
+    """Minimal two-axis PseudoPositioner for testing."""
+
+    px = Cpt(PseudoSingle)
+    py = Cpt(PseudoSingle)
+    rx = Cpt(SoftPositioner, init_pos=0)
+    ry = Cpt(SoftPositioner, init_pos=0)
+
+    def forward(self, pp):
+        return self.RealPosition(rx=pp.px, ry=pp.py)
+
+    def inverse(self, rp):
+        return self.PseudoPosition(px=rp.rx, py=rp.ry)
 
 
 class FakeIPython:
@@ -169,3 +186,19 @@ def test_interrupted(RE, hw):
     sm.RE.loop.call_later(1, sim_kill, 2)
     sm.mov("motor 1")
     assert sm.RE.state == "idle"
+
+
+def test_print_positioners_pseudo_positioner():
+    # PseudoPositioner.position is a namedtuple; np.round returns an ndarray
+    # under numpy 2.x, which raises TypeError with string format specs.
+    dev = TwoAxisPseudo(name="dev")
+    _print_positioners([dev])  # must not raise TypeError
+
+
+def test_wa_pseudo_positioner():
+    # %wa must not raise TypeError for multi-axis PseudoPositioner objects.
+    dev = TwoAxisPseudo(name="dev", labels=["motors"])
+    ip = FakeIPython({"dev": dev})
+    sm = BlueskyMagics(ip)
+    sm.wa("")  # must not raise TypeError
+    sm.wa("motors")  # must not raise TypeError


### PR DESCRIPTION
## Summary

Closes #2001.

- `np.round()` on a `PseudoPositioner` namedtuple (`position`, `limits`) returns an `ndarray` under numpy 2.x, which rejects string alignment format specs such as `{: <11}`, raising `TypeError`
- Extract a `_round()` helper that converts `ndarray` results to `str`, and use it in `_print_positioners` for `value`, `low_limit`, and `high_limit`
- Add tests using a minimal `TwoAxisPseudo` (`ophyd.PseudoPositioner` subclass) to cover `_print_positioners` directly and the `%wa` magic end-to-end

Contributor: OpenCode (argo/claudesonnet46)