### PR TITLE
Fix docs build and type checking

### DIFF
--- a/docs/multi_run_plans.rst
+++ b/docs/multi_run_plans.rst
@@ -219,6 +219,7 @@ when the run opened.
 
 .. ipython:: python
     :suppress:
+    :okwarning:
 
     %run -m multi_run_plans_sequential
 
@@ -251,6 +252,7 @@ the table for the 'outer' run.
 
 .. ipython:: python
     :suppress:
+    :okwarning:
 
     %run -m multi_run_plans_nested
 
@@ -280,6 +282,7 @@ performs callback subscriptions.
 
 .. ipython:: python
     :suppress:
+    :okwarning:
 
     %run -m multi_run_plans_select_cb
 
@@ -305,6 +308,7 @@ before at each call.
 
 .. ipython:: python
     :suppress:
+    :okwarning:
 
     %run -m multi_run_plans_recursive
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,6 +9,8 @@ version = "1.15.1"
 
 [dependencies]
 python = "*"
+pip = ">=26.1.2,<27"
+graphviz = ">=14.1.2,<15"
 
 [pypi-dependencies]
 bluesky = { path = ".", editable = true, extras = ["all"] }

--- a/src/bluesky/callbacks/tiled_writer.py
+++ b/src/bluesky/callbacks/tiled_writer.py
@@ -370,11 +370,16 @@ class RunNormalizer(CallbackBase):
             # 5. If unable to do any of the above, do not set 'dtype_numpy' at all.
             dtype_descr = data_keys_spec.pop("dtype_descr", [])  # type: ignore
             dtype_str = data_keys_spec.pop("dtype_str", None)  # type: ignore
-            if dtype_numpy := (
-                list(map(list, dtype_descr))
-                or data_keys_spec.get("dtype_numpy", dtype_str)
-                or JSON_TO_NUMPY_DTYPE.get(data_keys_spec["dtype"])
-            ):
+            dtype_numpy: str | list[tuple[str, str]] | None
+            if dtype_descr:
+                dtype_numpy = [(str(name), str(dt)) for name, dt in dtype_descr]
+            elif "dtype_numpy" in data_keys_spec:
+                dtype_numpy = data_keys_spec["dtype_numpy"]
+            elif dtype_str:
+                dtype_numpy = dtype_str
+            else:
+                dtype_numpy = JSON_TO_NUMPY_DTYPE.get(data_keys_spec["dtype"])
+            if dtype_numpy:
                 data_keys_spec["dtype_numpy"] = dtype_numpy
 
         # Ensure that all event data_keys have object_name assigned (for consistency)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds `:okwarning:` directives to sphinx `ipython::` blocks where warnings from dependencies were coming from.

Fixes type checking on tiled writer's use of `dtype_numpy`.

Also adds some dependencies to run `tox` and build the docs using pixi.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Starlette, one of TIled's dependencies, is producing warnings now which causes the docs build to fail since warnings are treated as errors by default.

```
bluesky/.pixi/envs/default/lib/python3.14/site-packages/tiled/client/context.py:249: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
  from starlette.testclient import TestClient
```

Type inference from `mypy` was also failing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A if docs CI job now passes
<!--
## Screenshots (if appropriate):
-->
