### PR TITLE
RemoteDispatcher ZMQ connection handshake

### DIFF
--- a/src/bluesky/callbacks/zmq.py
+++ b/src/bluesky/callbacks/zmq.py
@@ -442,7 +442,7 @@ class RemoteDispatcher(Dispatcher):
         optional event loop to use.  Default is to create a new event loop.
     deserializer: function, optional
         optional function to deserialize data. Default is pickle.loads
-    connection_timeout : float, optional
+    handshake_timeout : float, optional
         Configurable timeout to wait for connection handshake.
         Defaults to ``None``, no wait for handshake.
 
@@ -465,7 +465,7 @@ class RemoteDispatcher(Dispatcher):
         deserializer: Callable = pickle.loads,
         strict: bool = False,
         curve_config: ServerCurve | ClientCurve | None = None,
-        connection_timeout: float | None = None,
+        handshake_timeout: float | None = None,
     ):
         if isinstance(prefix, str):
             raise ValueError("prefix must be bytes, not string")
@@ -486,8 +486,9 @@ class RemoteDispatcher(Dispatcher):
         self._socket = None
         self._monitor = None
         self._wait_task = None
-        self._connection_timeout = connection_timeout
-        self._connected = threading.Event()
+        self._handshake_timeout = handshake_timeout
+        self._ready_event = threading.Event()
+        self._poll_ready = asyncio.Event()
 
         def __finish_setup():
             asyncio.set_event_loop(self.loop)
@@ -507,11 +508,11 @@ class RemoteDispatcher(Dispatcher):
                 server_key, _ = zmq.auth.load_certificate(curve_config.server_public_key)
                 sock.setsockopt(zmq.CURVE_SERVERKEY, server_key)
 
-            if self._connection_timeout is not None:
+            if self._handshake_timeout is not None:
                 self._monitor = self._socket.get_monitor_socket(
                     events=zmq.EVENT_HANDSHAKE_SUCCEEDED,
                 )
-                self._wait_task = self.loop.create_task(self._wait_for_handshake(self._connection_timeout))
+                self._wait_task = self.loop.create_task(self._wait_for_ready(self._handshake_timeout))
 
             self._socket.connect(self.address)
             self._socket.setsockopt_string(zmq.SUBSCRIBE, "")
@@ -525,6 +526,11 @@ class RemoteDispatcher(Dispatcher):
 
     async def _poll(self):
         our_prefix = self._prefix  # local var to save an attribute lookup
+        # Signal that we are about to enter the receive loop, synchronously.
+        # _wait_for_ready awaits this before setting _ready_event,
+        # ensuring wait_for_ready() only unblocks once _poll is genuinely
+        # ready to receive messages.
+        self._poll_ready.set()
         while True:
             message = await self._socket.recv()
             try:
@@ -573,13 +579,30 @@ class RemoteDispatcher(Dispatcher):
                         continue
                 self.loop.call_soon(self.process, DocumentNames[name], doc)
 
-    async def _wait_for_handshake(self, timeout: float = 5.0) -> None:
+    async def _wait_for_ready(self, timeout: float = 5.0) -> None:
         if not self._monitor:
             raise RuntimeError("Socket monitor for the connection handshake should be set at this point.")
-        await asyncio.wait_for(recv_monitor_message(self._monitor), timeout=timeout)
+        try:
+            # Start reading from the monitor socket immediately.
+            await asyncio.wait_for(recv_monitor_message(self._monitor), timeout=timeout)
+            # Wait for _poll to signal it is at `await socket.recv()`
+            await self._poll_ready.wait()
+            # Only when handshake is successful and we are receiving are we ready
+            self._ready_event.set()
+        except asyncio.TimeoutError:
+            logger.error(f"Connection handshake timed out after {timeout}s")
+            if self._task is not None:
+                self._task.cancel()
+            raise
+        finally:
+            if self._socket is not None:
+                self._socket.disable_monitor()
+            if self._monitor is not None:
+                self._monitor.close(linger=0)
 
-    def wait_for_connection(self, timeout: float | None = None) -> bool:
-        """Block until the SUB socket handshake has completed successfully.
+    def ready(self, timeout: float | None = None) -> bool:
+        """
+        Block until the SUB socket until we are ready to receive messages.
 
         Intended to be called from a thread other than the one running the
         dispatcher's event loop, so that callers can know when it is safe
@@ -594,35 +617,15 @@ class RemoteDispatcher(Dispatcher):
         Returns
         -------
         bool
