### PR TITLE
ENH: Added during_task setter and getter to RunEngine

### DIFF
--- a/src/bluesky/run_engine.py
+++ b/src/bluesky/run_engine.py
@@ -613,7 +613,7 @@ class RunEngine:
         --------
         >>> from bluesky import RunEngine
         >>> RE = RunEngine(during_task=CustomDuringTask())
-        >>> RE.during_task 
+        >>> RE.during_task
         """
         return self._during_task
 

--- a/src/bluesky/run_engine.py
+++ b/src/bluesky/run_engine.py
@@ -604,6 +604,32 @@ class RunEngine:
         # return as a list, not lazy loader, no surprises...
         return list(self._command_registry.keys())
 
+    @property
+    def during_task(self):
+        """
+        Property to access during_task after RunEngine initialization
+
+        Examples
+        --------
+        >>> from bluesky import RunEngine
+        >>> RE = RunEngine(during_task=CustomDuringTask())
+        >>> RE.during_task 
+        """
+        return self._during_task
+
+    @during_task.setter
+    def during_task(self, value):
+        """
+        Property to set during_task after the RunEngine has initialized
+
+        Examples
+        --------
+        >>> from bluesky import RunEngine
+        >>> RE = RunEngine()
+        >>> RE.during_task = CustomDuringTask()
+        """
+        self._during_task = value
+
     def print_command_registry(self, verbose=False):
         """
         This conveniently prints the command registry of available

--- a/src/bluesky/tests/test_run_engine.py
+++ b/src/bluesky/tests/test_run_engine.py
@@ -49,7 +49,7 @@ from bluesky.run_engine import (
 from bluesky.suspenders import SuspendBoolHigh
 from bluesky.tests import requires_ophyd, uses_os_kill_sigint
 from bluesky.tests.utils import DocCollector, MsgCollector
-from bluesky.utils import SigintHandler
+from bluesky.utils import DefaultDuringTask, DuringTask, SigintHandler
 
 from .utils import _careful_event_set, _fabricate_asycio_event
 
@@ -79,6 +79,28 @@ def test_panic_trap(RE):
 def test_state_is_readonly(RE):
     with pytest.raises(AttributeError):
         RE.state = "running"
+
+
+def test_during_task_property(RE):
+    # Default during_task is a DefaultDuringTask instance
+    assert isinstance(RE.during_task, DefaultDuringTask)
+
+    # The getter returns the underlying private attribute
+    assert RE.during_task is RE._during_task
+
+    # The setter replaces it and is reflected by the getter
+    custom = DuringTask()
+    RE.during_task = custom
+    assert RE.during_task is custom
+    assert RE._during_task is custom
+
+
+def test_during_task_constructor_injection():
+    # during_task passed to the constructor is exposed via the property
+    custom = DuringTask()
+    RE = RunEngine({}, during_task=custom)
+    assert RE.during_task is custom
+    assert RE._during_task is custom
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Added during_task setter and getter to the RunEngine to allow users to set it after initializing it

## Description
Added `@property` and `setter` to set private self._during_task. Added simple tests along with it

## Motivation and Context
This will allow a user to set during_task on an already initialized RE instance, for example a RunEngine initialized in a startup profile can later be integrated into a simple qt GUI, instead of pumping the Qt event loop via matplotlib imports one can write and attach their own DuringTask object. This also avoids directly assigning a DuringTask object to the private _during_task.

## How Has This Been Tested?
Added tests to test suite

