### PR TITLE
Cancel any in-progress CI jobs when additional commits are pushed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Cancel in-progress CI workflows if a subsequent commit is pushed to the same PR branch.


## Motivation and Context
The test suite takes quite a long time to complete, and generally only the most recent commit's CI status is checked. This allows for tighter iteration times in CI without requiring local checks.

## How Has This Been Tested?
I've enabled this feature for the `tiled` and `queueserver` repositories, both of which also have long-running test suites.