-            ``True`` if the handshake completed within the timeout,
+            ``True`` if ready signal is set within the timeout,
             ``False`` otherwise.
         """
-        if self._connection_timeout is None:
+        if self._handshake_timeout is None:
             raise RuntimeError(
-                "Handshake event monitoring is not set up. "
-                "Use the `connection_timeout` argument on `RemoteDispatcher` to do set this up."
+                "Handshake event monitoring is not set up so there is no way to guarantee readiness. "
+                "Initialize with `handshake_timeout` argument to set this up."
             )
-        return self._connected.wait(timeout=timeout)
-
-    def _await_connection(self, timeout: float = 5.0) -> None:
-        """Wait for SUB socket event handshake"""
-
-        logger.debug(f"Waiting for connection handshake ({timeout=}s")
-        try:
-            if self._wait_task:
-                self.loop.run_until_complete(self._wait_task)
-        except asyncio.TimeoutError:
-            logger.error(f"Connection handshake timed out after {timeout}s")
-            raise
-        else:
-            self._connected.set()
-        finally:
-            if self._wait_task is not None:
-                self._wait_task.cancel()
-            if self._socket is not None:
-                self._socket.disable_monitor()
-            if self._monitor is not None:
-                self._monitor.close(linger=0)
+        return self._ready_event.wait(timeout=timeout)
 
     def start(self):
         if self.closed:
@@ -633,13 +636,21 @@ class RemoteDispatcher(Dispatcher):
             )
         try:
             self.__factory()
-            if self._connection_timeout is not None:
-                self._await_connection()
             self._task = self.loop.create_task(self._poll())
-            self.loop.run_until_complete(self._task)
-            task_exception = self._task.exception()
-            if task_exception is not None:
-                raise task_exception
+            try:
+                self.loop.run_until_complete(self._task)
+            except asyncio.CancelledError as err:
+                # _poll was cancelled.  If _wait_task caused it (handshake
+                # timeout), surface that exception instead of CancelledError.
+                if self._wait_task is not None and self._wait_task.done() and not self._wait_task.cancelled():
+                    exc = self._wait_task.exception()
+                    if exc is not None:
+                        raise exc from None
+                raise err
+            if not self._task.cancelled():
+                task_exception = self._task.exception()
+                if task_exception is not None:
+                    raise task_exception
         finally:
             # The loop has stopped, so tear everything down here and signal
             # any thread blocked in ``stop`` that cleanup is complete.
@@ -648,7 +659,7 @@ class RemoteDispatcher(Dispatcher):
     def _cleanup(self):
         # Release the task, socket, context and loop. Safe to call only once
         # the loop has stopped; closing a running loop raises RuntimeError.
-        self._connected.clear()
+        self._ready_event.clear()
         if self._wait_task is not None:
             self._wait_task.cancel()
         if self._task is not None:

--- a/src/bluesky/callbacks/zmq.py
+++ b/src/bluesky/callbacks/zmq.py
@@ -602,7 +602,7 @@ class RemoteDispatcher(Dispatcher):
 
     def ready(self, timeout: float | None = None) -> bool:
         """
-        Block until the SUB socket until we are ready to receive messages.
+        Block until the SUB socket is ready to receive messages.
 
         Intended to be called from a thread other than the one running the
         dispatcher's event loop, so that callers can know when it is safe

--- a/src/bluesky/callbacks/zmq.py
+++ b/src/bluesky/callbacks/zmq.py
@@ -527,7 +527,6 @@ class RemoteDispatcher(Dispatcher):
         our_prefix = self._prefix  # local var to save an attribute lookup
         while True:
             message = await self._socket.recv()
-            self._connected.set()
             try:
                 prefix, name, doc = message.split(b" ", 2)
             except ValueError as e:

--- a/src/bluesky/callbacks/zmq.py
+++ b/src/bluesky/callbacks/zmq.py
@@ -448,9 +448,8 @@ class RemoteDispatcher(Dispatcher):
     Attributes
     ----------
     connected : bool
-        ``True`` once the SUB socket handshake has completed successfully
-        (only meaningful when ``connection_timeout`` is provided). Reset to
-        ``False`` on ``stop()``. See also :meth:`wait_for_connection`.
+        ``True`` once the SUB socket handshake has completed successfully.
+        Reset to ``False`` on ``stop()``. See also :meth:`wait_for_connection`.
 
     Examples
     --------
@@ -529,6 +528,7 @@ class RemoteDispatcher(Dispatcher):
         our_prefix = self._prefix  # local var to save an attribute lookup
         while True:
             message = await self._socket.recv()
+            self._connected.set()
             try:
                 prefix, name, doc = message.split(b" ", 2)
             except ValueError as e:

--- a/src/bluesky/callbacks/zmq.py
+++ b/src/bluesky/callbacks/zmq.py
@@ -16,6 +16,7 @@ import asyncio
 import copy
 import logging
 import pickle
+import sys
 import threading
 import warnings
 from collections.abc import Callable
@@ -482,7 +483,10 @@ class RemoteDispatcher(Dispatcher):
         self.address = _normalize_address(address)
 
         if loop is None:
-            loop = asyncio.new_event_loop()
+            if sys.platform == "win32":
+                loop = asyncio.SelectorEventLoop()
+            else:
+                loop = asyncio.new_event_loop()
         self.loop = loop
         self._context = None
         self._socket = None

--- a/src/bluesky/callbacks/zmq.py
+++ b/src/bluesky/callbacks/zmq.py
@@ -625,7 +625,13 @@ class RemoteDispatcher(Dispatcher):
                 "Handshake event monitoring is not set up so there is no way to guarantee readiness. "
                 "Initialize with `handshake_timeout` argument to set this up."
             )
