### PR TITLE
Parse `object_classes` of described objects and add them to the event descriptor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 description = "Experiment specification & orchestration."
 dependencies = [
     "cycler",
-    "event-model>=1.23.1",
+    "event-model>=1.24.0",
     "historydict",
     "msgpack",
     "msgpack-numpy",

--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -274,6 +274,7 @@ class RunBundler:
         data_keys = {}
         config = {}
         object_keys = {}
+        object_classes = {}
         hints: dict[str, Any] = {}
 
         for obj, dks in objs_dks.items():
@@ -282,6 +283,8 @@ class RunBundler:
             object_keys[obj.name] = list(dks)
             for key in dks.keys():
                 dks[key]["object_name"] = obj.name
+            obj_t = obj.__class__
+            object_classes[obj.name] = f"{obj_t.__module__}.{obj_t.__qualname__}"
             data_keys.update(dks)
             config[obj.name] = {
                 "data": self._current_stream_cache.config_values_cache[obj],
@@ -295,6 +298,7 @@ class RunBundler:
             configuration=config,
             hints=hints,
             object_keys=object_keys,
+            object_classes=object_classes,
         )
         await self.emit(DocumentNames.descriptor, self._descriptors[desc_key].descriptor_doc)
         doc_logger.debug(

--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -283,7 +283,10 @@ class RunBundler:
             object_keys[obj.name] = list(dks)
             for key in dks.keys():
                 dks[key]["object_name"] = obj.name
-            obj_t = obj.__class__
+            if isinstance(obj, type):
+                obj_t = obj  # To handle static readables
+            else:
+                obj_t = type(obj)  # type: ignore
             object_classes[obj.name] = f"{obj_t.__module__}.{obj_t.__qualname__}"
             data_keys.update(dks)
             config[obj.name] = {

--- a/src/bluesky/tests/test_external_assets_and_paging.py
+++ b/src/bluesky/tests/test_external_assets_and_paging.py
@@ -646,9 +646,9 @@ def test_object_classes(RE):
         def read(self):
             return {f"{self.name}-sig1": Reading(value=0, timestamp=123)}
 
-    class SomeStaticReadable:
+    class SomeClassReadable:
         parent = None
-        name = "some_static_readble"
+        name = "some_class_readble"
 
         @classmethod
         def describe(cls):
@@ -658,13 +658,28 @@ def test_object_classes(RE):
         def read(cls):
             return {f"{cls.name}-sig1": Reading(value=0, timestamp=123)}
 
+    class SomeStaticReadable:
+        parent = None
+        name = "some_static_readble"
+
+        @staticmethod
+        def describe():
+            return {"some_static_readble-sig1": DataKey(source="pv", dtype="number", shape=[])}
+
+        @staticmethod
+        def read():
+            return {"some_static_readble-sig1": Reading(value=0, timestamp=123)}
+
     docs = DocHolder()
 
-    RE(bp.count([SomeReadable(), axis, SomeStaticReadable]), docs.append)
+    RE(bp.count([SomeReadable(), axis, SomeStaticReadable, SomeClassReadable]), docs.append)  # type: ignore
     assert len(docs["descriptor"]) == 1
     descriptor = docs["descriptor"][0]
     assert descriptor["object_classes"] == {
         "det1": "ophyd.sim.SynAxis",
+        "some_class_readble": (
+            "bluesky.tests.test_external_assets_and_paging.test_object_classes.<locals>.SomeClassReadable"
+        ),
         "some_readble": "bluesky.tests.test_external_assets_and_paging.test_object_classes.<locals>.SomeReadable",
         "some_static_readble": (
             "bluesky.tests.test_external_assets_and_paging.test_object_classes.<locals>.SomeStaticReadable"

--- a/src/bluesky/tests/test_external_assets_and_paging.py
+++ b/src/bluesky/tests/test_external_assets_and_paging.py
@@ -24,6 +24,7 @@ from bluesky.protocols import (
     WritesExternalAssets,
     WritesStreamAssets,
 )
+from bluesky.tests import requires_ophyd
 
 
 class DocHolder(dict):
@@ -624,3 +625,48 @@ def test_multiple_declare_in_same_stream(RE):
     assert docs["descriptor"][1]["name"] == "main"
     assert frozenset(docs["descriptor"][1]["data_keys"]) == frozenset(data_keys)
     assert all(d["descriptor"] == docs["descriptor"][1]["uid"] for d in docs["stream_datum"][4:])
+
+
+@requires_ophyd
+def test_object_classes(RE):
+    from ophyd.sim import SynAxis  # type: ignore
+
+    axis = SynAxis(name="det1")
+
+    class SomeReadable:
+        parent = None
+
+        @property
+        def name(self):
+            return "some_readble"
+
+        def describe(self):
+            return {f"{self.name}-sig1": DataKey(source="pv", dtype="number", shape=[])}
+
+        def read(self):
+            return {f"{self.name}-sig1": Reading(value=0, timestamp=123)}
+
+    class SomeStaticReadable:
+        parent = None
+        name = "some_static_readble"
+
+        @classmethod
+        def describe(cls):
+            return {f"{cls.name}-sig1": DataKey(source="pv", dtype="number", shape=[])}
+
+        @classmethod
+        def read(cls):
+            return {f"{cls.name}-sig1": Reading(value=0, timestamp=123)}
+
+    docs = DocHolder()
+
+    RE(bp.count([SomeReadable(), axis, SomeStaticReadable]), docs.append)
+    assert len(docs["descriptor"]) == 1
+    descriptor = docs["descriptor"][0]
+    assert descriptor["object_classes"] == {
+        "det1": "ophyd.sim.SynAxis",
+        "some_readble": "bluesky.tests.test_external_assets_and_paging.test_object_classes.<locals>.SomeReadable",
+        "some_static_readble": (
+            "bluesky.tests.test_external_assets_and_paging.test_object_classes.<locals>.SomeStaticReadable"
+        ),
+    }


### PR DESCRIPTION
Closes #2013 

The bluesky component of the above issue. This should be merged and released alongside event-model with https://github.com/bluesky/event-model/pull/375