### PR TITLE
Add Pixi and type fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true -diff

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,8 @@ lockfiles/
 .vscode/tags
 
 .hypothesis/
+
+# pixi environments
+.pixi/*
+!.pixi/config.toml
+pixi.lock

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,14 @@
+[workspace]
+authors = ["thomashopkins32 <thopkins1@bnl.gov>"]
+channels = ["conda-forge"]
+name = "bluesky"
+platforms = ["linux-64"]
+version = "1.15.1"
+
+[tasks]
+
+[dependencies]
+python = "*"
+
+[pypi-dependencies]
+bluesky = { path = ".", editable = true, extras = ["all"] }

--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -1217,11 +1217,13 @@ class RunBundler:
                 await self._prepare_stream(name, obj_set)
                 continue
 
-    async def _cache_describe_collect(self, obj):
+    async def _cache_describe_collect(self, obj: Flyable):
         "Read the object's describe_collect and cache it."
         if obj not in self._describe_collect_cache:
-            obj = check_supports(obj, Collectable)
-            c: dict[str, DataKey] | dict[str, dict[str, DataKey]] = await maybe_await(obj.describe_collect())
+            collectable_obj = cast(Collectable, check_supports(obj, Collectable))
+            c: dict[str, DataKey] | dict[str, dict[str, DataKey]] = await maybe_await(
+                collectable_obj.describe_collect()
+            )
             self._describe_collect_cache[obj] = c
 
     async def _ensure_cached(self, obj, collect: bool = False):

--- a/src/bluesky/tests/test_olog_cb.py
+++ b/src/bluesky/tests/test_olog_cb.py
@@ -1,7 +1,7 @@
 from bluesky import Msg
 from bluesky.callbacks.olog import logbook_cb_factory
 
-text = []
+text: list[str] = []
 
 
 def f(**kwargs):

--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -1040,8 +1040,8 @@ def get_history():
             return historydict.HistoryDict(":memory:")
 
 
-_QT_KICKER_INSTALLED = {}
-_NB_KICKER_INSTALLED = {}
+_QT_KICKER_INSTALLED: dict = {}
+_NB_KICKER_INSTALLED: dict = {}
 
 
 def install_kicker(loop=None, update_rate=0.03):


### PR DESCRIPTION


## Description
- Adds the smallest possible `pixi.toml` 
- Fixes type checking issues causing failed builds 

## Motivation and Context
Pixi is a useful tool (could have chosen `uv` as well, but I like Pixi for conda-forge non-python dependencies). It can be expanded further later, this was the minimal needed for development workflows.

Type checking tests were failing, so I took this opportunity to fix them.

## How Has This Been Tested?
`pixi run mypy src` runs without error.

<!--
## Screenshots (if appropriate):
-->
