### PR TITLE
ENH: add testing for python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
       matrix:
         runs-on: ["ubuntu-latest", "windows-latest"] # can add macos-latest
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        exclude:
+          # duckdb (tiled dep) has no Windows wheels for 3.14 yet
+          - runs-on: "windows-latest"
+            python-version: "3.14"
         include:
           # Include one that runs in the dev environment
           - runs-on: "ubuntu-latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         runs-on: ["ubuntu-latest", "windows-latest"] # can add macos-latest
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           # Include one that runs in the dev environment
           - runs-on: "ubuntu-latest"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add 3.14 to the CI testing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

3.14 has been out since October 2025, would be nice to align - hopefully does not break anything (or it might be useful to catch some bugs).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Waiting for CI to do its thing.

<!--
## Screenshots (if appropriate):
-->
