### PR TITLE
DOC: document run metadata serialization requirement

### DIFF
--- a/src/bluesky/preprocessors.py
+++ b/src/bluesky/preprocessors.py
@@ -357,7 +357,8 @@ def run_wrapper(plan, *, md=None):
     plan : iterable or iterator
         a generator, list, or similar containing `Msg` objects
     md : dict, optional
-        metadata to be passed into the 'open_run' message
+        metadata to be passed into the 'open_run' message. Values must be
+        JSON-serializable and compatible with the event-model RunStart schema.
     """
     rs_uid = yield from open_run(md)
 


### PR DESCRIPTION
## Description

Document that metadata passed through `run_wrapper` / `run_decorator` must be JSON-serializable and compatible with the event-model RunStart schema.

## Motivation and Context

Closes #1913. The issue asks for this restriction to be visible at the preprocessor docstring level, so users know not to pass arbitrary Python objects into run metadata.

## How Has This Been Tested?

Not run locally.

Static Git checks passed:
- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- `git show --check --stat --oneline HEAD`

Remote CI:
- Passing: `check / pr`, `lint / run`, `docs / build`, `dist / build`, Checkmarx, Codecov, Ubuntu tests, Windows 3.10/3.11/3.13 tests
- Failing: `test (windows-latest, 3.12) / run` in `src/bluesky/tests/test_suspenders.py::test_suspender_wrapper[True]` with a timing assertion (`0.8798 > 0.9` expected), outside the changed docstring