### PR TITLE
SuspendWhenChanged suspender misinterprets falsy expected values

### DIFF
--- a/src/bluesky/suspenders.py
+++ b/src/bluesky/suspenders.py
@@ -663,7 +663,7 @@ class SuspendWhenChanged(SuspenderBase):
         tripped_message="",
         **kwargs,
     ):
-        self.expected_value = expected_value or signal.value
+        self.expected_value = signal.value if expected_value is None else expected_value
         self.allow_resume = allow_resume
         super().__init__(
             signal, sleep=sleep, pre_plan=pre_plan, post_plan=post_plan, tripped_message=tripped_message, **kwargs

--- a/src/bluesky/tests/test_suspenders.py
+++ b/src/bluesky/tests/test_suspenders.py
@@ -15,6 +15,7 @@ from bluesky.suspenders import (
     SuspendFloor,
     SuspendInBand,
     SuspendOutBand,
+    SuspendWhenChanged,
     SuspendWhenOutsideBand,
 )
 from bluesky.tests.utils import MsgCollector
@@ -210,6 +211,17 @@ def test_pause_from_suspend(RE, hw):
     assert [m[0] for m in msg_lst] == ["wait_for"]
     RE.resume()
     assert ["wait_for", "wait_for", "checkpoint"] == [m[0] for m in msg_lst]
+
+
+def test_suspend_when_changed_preserves_falsy_expected_value(hw):
+    sig = hw.bool_sig
+    sig.put(1)
+
+    susp = SuspendWhenChanged(sig, expected_value=0)
+
+    assert susp.expected_value == 0
+    assert not susp._should_suspend(0)
+    assert susp._should_suspend(1)
 
 
 def test_deferred_pause_from_suspend(RE, hw):


### PR DESCRIPTION
## Summary
- Addresses https://github.com/bluesky/bluesky/issues/1987
- Applies the validated ForgeHub draft for SuspendWhenChanged suspender misinterprets falsy expected values

## Validation
- manual_validation: uv run --extra dev pytest src/bluesky/tests/test_suspenders.py -k preserves_falsy=0