-        return self._ready_event.wait(timeout=timeout)
+        self._ready_event.wait(timeout=timeout)
+        if self.closed:
+            raise RuntimeError(
+                "RemoteDispatcher was closed before the connection handshake completed. "
+                "The dispatcher is no longer running."
+            )
+        return self._ready_event.is_set()
 
     def start(self):
         if self.closed:
@@ -657,9 +663,6 @@ class RemoteDispatcher(Dispatcher):
             self._cleanup()
 
     def _cleanup(self):
-        # Release the task, socket, context and loop. Safe to call only once
-        # the loop has stopped; closing a running loop raises RuntimeError.
-        self._ready_event.clear()
         if self._wait_task is not None:
             self._wait_task.cancel()
         if self._task is not None:
@@ -674,6 +677,7 @@ class RemoteDispatcher(Dispatcher):
         if not self.loop.is_closed():
             self.loop.close()
         self.closed = True
+        self._ready_event.set()
         self._stopped.set()
 
     def stop(self):

--- a/src/bluesky/callbacks/zmq.py
+++ b/src/bluesky/callbacks/zmq.py
@@ -597,6 +597,11 @@ class RemoteDispatcher(Dispatcher):
             ``True`` if the handshake completed within the timeout,
             ``False`` otherwise.
         """
+        if self._connection_timeout is None:
+            raise RuntimeError(
+                "Handshake event monitoring is not set up. "
+                "Use the `connection_timeout` argument on `RemoteDispatcher` to do set this up."
+            )
         return self._connected.wait(timeout=timeout)
 
     def _await_connection(self, timeout: float = 5.0) -> None:

--- a/src/bluesky/callbacks/zmq.py
+++ b/src/bluesky/callbacks/zmq.py
@@ -446,12 +446,6 @@ class RemoteDispatcher(Dispatcher):
         Configurable timeout to wait for connection handshake.
         Defaults to ``None``, no wait for handshake.
 
-    Attributes
-    ----------
-    connected : bool
-        ``True`` once the SUB socket handshake has completed successfully.
-        Reset to ``False`` on ``stop()``. See also :meth:`wait_for_connection`.
-
     Examples
     --------
 
@@ -583,11 +577,6 @@ class RemoteDispatcher(Dispatcher):
         if not self._monitor:
             raise RuntimeError("Socket monitor for the connection handshake should be set at this point.")
         await asyncio.wait_for(recv_monitor_message(self._monitor), timeout=timeout)
-
-    @property
-    def connected(self) -> bool:
-        """Whether the SUB socket handshake has completed successfully."""
-        return self._connected.is_set()
 
     def wait_for_connection(self, timeout: float | None = None) -> bool:
         """Block until the SUB socket handshake has completed successfully.

--- a/src/bluesky/callbacks/zmq.py
+++ b/src/bluesky/callbacks/zmq.py
@@ -25,6 +25,7 @@ import zmq
 import zmq.asyncio as zmq_asyncio
 import zmq.auth
 from zmq.auth.thread import ThreadAuthenticator
+from zmq.utils.monitor import recv_monitor_message
 
 from ..run_engine import Dispatcher, DocumentNames
 
@@ -439,6 +440,9 @@ class RemoteDispatcher(Dispatcher):
         optional event loop to use.  Default is to create a new event loop.
     deserializer: function, optional
         optional function to deserialize data. Default is pickle.loads
+    connection_timeout : float, optional
+        Configurable timeout to wait for connection handshake.
+        Defaults to ``None``, no wait for handshake.
 
     Examples
     --------
@@ -459,6 +463,7 @@ class RemoteDispatcher(Dispatcher):
         deserializer: Callable = pickle.loads,
         strict: bool = False,
         curve_config: ServerCurve | ClientCurve | None = None,
+        connection_timeout: float | None = None,
     ):
         if isinstance(prefix, str):
             raise ValueError("prefix must be bytes, not string")
@@ -474,6 +479,9 @@ class RemoteDispatcher(Dispatcher):
         self.loop = loop
         self._context = None
         self._socket = None
+        self._monitor = None
+        self._wait_task = None
+        self._connection_timeout = connection_timeout
 
         def __finish_setup():
             asyncio.set_event_loop(self.loop)
@@ -492,6 +500,12 @@ class RemoteDispatcher(Dispatcher):
                 # Load the server public key and register with the socket
                 server_key, _ = zmq.auth.load_certificate(curve_config.server_public_key)
                 sock.setsockopt(zmq.CURVE_SERVERKEY, server_key)
+
+            if self._connection_timeout is not None:
+                self._monitor = self._socket.get_monitor_socket(
+                    events=zmq.EVENT_HANDSHAKE_SUCCEEDED,
+                )
+                self._wait_task = self.loop.create_task(self._wait_for_handshake(self._connection_timeout))
 
             self._socket.connect(self.address)
             self._socket.setsockopt_string(zmq.SUBSCRIBE, "")
@@ -552,6 +566,29 @@ class RemoteDispatcher(Dispatcher):
                         continue
                 self.loop.call_soon(self.process, DocumentNames[name], doc)
 
