### PR TITLE
Loosen RE metadata type hint

### DIFF
--- a/src/bluesky/run_engine.py
+++ b/src/bluesky/run_engine.py
@@ -9,7 +9,7 @@ import threading
 import typing
 import weakref
 from collections import ChainMap, defaultdict, deque
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, MutableMapping
 from contextlib import ExitStack
 from dataclasses import dataclass
 from datetime import datetime
@@ -405,7 +405,7 @@ class RunEngine:
 
     def __init__(
         self,
-        md: Mapping | None = None,
+        md: MutableMapping | None = None,
         *,
         loop: asyncio.AbstractEventLoop | None = None,
         preprocessors: list | None = None,

--- a/src/bluesky/run_engine.py
+++ b/src/bluesky/run_engine.py
@@ -9,7 +9,7 @@ import threading
 import typing
 import weakref
 from collections import ChainMap, defaultdict, deque
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from contextlib import ExitStack
 from dataclasses import dataclass
 from datetime import datetime
@@ -200,7 +200,7 @@ class LoggingPropertyMachine(PropertyMachine):
             return super().__get__(instance, owner)
 
 
-def default_scan_id_source(md):
+def default_scan_id_source(md: Mapping) -> int:
     return md.get("scan_id", 0) + 1
 
 
@@ -405,14 +405,14 @@ class RunEngine:
 
     def __init__(
         self,
-        md: dict | None = None,
+        md: Mapping | None = None,
         *,
         loop: asyncio.AbstractEventLoop | None = None,
         preprocessors: list | None = None,
         context_managers: list | None = None,
         md_validator: typing.Callable | None = None,
         md_normalizer: typing.Callable | None = None,
-        scan_id_source: typing.Callable[[dict], SyncOrAsync[int]] = default_scan_id_source,
+        scan_id_source: typing.Callable[[Mapping], SyncOrAsync[int]] = default_scan_id_source,
         during_task: DuringTask | None = None,
         call_returns_result: bool = False,
     ):

--- a/src/bluesky/tests/test_metadata.py
+++ b/src/bluesky/tests/test_metadata.py
@@ -1,3 +1,5 @@
+from collections.abc import MutableMapping
+
 import event_model
 import ophyd
 
@@ -73,3 +75,46 @@ def test_md_mormalizer(RE):
     assert "test" in start_doc
     assert start_doc["test"] == 1
     assert start_doc["a"]["b"]["c"] is not metadata["a"]["b"]["c"]
+
+
+class CustomMapping(MutableMapping):
+    """A MutableMapping subclass to test that RE.md accepts non-dict mappings."""
+
+    def __init__(self, *args, **kwargs):
+        self._store = dict(*args, **kwargs)
+
+    def __getitem__(self, key):
+        return self._store[key]
+
+    def __setitem__(self, key, value):
+        self._store[key] = value
+
+    def __delitem__(self, key):
+        del self._store[key]
+
+    def __iter__(self):
+        return iter(self._store)
+
+    def __len__(self):
+        return len(self._store)
+
+
+def test_mutable_mapping_as_md(RE):
+    """Test that RE.md works with a MutableMapping subclass instead of dict."""
+    md = CustomMapping({"project": "test_project", "sample": "sample_1"})
+    RE.md = md
+    RE.md.setdefault("versions", {})
+
+    assert RE.md["project"] == "test_project"
+    assert RE.md["sample"] == "sample_1"
+
+    start_doc = None
+
+    def test_callback(name, doc):
+        nonlocal start_doc
+        if name == "start":
+            start_doc = doc
+
+    RE(count([]), test_callback)
+    assert start_doc["project"] == "test_project"
+    assert start_doc["sample"] == "sample_1"


### PR DESCRIPTION
Without this, `MutableMapping` subclasses like `RedisJSONDict` would be flagged by static analysis type checking as invalid inputs to `RunEngine.__init__`.

- **Loosen type hint for RE.md to be Mapping instead of dict**
- **Type must be mutable. Add unit test that confirms behavior, type checker passes**
