### PR TITLE
BUG: restore stream cache after describe_collect

### DIFF
--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -813,24 +813,27 @@ class RunBundler:
                 f"streams: {duplicates.keys()}",
             )
 
-        for stream_name, stream_data_keys in describe_collect_items:
-            # Will this be okay left at last stream?
-            self._set_current_stream_cache(stream_name)
-            # Should we make the describe_cache the describe_collect_cache?
-            self._current_stream_cache.describe_cache[collect_object] = stream_data_keys
-            await self._current_stream_cache.ensure_cached(collect_object, collect=True)
+        current_stream_cache = self._current_stream_cache
+        try:
+            for stream_name, stream_data_keys in describe_collect_items:
+                self._set_current_stream_cache(stream_name)
+                # Should we make the describe_cache the describe_collect_cache?
+                self._current_stream_cache.describe_cache[collect_object] = stream_data_keys
+                await self._current_stream_cache.ensure_cached(collect_object, collect=True)
 
-            if stream_name not in self._descriptor_objs or (
-                collect_object not in self._descriptor_objs[stream_name]
-            ):
-                await self._prepare_stream(stream_name, {collect_object: stream_data_keys})
-            else:
-                objs_read = self._descriptor_objs[stream_name]
-                if stream_data_keys != objs_read[collect_object]:
-                    raise RuntimeError(
-                        f"Mismatched objects read, expected {stream_data_keys!s}, got {objs_read!s}"
-                    )
-            local_descriptors[frozenset(stream_data_keys)] = self._descriptors[stream_name]
+                if stream_name not in self._descriptor_objs or (
+                    collect_object not in self._descriptor_objs[stream_name]
+                ):
+                    await self._prepare_stream(stream_name, {collect_object: stream_data_keys})
+                else:
+                    objs_read = self._descriptor_objs[stream_name]
+                    if stream_data_keys != objs_read[collect_object]:
+                        raise RuntimeError(
+                            f"Mismatched objects read, expected {stream_data_keys!s}, got {objs_read!s}"
+                        )
+                local_descriptors[frozenset(stream_data_keys)] = self._descriptors[stream_name]
+        finally:
+            self._current_stream_cache = current_stream_cache
 
         self._local_descriptors[collect_object] = local_descriptors
 

--- a/src/bluesky/tests/test_flyer.py
+++ b/src/bluesky/tests/test_flyer.py
@@ -6,8 +6,10 @@ import pytest
 from event_model.documents.event import PartialEvent
 from ophyd import Component as Cpt
 from ophyd import Device
-from ophyd.sim import NullStatus, StatusBase, TrivialFlyer
+from ophyd.sim import MockFlyer, NullStatus, StatusBase, TrivialFlyer, det, det1, motor
 
+import bluesky.plan_stubs as bps
+import bluesky.preprocessors as bpp
 from bluesky import Msg
 from bluesky.plan_stubs import (
     close_run,
@@ -286,6 +288,37 @@ def test_flyer_descriptor(RE, hw):
     print(f"trivial flyer descriptor: {trivial_flyer_descriptor}")
     assert len(trivial_flyer_descriptor["configuration"]) == 1
     assert "trivial_flyer" in trivial_flyer_descriptor["object_keys"]
+
+
+@requires_ophyd
+def test_collect_between_read_and_save_keeps_stream_caches_isolated(RE):
+    flyer = MockFlyer("flyer1", det1, motor, 1, 5, 20)
+    documents = defaultdict(list)
+
+    @bpp.run_decorator()
+    @bpp.stage_decorator([det, flyer])
+    def plan():
+        yield from bps.create()
+        yield from bps.kickoff(flyer)
+        yield from bps.read(det1)
+        yield from bps.collect(flyer)
+        yield from bps.save()
+
+    RE(plan(), lambda name, doc: documents[name].append(doc))
+
+    descriptors = {doc["uid"]: doc for doc in documents["descriptor"]}
+    events = [*documents["event"], *documents["event_page"]]
+    primary = next(doc for doc in documents["descriptor"] if doc["name"] == "primary")
+    assert set(primary["data_keys"]) == {"det1"}
+    assert any(
+        set(doc["data"]) == set(doc["timestamps"]) == {"det1"}
+        for doc in events
+        if doc["descriptor"] == primary["uid"]
+    )
+    assert all(
+        set(doc["data"]) == set(doc["timestamps"]) == set(descriptors[doc["descriptor"]]["data_keys"])
+        for doc in events
+    )
 
 
 @requires_ophyd


### PR DESCRIPTION
## Description

Restore the active event-bundle stream cache after `_describe_collect()` temporarily switches across flyer streams. A `try`/`finally` keeps subsequent `save()` processing on the cache that was active before descriptor preparation.

## Motivation and Context

Fixes #2010.

`_describe_collect()` previously left the last collect-stream cache active. A later `save()` therefore validated the primary event against the wrong, empty cache and raised an event-model validation error.

## How Has This Been Tested?

- Added a regression test for `create -> kickoff -> read -> collect -> save`, including descriptor/data/timestamp consistency checks.
- Verified artifact run: `src/bluesky/tests/test_flyer.py` — 28 passed.
- Revalidated against current `main`: the two upstream files are byte-identical to the tested base, the patch applies cleanly, the resulting file hashes match the tested artifacts, both changed files compile, and `git diff --check` passes.
- The current isolated runner lacks `setuptools_scm` and `event_model`; no dependency was installed, so pytest was not repeated in that runner.

## AI assistance disclosure

This contribution and PR text were prepared by an AI coding agent under user authorization. The agent reproduced the bug, implemented the minimal fix, added the regression test, and rechecked the current upstream issue, duplicate, policy, and source state. Test results above are reported exactly.