+    async def _wait_for_handshake(self, timeout: float = 5.0) -> None:
+        if not self._monitor:
+            raise RuntimeError("Socket monitor for the connection handshake should be set at this point.")
+        await asyncio.wait_for(recv_monitor_message(self._monitor), timeout=timeout)
+
+    def _await_connection(self, timeout: float = 5.0) -> None:
+        """Wait for SUB socket event handshake"""
+
+        logger.debug(f"Waiting for connection handshake ({timeout=}s")
+        try:
+            if self._wait_task:
+                self.loop.run_until_complete(self._wait_task)
+        except asyncio.TimeoutError:
+            logger.error(f"Connection handshake timed out after {timeout}s")
+            raise
+        finally:
+            if self._wait_task is not None:
+                self._wait_task.cancel()
+            if self._socket is not None:
+                self._socket.disable_monitor()
+            if self._monitor is not None:
+                self._monitor.close(linger=0)
+
     def start(self):
         if self.closed:
             raise RuntimeError(
@@ -561,6 +598,8 @@ class RemoteDispatcher(Dispatcher):
             )
         try:
             self.__factory()
+            if self._connection_timeout is not None:
+                self._await_connection()
             self._task = self.loop.create_task(self._poll())
             self.loop.run_until_complete(self._task)
             task_exception = self._task.exception()
@@ -570,6 +609,8 @@ class RemoteDispatcher(Dispatcher):
             self.stop()
 
     def stop(self):
+        if self._wait_task is not None:
+            self._wait_task.cancel()
         if self._task is not None:
             self._task.cancel()
         if self._socket is not None:

--- a/src/bluesky/callbacks/zmq.py
+++ b/src/bluesky/callbacks/zmq.py
@@ -600,19 +600,13 @@ class RemoteDispatcher(Dispatcher):
             if self._monitor is not None:
                 self._monitor.close(linger=0)
 
-    def ready(self, timeout: float | None = None) -> bool:
+    def ready(self) -> bool:
         """
         Block until the SUB socket until we are ready to receive messages.
 
         Intended to be called from a thread other than the one running the
         dispatcher's event loop, so that callers can know when it is safe
         to start publishing messages that the dispatcher should receive.
-
-        Parameters
-        ----------
-        timeout : float, optional
-            Maximum time in seconds to wait. ``None`` (the default) waits
-            indefinitely.
 
         Returns
         -------
@@ -625,13 +619,10 @@ class RemoteDispatcher(Dispatcher):
                 "Handshake event monitoring is not set up so there is no way to guarantee readiness. "
                 "Initialize with `handshake_timeout` argument to set this up."
             )
-        self._ready_event.wait(timeout=timeout)
-        if self.closed:
-            raise RuntimeError(
-                "RemoteDispatcher was closed before the connection handshake completed. "
-                "The dispatcher is no longer running."
-            )
-        return self._ready_event.is_set()
+        # Not blocking forever since this event is guaranteed to be set on cleanup
+        # The ``_handshake_timeout`` already handles timing out.
+        self._ready_event.wait()
+        return not self.closed and self._ready_event.is_set()
 
     def start(self):
         if self.closed:

--- a/src/bluesky/callbacks/zmq.py
+++ b/src/bluesky/callbacks/zmq.py
@@ -16,6 +16,7 @@ import asyncio
 import copy
 import logging
 import pickle
+import threading
 import warnings
 from collections.abc import Callable
 from pathlib import Path
@@ -444,6 +445,13 @@ class RemoteDispatcher(Dispatcher):
         Configurable timeout to wait for connection handshake.
         Defaults to ``None``, no wait for handshake.
 
+    Attributes
+    ----------
+    connected : bool
+        ``True`` once the SUB socket handshake has completed successfully
+        (only meaningful when ``connection_timeout`` is provided). Reset to
+        ``False`` on ``stop()``. See also :meth:`wait_for_connection`.
+
     Examples
     --------
 
@@ -482,6 +490,7 @@ class RemoteDispatcher(Dispatcher):
         self._monitor = None
         self._wait_task = None
         self._connection_timeout = connection_timeout
+        self._connected = threading.Event()
 
         def __finish_setup():
             asyncio.set_event_loop(self.loop)
@@ -571,6 +580,32 @@ class RemoteDispatcher(Dispatcher):
             raise RuntimeError("Socket monitor for the connection handshake should be set at this point.")
         await asyncio.wait_for(recv_monitor_message(self._monitor), timeout=timeout)
 
+    @property
+    def connected(self) -> bool:
+        """Whether the SUB socket handshake has completed successfully."""
+        return self._connected.is_set()
+
+    def wait_for_connection(self, timeout: float | None = None) -> bool:
+        """Block until the SUB socket handshake has completed successfully.
+
+        Intended to be called from a thread other than the one running the
+        dispatcher's event loop, so that callers can know when it is safe
+        to start publishing messages that the dispatcher should receive.
+
+        Parameters
+        ----------
+        timeout : float, optional
+            Maximum time in seconds to wait. ``None`` (the default) waits
+            indefinitely.
+
+        Returns
+        -------
+        bool
+            ``True`` if the handshake completed within the timeout,
+            ``False`` otherwise.
+        """
+        return self._connected.wait(timeout=timeout)
+
     def _await_connection(self, timeout: float = 5.0) -> None:
         """Wait for SUB socket event handshake"""
 
@@ -581,6 +616,8 @@ class RemoteDispatcher(Dispatcher):
         except asyncio.TimeoutError:
             logger.error(f"Connection handshake timed out after {timeout}s")
             raise
+        else:
+            self._connected.set()
         finally:
             if self._wait_task is not None:
                 self._wait_task.cancel()
@@ -609,6 +646,7 @@ class RemoteDispatcher(Dispatcher):
             self.stop()
 
     def stop(self):
+        self._connected.clear()
         if self._wait_task is not None:
             self._wait_task.cancel()
         if self._task is not None:

--- a/src/bluesky/tests/test_zmq.py
+++ b/src/bluesky/tests/test_zmq.py
@@ -597,6 +597,14 @@ def test_remote_dispatcher_connection_timeout_in_thread():
     assert isinstance(exceptions[0], asyncio.TimeoutError)
 
 
+def test_remote_dispatcher_handshake_wait_without_connection_timeout_configured():
+    """Test that handshake wait fails when not using handshake monitoring."""
+
+    dispatcher = RemoteDispatcher("localhost:5841")
+    with pytest.raises(RuntimeError):
+        dispatcher.wait_for_connection(1.0)
+
+
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_remote_dispatcher_stop_from_other_thread():
     """Regression test for #2012: stop() called from another thread must not raise RuntimeError.

