### PR TITLE
BUG: suppress OpenTelemetry import warning

### DIFF
--- a/src/bluesky/run_engine.py
+++ b/src/bluesky/run_engine.py
@@ -20,8 +20,6 @@ from warnings import warn
 
 import event_model
 from event_model import DocumentNames
-from opentelemetry import trace
-from opentelemetry.trace import Span
 
 from bluesky._vendor.super_state_machine.errors import TransitionError
 from bluesky._vendor.super_state_machine.extras import PropertyMachine
@@ -44,7 +42,7 @@ from .protocols import (
     Triggerable,
     check_supports,
 )
-from .tracing import tracer
+from .tracing import get_current_span, tracer
 from .utils import (
     AsyncInput,
     CallbackRegistry,
@@ -70,6 +68,11 @@ from .utils import (
 )
 
 _SPAN_NAME_PREFIX = "Bluesky RunEngine"
+
+if typing.TYPE_CHECKING:
+    from opentelemetry.trace import Span
+else:
+    Span = typing.Any
 
 current_task: typing.Callable[[asyncio.AbstractEventLoop | None], asyncio.Task | None]
 try:
@@ -2175,7 +2178,7 @@ class RunEngine:
 
         where <GROUP> is a hashable identifier.
         """
-        _set_span_msg_attributes(trace.get_current_span(), msg)
+        _set_span_msg_attributes(get_current_span(), msg)
         kwargs = dict(msg.kwargs)
         group = kwargs.pop("group", None)
         obj = check_supports(msg.obj, Flyable)
@@ -2196,7 +2199,7 @@ class RunEngine:
             Msg('collect', flyer_object)
             Msg('collect', flyer_object, stream=True, return_payload=False, name="a_name")
         """
-        _set_span_msg_attributes(trace.get_current_span(), msg)
+        _set_span_msg_attributes(get_current_span(), msg)
         run_key = msg.run
         if (
             current_run := self._run_bundlers.get(run_key, key_absence_sentinel := object())
@@ -2233,7 +2236,7 @@ class RunEngine:
 
         where arguments are passed through to `obj.set(*args, **kwargs)`.
         """
-        _set_span_msg_attributes(trace.get_current_span(), msg)
+        _set_span_msg_attributes(get_current_span(), msg)
         obj = check_supports(msg.obj, Movable)
         kwargs = dict(msg.kwargs)
         group = kwargs.pop("group", None)
@@ -2280,7 +2283,7 @@ class RunEngine:
 
         where ``<GROUP>`` is any hashable key and ``<ERROR_ON_TIMEOUT>`` is a boolean.
         """
-        _set_span_msg_attributes(trace.get_current_span(), msg)
+        _set_span_msg_attributes(get_current_span(), msg)
         done = False  # boolean that tracks whether waiting is complete
         if msg.args:
             (group,) = msg.args
@@ -2290,9 +2293,9 @@ class RunEngine:
         watch = msg.kwargs.get("watch", ())
         watch_task: asyncio.Task | None = None
         if group:
-            trace.get_current_span().set_attribute("group", group)
+            get_current_span().set_attribute("group", group)
         else:
-            trace.get_current_span().set_attribute("no_group_given", True)
+            get_current_span().set_attribute("no_group_given", True)
         futs = self._groups.pop(group, set())
         if futs:
             status_objs = self._status_objs.pop(group)

--- a/src/bluesky/tests/test_run_engine.py
+++ b/src/bluesky/tests/test_run_engine.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import signal
+import subprocess
 import sys
 import threading
 import time as ttime
@@ -52,6 +53,26 @@ from bluesky.tests.utils import DocCollector, MsgCollector
 from bluesky.utils import SigintHandler
 
 from .utils import _careful_event_set, _fabricate_asycio_event
+
+
+def test_run_engine_import_with_deprecation_warnings_as_errors():
+    src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, [src_path, env.get("PYTHONPATH", "")]))
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-W",
+            "error::DeprecationWarning",
+            "-c",
+            "import bluesky.run_engine",
+        ],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
 
 
 def test_states():

--- a/src/bluesky/tracing.py
+++ b/src/bluesky/tracing.py
@@ -1,11 +1,21 @@
 import functools
 from collections.abc import Callable
 from typing import cast
-
-from opentelemetry.trace import Tracer, get_tracer
+from warnings import catch_warnings, filterwarnings
 
 from .protocols import P
 from .utils import MsgGenerator
+
+_OTEL_ENTRY_POINTS_DEPRECATION = "SelectableGroups dict interface is deprecated. Use select."
+
+with catch_warnings():
+    filterwarnings(
+        "ignore",
+        message=_OTEL_ENTRY_POINTS_DEPRECATION,
+        category=DeprecationWarning,
+    )
+    from opentelemetry.trace import Tracer, get_tracer
+    from opentelemetry.trace import get_current_span as get_current_span
 
 tracer = get_tracer(__name__)
 


### PR DESCRIPTION
## Description

This suppresses the known OpenTelemetry/importlib-metadata `SelectableGroups dict interface is deprecated. Use select.` warning only while importing `opentelemetry.trace`. `run_engine.py` now obtains `get_current_span()` from the local tracing module instead of importing `opentelemetry.trace` directly at module import time.

It also adds a regression that imports `bluesky.run_engine` in a subprocess with `DeprecationWarning` treated as an error.

## Motivation and Context

Fixes #2020. Downstream projects that run tests with warnings as errors can fail during collection before any RunEngine code is used, because importing `bluesky.run_engine` imports OpenTelemetry and triggers this dependency warning.

## How Has This Been Tested?

Not run locally.
Static validation was limited to Git whitespace checks: `git diff --check`, `git diff --cached --check`, and `git diff --check HEAD~1..HEAD`.

## Disclosure

This PR is AI-assisted. I am responsible for the proposed change and for responding to review feedback.