### PR TITLE
MNT: use `TypeIs` for type narrowing in `iterate_maybe_async`

### DIFF
--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -1995,12 +1995,16 @@ def maybe_update_hints(hints: dict[str, Hints], obj):
         hints[obj.name] = obj.hints
 
 
+def _isasyncgen(iterator: SyncOrAsyncIterator[T]) -> TypeIs[AsyncIterator[T]]:
+    return inspect.isasyncgen(iterator)
+
+
 async def iterate_maybe_async(iterator: SyncOrAsyncIterator[T]) -> AsyncIterator[T]:
-    if inspect.isasyncgen(iterator):
+    if _isasyncgen(iterator):
         async for v in iterator:
             yield v
     else:
-        for v in iterator:  # type: ignore
+        for v in iterator:
             yield v
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Uses `TypeIs` to correctly narrow the type of `SyncOrAsyncIterator` through `inspect.isasyncgen`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Noticed in the last batch of commits this type error was introduced (not sure how).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`tox -e type-checking` locally.

<!--
## Screenshots (if appropriate):
-->