--- a/src/bluesky/tests/test_zmq.py
+++ b/src/bluesky/tests/test_zmq.py
@@ -684,11 +684,9 @@ def test_remote_dispatcher_connection_success():
         dispatcher_thread = threading.Thread(target=run_dispatcher, daemon=True)
         dispatcher_thread.start()
         assert dispatcher.wait_for_connection(timeout=2), "handshake was not signaled within timeout"
-        assert dispatcher.connected
         assert recv_event.wait(timeout=2), "recv was not called within timeout"
         dispatcher.loop.call_soon_threadsafe(dispatcher.stop)
         dispatcher_thread.join()
-        assert not dispatcher.connected, "connected should be False after stop()"
 
 
 def test_remote_dispatcher_connection_timeout_in_thread():
@@ -711,7 +709,6 @@ def test_remote_dispatcher_connection_timeout_in_thread():
     assert not dispatcher.wait_for_connection(timeout=0.1), (
         "wait_for_connection should return False on handshake timeout"
     )
-    assert not dispatcher.connected
 
     dispatcher_thread.join(timeout=2)
     assert not dispatcher_thread.is_alive(), "dispatcher thread did not exit after timeout"

--- a/src/bluesky/tests/test_zmq.py
+++ b/src/bluesky/tests/test_zmq.py
@@ -683,6 +683,37 @@ def test_remote_dispatcher_connection_success():
 
         dispatcher_thread = threading.Thread(target=run_dispatcher, daemon=True)
         dispatcher_thread.start()
+        assert dispatcher.wait_for_connection(timeout=2), "handshake was not signaled within timeout"
+        assert dispatcher.connected
         assert recv_event.wait(timeout=2), "recv was not called within timeout"
         dispatcher.loop.call_soon_threadsafe(dispatcher.stop)
         dispatcher_thread.join()
+        assert not dispatcher.connected, "connected should be False after stop()"
+
+
+def test_remote_dispatcher_connection_timeout_in_thread():
+    """Test that handshake failure is observable from another thread via wait_for_connection."""
+
+    dispatcher = RemoteDispatcher("localhost:5841", connection_timeout=0.01)
+
+    exceptions: list[BaseException] = []
+
+    def run_dispatcher():
+        try:
+            dispatcher.start()
+        except BaseException as e:
+            exceptions.append(e)
+
+    dispatcher_thread = threading.Thread(target=run_dispatcher, daemon=True)
+    dispatcher_thread.start()
+
+    # Caller in another thread sees the connection never succeeded.
+    assert not dispatcher.wait_for_connection(timeout=0.1), (
+        "wait_for_connection should return False on handshake timeout"
+    )
+    assert not dispatcher.connected
+
+    dispatcher_thread.join(timeout=2)
+    assert not dispatcher_thread.is_alive(), "dispatcher thread did not exit after timeout"
+    assert len(exceptions) == 1
+    assert isinstance(exceptions[0], asyncio.TimeoutError)

--- a/src/bluesky/tests/test_zmq.py
+++ b/src/bluesky/tests/test_zmq.py
@@ -1,11 +1,14 @@
+import asyncio
 import gc
 import itertools
 import logging
 import os
+import pickle
 import signal
 import threading
 import time
 from subprocess import run
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import multiprocess
 import numpy as np
@@ -525,7 +528,6 @@ def test_dep_warning_if_using_port_args(mock_zmq_context, in_or_out: str):
 
 @pytest.mark.parametrize("cls", [ServerCurve, ClientCurve])
 def test_cannot_bind_with_incorrect_curve(mock_zmq_context, tmp_path, cls):
-
     args = [tmp_path, tmp_path]
     if cls == ServerCurve:
         args.append(None)  # ServerCurve takes an extra argument
@@ -635,3 +637,52 @@ def test_configure_server_socket_server_curve(
         assert "Bound to random port: 12345" in caplog.text
     else:
         assert f"Bound to address: {expected_addr}" in caplog.text
+
+
+def test_remote_dispatcher_connection_timeout():
+    """Test that RemoteDispatcher times out when handshake doesn't complete."""
+
+    dispatcher = RemoteDispatcher("localhost:5841", connection_timeout=0.1)
+
+    with pytest.raises(asyncio.TimeoutError):
+        dispatcher.start()
+
+
+def test_remote_dispatcher_connection_success():
+    """Test that RemoteDispatcher succeeds when handshake completes. It should process 1 message and exit."""
+
+    recv_event = threading.Event()
+
+    mock_monitor = MagicMock()
+
+    async def mock_recv(*args, **kwargs):
+        if not recv_event.is_set():
+            recv_event.set()
+            return b" start " + pickle.dumps({})
+        # Block forever after first call to allow cancellation
+        await asyncio.Event().wait()
+
+    with (
+        patch("zmq.asyncio.Socket.get_monitor_socket", return_value=mock_monitor),
+        patch("zmq.asyncio.Socket.disable_monitor"),
+        patch(
+            "bluesky.callbacks.zmq.recv_monitor_message",
+            new_callable=AsyncMock,
+            return_value={"event": zmq.EVENT_HANDSHAKE_SUCCEEDED},
+        ),
+        patch("zmq.asyncio.Socket.connect"),
+        patch("zmq.asyncio.Socket.recv", side_effect=mock_recv),
+    ):
+        dispatcher = RemoteDispatcher("localhost:5841", connection_timeout=5.0)
+
+        def run_dispatcher():
+            try:
+                dispatcher.start()
+            except asyncio.CancelledError:
+                pass
+
+        dispatcher_thread = threading.Thread(target=run_dispatcher, daemon=True)
+        dispatcher_thread.start()
+        assert recv_event.wait(timeout=2), "recv was not called within timeout"
+        dispatcher.loop.call_soon_threadsafe(dispatcher.stop)
+        dispatcher_thread.join()

--- a/src/bluesky/tests/test_zmq.py
+++ b/src/bluesky/tests/test_zmq.py
@@ -123,7 +123,7 @@ def dispatcher():
     d.subscribe(store_document)
     d.subscribe(stop_doc_watcher)
     threading.Thread(target=d.start, daemon=True).start()
-    assert d.ready(5.0)
+    assert d.ready()
     return stop_event, docs_received
 
 
@@ -260,7 +260,7 @@ def test_zmq_prefix(proxy):
     d.subscribe(store_document)
     d.subscribe(stop_doc_watcher)
     threading.Thread(target=d.start, daemon=True).start()
-    assert d.ready(5.0)
+    assert d.ready()
 
     local_docs = []
 
@@ -565,7 +565,7 @@ def test_remote_dispatcher_ready_success():
 
         dispatcher_thread = threading.Thread(target=dispatcher.start, daemon=True)
         dispatcher_thread.start()
-        assert dispatcher.ready(timeout=2), "readiness was not signaled within timeout"
+        assert dispatcher.ready(), "readiness was not signaled within timeout"
         assert recv_event.wait(timeout=2), "recv was not called within timeout"
         dispatcher.stop()
 
@@ -587,7 +587,7 @@ def test_remote_dispatcher_handshake_timeout_in_thread():
     dispatcher_thread.start()
 
     # Caller in another thread sees the connection never succeeded.
-    assert not dispatcher.ready(timeout=0.1), "ready should return False on handshake timeout"
+    assert not dispatcher.ready(), "ready should return False on handshake timeout"
 
     dispatcher_thread.join(timeout=2)
     assert not dispatcher_thread.is_alive(), "dispatcher thread did not exit after timeout"
@@ -600,7 +600,7 @@ def test_remote_dispatcher_handshake_wait_without_handshake_timeout_configured()
 
     dispatcher = RemoteDispatcher("localhost:5841")
     with pytest.raises(RuntimeError):
-        dispatcher.ready(1.0)
+        dispatcher.ready()
 
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/src/bluesky/tests/test_zmq.py
+++ b/src/bluesky/tests/test_zmq.py
@@ -609,15 +609,20 @@ def test_remote_dispatcher_stop_from_other_thread():
 
     stop() is synchronous, so once it returns the dispatcher is fully torn down.
     """
-    dispatcher = RemoteDispatcher("127.0.0.1:60611")  # nothing listening
-    thread = threading.Thread(target=dispatcher.start, daemon=True)
-    thread.start()
-    try:
+    recv_event = threading.Event()
+
+    async def mock_recv():
+        recv_event.set()
+        await asyncio.Event().wait()
+
+    with patch("zmq.asyncio.Socket.recv", side_effect=mock_recv):
+        dispatcher = RemoteDispatcher("127.0.0.1:60611")  # nothing listening
+        thread = threading.Thread(target=dispatcher.start, daemon=True)
+        thread.start()
+        recv_event.wait(timeout=5)
+        assert recv_event.is_set()
         dispatcher.stop()
         assert dispatcher.closed
         assert dispatcher._task is None
         assert dispatcher._socket is None
         assert dispatcher._context is None
-    finally:
-        thread.join(timeout=5)
-    assert not thread.is_alive()

--- a/src/bluesky/tests/test_zmq.py
+++ b/src/bluesky/tests/test_zmq.py
@@ -638,7 +638,7 @@ def test_configure_server_socket_server_curve(
 def test_remote_dispatcher_connection_timeout():
     """Test that RemoteDispatcher times out when handshake doesn't complete."""
 
-    dispatcher = RemoteDispatcher("localhost:5841", connection_timeout=0.1)
+    dispatcher = RemoteDispatcher("localhost:5841", connection_timeout=0.00001)
 
     with pytest.raises(asyncio.TimeoutError):
         dispatcher.start()
@@ -671,24 +671,17 @@ def test_remote_dispatcher_connection_success():
     ):
         dispatcher = RemoteDispatcher("localhost:5841", connection_timeout=5.0)
 
-        def run_dispatcher():
-            try:
-                dispatcher.start()
-            except asyncio.CancelledError:
-                pass
-
-        dispatcher_thread = threading.Thread(target=run_dispatcher, daemon=True)
+        dispatcher_thread = threading.Thread(target=dispatcher.start, daemon=True)
         dispatcher_thread.start()
         assert dispatcher.wait_for_connection(timeout=2), "handshake was not signaled within timeout"
         assert recv_event.wait(timeout=2), "recv was not called within timeout"
-        dispatcher.loop.call_soon_threadsafe(dispatcher.stop)
-        dispatcher_thread.join()
+        dispatcher.stop()
 
 
 def test_remote_dispatcher_connection_timeout_in_thread():
     """Test that handshake failure is observable from another thread via wait_for_connection."""
 
-    dispatcher = RemoteDispatcher("localhost:5841", connection_timeout=0.01)
+    dispatcher = RemoteDispatcher("localhost:5841", connection_timeout=0.0001)
 
     exceptions = []
 

--- a/src/bluesky/tests/test_zmq.py
+++ b/src/bluesky/tests/test_zmq.py
@@ -119,11 +119,11 @@ def dispatcher():
 
     # On Windows, zmq.asyncio requires SelectorEventLoop (not ProactorEventLoop)
     loop = asyncio.SelectorEventLoop() if sys.platform == "win32" else None
-    d = RemoteDispatcher("127.0.0.1:5568", loop=loop, connection_timeout=5.0)
+    d = RemoteDispatcher("127.0.0.1:5568", loop=loop, handshake_timeout=5.0)
     d.subscribe(store_document)
     d.subscribe(stop_doc_watcher)
     threading.Thread(target=d.start, daemon=True).start()
-    assert d.wait_for_connection(5.0)
+    assert d.ready(5.0)
     return stop_event, docs_received
 
 
@@ -255,12 +255,12 @@ def test_zmq_prefix(proxy):
     d = RemoteDispatcher(
         "127.0.0.1:5568",
         prefix=b"sb",
-        connection_timeout=5.0,
+        handshake_timeout=5.0,
     )
     d.subscribe(store_document)
     d.subscribe(stop_doc_watcher)
     threading.Thread(target=d.start, daemon=True).start()
-    assert d.wait_for_connection(5.0)
+    assert d.ready(5.0)
 
     local_docs = []
 
@@ -527,17 +527,17 @@ def test_configure_server_socket_server_curve(
         assert f"Bound to address: {expected_addr}" in caplog.text
 
 
-def test_remote_dispatcher_connection_timeout():
+def test_remote_dispatcher_handshake_timeout():
     """Test that RemoteDispatcher times out when handshake doesn't complete."""
 
-    dispatcher = RemoteDispatcher("localhost:5841", connection_timeout=0.00001)
+    dispatcher = RemoteDispatcher("localhost:5841", handshake_timeout=0.00001)
 
     with pytest.raises(asyncio.TimeoutError):
         dispatcher.start()
 
 
-def test_remote_dispatcher_connection_success():
-    """Test that RemoteDispatcher succeeds when handshake completes. It should process 1 message and exit."""
+def test_remote_dispatcher_ready_success():
+    """Test that RemoteDispatcher is ready. It should process 1 message and exit."""
 
     recv_event = threading.Event()
 
@@ -561,19 +561,19 @@ def test_remote_dispatcher_connection_success():
         patch("zmq.asyncio.Socket.connect"),
         patch("zmq.asyncio.Socket.recv", side_effect=mock_recv),
     ):
-        dispatcher = RemoteDispatcher("localhost:5841", connection_timeout=5.0)
+        dispatcher = RemoteDispatcher("localhost:5841", handshake_timeout=5.0)
 
         dispatcher_thread = threading.Thread(target=dispatcher.start, daemon=True)
         dispatcher_thread.start()
-        assert dispatcher.wait_for_connection(timeout=2), "handshake was not signaled within timeout"
+        assert dispatcher.ready(timeout=2), "readiness was not signaled within timeout"
         assert recv_event.wait(timeout=2), "recv was not called within timeout"
         dispatcher.stop()
 
 
-def test_remote_dispatcher_connection_timeout_in_thread():
-    """Test that handshake failure is observable from another thread via wait_for_connection."""
+def test_remote_dispatcher_handshake_timeout_in_thread():
+    """Test that handshake failure is observable from another thread."""
 
-    dispatcher = RemoteDispatcher("localhost:5841", connection_timeout=0.0001)
+    dispatcher = RemoteDispatcher("localhost:5841", handshake_timeout=0.0001)
 
     exceptions = []
 
@@ -587,9 +587,7 @@ def test_remote_dispatcher_connection_timeout_in_thread():
     dispatcher_thread.start()
 
     # Caller in another thread sees the connection never succeeded.
-    assert not dispatcher.wait_for_connection(timeout=0.1), (
-        "wait_for_connection should return False on handshake timeout"
-    )
+    assert not dispatcher.ready(timeout=0.1), "ready should return False on handshake timeout"
 
     dispatcher_thread.join(timeout=2)
     assert not dispatcher_thread.is_alive(), "dispatcher thread did not exit after timeout"
@@ -597,12 +595,12 @@ def test_remote_dispatcher_connection_timeout_in_thread():
     assert isinstance(exceptions[0], asyncio.TimeoutError)
 
 
-def test_remote_dispatcher_handshake_wait_without_connection_timeout_configured():
-    """Test that handshake wait fails when not using handshake monitoring."""
+def test_remote_dispatcher_handshake_wait_without_handshake_timeout_configured():
+    """Test that ready wait fails when not using handshake monitoring."""
 
     dispatcher = RemoteDispatcher("localhost:5841")
     with pytest.raises(RuntimeError):
-        dispatcher.wait_for_connection(1.0)
+        dispatcher.ready(1.0)
 
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")

--- a/src/bluesky/tests/test_zmq.py
+++ b/src/bluesky/tests/test_zmq.py
@@ -119,12 +119,11 @@ def dispatcher():
 
     # On Windows, zmq.asyncio requires SelectorEventLoop (not ProactorEventLoop)
     loop = asyncio.SelectorEventLoop() if sys.platform == "win32" else None
-    d = RemoteDispatcher("127.0.0.1:5568", loop=loop)
+    d = RemoteDispatcher("127.0.0.1:5568", loop=loop, connection_timeout=5.0)
     d.subscribe(store_document)
     d.subscribe(stop_doc_watcher)
     threading.Thread(target=d.start, daemon=True).start()
-    # TODO: Replace sleep with handshake event wait
-    time.sleep(_ZMQ_CONNECTION_TIMEOUT)
+    assert d.wait_for_connection(5.0)
     return stop_event, docs_received
 
 
@@ -256,13 +255,12 @@ def test_zmq_prefix(proxy):
     d = RemoteDispatcher(
         "127.0.0.1:5568",
         prefix=b"sb",
-        # On Windows, zmq.asyncio requires SelectorEventLoop (not ProactorEventLoop)
-        loop=asyncio.SelectorEventLoop() if sys.platform == "win32" else None,
+        connection_timeout=5.0,
     )
     d.subscribe(store_document)
     d.subscribe(stop_doc_watcher)
     threading.Thread(target=d.start, daemon=True).start()
-    time.sleep(_ZMQ_CONNECTION_TIMEOUT)  # TODO: Replace sleep with handshake event wait
+    assert d.wait_for_connection(5.0)
 
     local_docs = []
 
@@ -608,8 +606,6 @@ def test_remote_dispatcher_stop_from_other_thread():
     dispatcher = RemoteDispatcher("127.0.0.1:60611")  # nothing listening
     thread = threading.Thread(target=dispatcher.start, daemon=True)
     thread.start()
-    # Allow the loop and poll task to start.
-    time.sleep(0.5)
     try:
         dispatcher.stop()
         assert dispatcher.closed

--- a/src/bluesky/tests/test_zmq.py
+++ b/src/bluesky/tests/test_zmq.py
@@ -694,7 +694,7 @@ def test_remote_dispatcher_connection_timeout_in_thread():
 
     dispatcher = RemoteDispatcher("localhost:5841", connection_timeout=0.01)
 
-    exceptions: list[BaseException] = []
+    exceptions = []
 
     def run_dispatcher():
         try:


### PR DESCRIPTION
## Description
Adds a feature to the `RemoteDispatcher` that allows a user to wait for a handshake event on the ZMQ socket, even if the dispatcher is started on a separate thread.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The only alternative to this was to sleep for a few seconds and assume the dispatcher is ready.

As described in #2014 , when used as part of a closed-loop decision making system, it can suffer from ZMQ's late-joiner problem, where messages were published before the sub socket was ready to receive them. In this scenario, the closed-loop decision making system would start the `RemoteDispatcher` to listen to events, then immediately launch an Bluesky plan. Without properly waiting for the `RemoteDispatcher` to connect, the start of the Bluesky plan could easily be missed.

Closes #2014 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Unit tests were added with mocks for the ZMQ parts
- This should also fix flakiness in [Blop's queueserver tutorial](https://blueskyproject.io/blop/main/tutorials/queueserver.html)

## Notes

This late joiner issue is also a problem on the `Publisher` side when connecting to a `Proxy`. If this PR is merged I can follow-up with a handshake fix for that.
<!--
## Screenshots (if appropriate):
-->
