### PR TITLE
Replace assertion statements with explicit check + raise

### DIFF
--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -10,9 +10,11 @@ from typing import Any, Literal, TypeAlias, TypeGuard, cast
 
 from event_model import (
     ComposeDescriptorBundle,
+    ComposeEvent,
     DataKey,
     Datum,
     DocumentNames,
+    EventDescriptor,
     EventModelValueError,
     Resource,
     StreamDatum,
@@ -268,7 +270,7 @@ class RunBundler:
         self,
         desc_key: str,
         objs_dks: dict[HasName, dict[str, DataKey]],
-    ):
+    ) -> tuple[EventDescriptor, ComposeEvent, list[HasName]]:
         # We do not have an Event Descriptor for this set
         # so one must be created.
         data_keys = {}
@@ -322,14 +324,20 @@ class RunBundler:
             list(objs_dks),
         )
 
-    async def declare_stream(self, msg):
+    async def declare_stream(self, msg: Msg) -> tuple[EventDescriptor, ComposeEvent, list[HasName]]:
         """Generate and emit an EventDescriptor."""
-        command, no_obj, objs, kwargs, _ = msg
+        _, no_obj, objs, kwargs, _ = msg
         stream_name = kwargs.get("name")
-        assert stream_name is not None, "A stream name that is not None is required for pre-declare"
+        if stream_name is None:
+            raise ValueError(
+                "A stream name that is not None is required for pre-declare."
+            )
 
         collect = kwargs.get("collect", False)
-        assert no_obj is None
+        if no_obj is not None:
+            raise ValueError(
+                "The 'declare_stream' Msg does not accept positional arguments."
+            )
         objs = frozenset(objs)
         objs_dks = {}  # {collect_object: stream_data_keys}
 
@@ -344,10 +352,11 @@ class RunBundler:
                 )
 
                 # ensure that there is only one stream and it is the stream we have provided.
-                assert len(streams_and_data_keys) == 1 and streams_and_data_keys[0][0] == stream_name, (
-                    "`declare_stream` contained `collect=True` but  `describe_collect` did "
-                    f"not return a single Dict[str, DataKey] for the passed in {stream_name}"
-                )
+                if len(streams_and_data_keys) != 1 or streams_and_data_keys[0][0] != stream_name:
+                    raise ValueError(
+                        "`declare_stream` contained `collect=True` but  `describe_collect` did "
+                        f"not return a single Dict[str, DataKey] for the passed in {stream_name}"
+                    )
             else:
                 data_keys = self._current_stream_cache.describe_cache[obj]
 
@@ -366,7 +375,7 @@ class RunBundler:
             self._current_stream_cache = _StreamCache()
             self._saved_stream_cache[stream_name] = self._current_stream_cache
 
-    async def create(self, msg):
+    async def create(self, msg: Msg):
         """
         Start bundling future obj.read() calls for an Event document.
 
@@ -485,18 +494,20 @@ class RunBundler:
         def emit_event(readings: dict[str, Reading] | None = None, *args, **kwargs):
             if readings is not None:
                 # We were passed something we can use, but check no args or kwargs
-                assert not args and not kwargs, (
-                    "If subscribe callback called with readings, args and kwargs are not supported."
-                )
+                if args or kwargs:
+                    raise ValueError(
+                        "If subscribe callback called with readings, args and kwargs are not supported."
+                    )
             else:
                 # Ignore the inputs. Use this call as a signal to call read on the
                 # object, a crude way to be sure we get all the info we need.
                 readable_obj = check_supports(obj, Readable)  # type: ignore
                 readings = readable_obj.read()  # type: ignore
-                assert not inspect.isawaitable(readings), (
-                    f"{readable_obj} has async read() method and the callback "
-                    "passed to subscribe() was not called with Dict[str, Reading]"
-                )
+                if inspect.isawaitable(readings):
+                    raise RuntimeError(
+                        f"{readable_obj} has async read() method and the callback "
+                        "passed to subscribe() was not called with Dict[str, Reading]"
+                    )
             data, timestamps = _rearrange_into_parallel_dicts(readings)
             doc = compose_event(
                 data=data,
@@ -792,9 +803,8 @@ class RunBundler:
         def is_data_key(obj: Any) -> bool:
             return isinstance(obj, dict) and {"dtype", "shape", "source"}.issubset(frozenset(obj.keys()))
 
-        assert all(not is_data_key(value) for value in describe_collect.values()), (
-            "Single nested data keys should be pre-declared"
-        )
+        if not all(not is_data_key(value) for value in describe_collect.values()):
+            raise RuntimeError("Single nested data keys should be pre-declared")
 
         # Make sure you can't use identical data keys in multiple streams
         # Data structure is assumed to be dict[stream_name, dictionary of key -> data_key]
@@ -978,7 +988,10 @@ class RunBundler:
                 objs_read = frozenset(partial_event["data"])
                 compose_event = local_descriptors[objs_read].compose_event
                 data_keys = local_descriptors[objs_read].descriptor_doc["data_keys"]
-                assert frozenset(data_keys.keys()) == objs_read
+                if frozenset(data_keys.keys()) != objs_read:
+                    raise RuntimeError(
+                        f"Mismatched objects read, expected {frozenset(data_keys.keys())!s}, got {objs_read!s}"
+                    )
 
             if [x for x in self.get_external_data_keys(data_keys) if x in partial_event["data"]]:
                 raise RuntimeError("Received an event containing data for external data keys.")
@@ -1105,12 +1118,17 @@ class RunBundler:
         # If a stream name was provided in the message, check the stream has been declared
         # If one was not provided, but a single stream has been declared, then use that stream.
         if message_stream_name:
-            assert message_stream_name in declared_stream_names, (
-                "If a message stream name is provided declare stream needs to be called first."
-            )
+            if not message_stream_name in declared_stream_names:
+                raise RuntimeError(
+                    "If a message stream name is provided declare stream needs to be called first."
+                )
             stream_name = message_stream_name
         elif declared_stream_names:
-            assert len(frozenset(declared_stream_names)) == 1  # Allow duplicate declarations
+            if len(frozenset(declared_stream_names)) != 1:
+                raise RuntimeError(
+                    "If multiple streams have been declared for the collect objects, "
+                    "a message stream name must be provided to collect."
+                )
             stream_name = declared_stream_names[0]
 
         # If there is not a stream then we should be using an old-style doubly nested

--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -324,20 +324,18 @@ class RunBundler:
             list(objs_dks),
         )
 
-    async def declare_stream(self, msg: Msg) -> tuple[EventDescriptor, ComposeEvent, list[dict[HasName, dict[str, DataKey]]]]:
+    async def declare_stream(
+        self, msg: Msg
+    ) -> tuple[EventDescriptor, ComposeEvent, list[dict[HasName, dict[str, DataKey]]]]:
         """Generate and emit an EventDescriptor."""
         _, no_obj, objs, kwargs, _ = msg
         stream_name = kwargs.get("name")
         if stream_name is None:
-            raise ValueError(
-                "A stream name that is not None is required for pre-declare."
-            )
+            raise ValueError("A stream name that is not None is required for pre-declare.")
 
         collect = kwargs.get("collect", False)
         if no_obj is not None:
-            raise ValueError(
-                "The 'declare_stream' Msg does not accept positional arguments."
-            )
+            raise ValueError("The 'declare_stream' Msg does not accept positional arguments.")
         objs = frozenset(objs)
         objs_dks = {}  # {collect_object: stream_data_keys}
 
@@ -1118,10 +1116,8 @@ class RunBundler:
         # If a stream name was provided in the message, check the stream has been declared
         # If one was not provided, but a single stream has been declared, then use that stream.
         if message_stream_name:
-            if not message_stream_name in declared_stream_names:
-                raise RuntimeError(
-                    "If a message stream name is provided declare stream needs to be called first."
-                )
+            if message_stream_name not in declared_stream_names:
+                raise RuntimeError("If a message stream name is provided declare stream needs to be called first.")
             stream_name = message_stream_name
         elif declared_stream_names:
             if len(frozenset(declared_stream_names)) != 1:

--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -270,7 +270,7 @@ class RunBundler:
         self,
         desc_key: str,
         objs_dks: dict[HasName, dict[str, DataKey]],
-    ) -> tuple[EventDescriptor, ComposeEvent, list[HasName]]:
+    ) -> tuple[EventDescriptor, ComposeEvent, list[dict[HasName, dict[str, DataKey]]]]:
         # We do not have an Event Descriptor for this set
         # so one must be created.
         data_keys = {}
@@ -324,7 +324,7 @@ class RunBundler:
             list(objs_dks),
         )
 
-    async def declare_stream(self, msg: Msg) -> tuple[EventDescriptor, ComposeEvent, list[HasName]]:
+    async def declare_stream(self, msg: Msg) -> tuple[EventDescriptor, ComposeEvent, list[dict[HasName, dict[str, DataKey]]]]:
         """Generate and emit an EventDescriptor."""
         _, no_obj, objs, kwargs, _ = msg
         stream_name = kwargs.get("name")

--- a/src/bluesky/plans.py
+++ b/src/bluesky/plans.py
@@ -213,7 +213,8 @@ def list_scan(
 
     # add the motor-based hints
     _md["hints"] = derive_default_hints(motors)
-    assert isinstance(_md["hints"], dict), "Hints must be a dictionary"
+    if not isinstance(_md["hints"], dict):
+        raise TypeError("Hints must be a dictionary")
     # override any hints from the original md (if  exists)
     _md["hints"].update(md.get("hints", {}))
 
@@ -348,7 +349,8 @@ def list_grid_scan(
     _md.update(md or {})  # type: ignore
     try:
         motor_hints = [(m.hints["fields"], "primary") for m in motors]
-        assert isinstance(_md["hints"], dict), "Hints must be a dictionary"
+        if not isinstance(_md["hints"], dict):
+            raise RuntimeError("Hints must be a dictionary")
         _md["hints"].setdefault("dimensions", motor_hints)
     except (AttributeError, KeyError):
         ...

--- a/src/bluesky/protocols.py
+++ b/src/bluesky/protocols.py
@@ -524,7 +524,10 @@ def check_supports(obj: T, protocol: type[Any]) -> T:
         readable = check_supports(obj, Readable)
         readable.read()
     """
-    assert isinstance(obj, protocol), "%s does not implement all %s methods" % (obj, protocol.__name__)  # noqa: UP031
+    if not isinstance(obj, protocol):
+        raise TypeError(
+            "%s does not implement all %s methods" % (obj, protocol.__name__)
+        )
     return obj
 
 

--- a/src/bluesky/protocols.py
+++ b/src/bluesky/protocols.py
@@ -525,9 +525,7 @@ def check_supports(obj: T, protocol: type[Any]) -> T:
         readable.read()
     """
     if not isinstance(obj, protocol):
-        raise TypeError(
-            "%s does not implement all %s methods" % (obj, protocol.__name__)
-        )
+        raise TypeError("%s does not implement all %s methods" % (obj, protocol.__name__))
     return obj
 
 

--- a/src/bluesky/run_engine.py
+++ b/src/bluesky/run_engine.py
@@ -1549,7 +1549,10 @@ class RunEngine:
                     # If we are here, we have come back to life either to
                     # continue (resume) or to clean up before exiting.
 
-                assert len(self._response_stack) == len(self._plan_stack)
+                if len(self._response_stack) != len(self._plan_stack):
+                    raise RuntimeError(
+                        "The response stack and plan stack are out of sync. "
+                    )
                 # set resp to the sentinel so that if we fail in the sleep
                 # we do not add an extra response
                 resp = sentinel
@@ -1832,7 +1835,7 @@ class RunEngine:
             raise WaitForTimeoutError("Plan failed to complete in the specified time")
         return futs
 
-    async def _open_run(self, msg):
+    async def _open_run(self, msg: Msg):
         """Instruct the RunEngine to start a new "run"
 
         Expected message object is:
@@ -1888,7 +1891,7 @@ class RunEngine:
         self._run_start_uids.append(new_uid)
         return new_uid
 
-    async def _close_run(self, msg):
+    async def _close_run(self, msg: Msg):
         """Instruct the RunEngine to write the RunStop document
 
         Expected message object is:
@@ -1921,7 +1924,7 @@ class RunEngine:
         except IndexError:
             logger.warning("No open traces left to close!")
 
-    async def _create(self, msg):
+    async def _create(self, msg: Msg):
         """Trigger the run engine to start bundling future obj.read() calls for
          an Event document
 
@@ -1946,7 +1949,7 @@ class RunEngine:
             raise IllegalMessageSequence(ims_msg)
         return await current_run.create(msg)
 
-    async def _declare_stream(self, msg):
+    async def _declare_stream(self, msg: Msg):
         """Trigger the run engine to start bundling future obj.describe() calls for
          an Event document
 
@@ -1972,7 +1975,7 @@ class RunEngine:
             raise IllegalMessageSequence(ims_msg)
         return await current_run.declare_stream(msg)
 
-    async def _read(self, msg):
+    async def _read(self, msg: Msg):
         """
         Add a reading to the open event bundle.
 
@@ -2020,7 +2023,7 @@ class RunEngine:
         else:
             return list(await asyncio.gather(*coros))
 
-    async def _monitor(self, msg):
+    async def _monitor(self, msg: Msg):
         """
         Monitor a signal. Emit event documents asynchronously.
 
@@ -2047,7 +2050,7 @@ class RunEngine:
             await current_run.monitor(msg)
         await self._reset_checkpoint_state_coro()
 
-    async def _unmonitor(self, msg):
+    async def _unmonitor(self, msg: Msg):
         """
         Stop monitoring; i.e., remove the callback emitting event documents.
 
@@ -2065,7 +2068,7 @@ class RunEngine:
             await current_run.unmonitor(msg)
         await self._reset_checkpoint_state_coro()
 
-    async def _save(self, msg):
+    async def _save(self, msg: Msg):
         """Save the event that is currently being bundled
 
         Expected message object is:
@@ -2083,7 +2086,7 @@ class RunEngine:
         else:
             await current_run.save(msg)
 
-    async def _drop(self, msg):
+    async def _drop(self, msg: Msg):
         """Drop the event that is currently being bundled
 
         Expected message object is:
@@ -2099,7 +2102,7 @@ class RunEngine:
         else:
             await current_run.drop(msg)
 
-    async def _prepare(self, msg):
+    async def _prepare(self, msg: Msg):
         """Prepare a flyer for a flyscan
 
         Expected message object is:
@@ -2120,7 +2123,7 @@ class RunEngine:
 
         return ret
 
-    async def _kickoff(self, msg):
+    async def _kickoff(self, msg: Msg):
         """Start a flyscan object
 
         Special kwargs for the 'Msg' object in this function:
@@ -2160,7 +2163,7 @@ class RunEngine:
         return ret
 
     @tracer.start_as_current_span(f"{_SPAN_NAME_PREFIX} complete")
-    async def _complete(self, msg):
+    async def _complete(self, msg: Msg):
         """
         Tell a flyer, 'stop collecting, whenever you are ready'.
 
@@ -2188,7 +2191,7 @@ class RunEngine:
         return ret
 
     @tracer.start_as_current_span(f"{_SPAN_NAME_PREFIX} collect")
-    async def _collect(self, msg):
+    async def _collect(self, msg: Msg):
         """
         Collect data cached by a flyer and emit documents
 
@@ -2208,20 +2211,20 @@ class RunEngine:
 
         return await current_run.collect(msg)
 
-    async def _null(self, msg):
+    async def _null(self, msg: Msg):
         """
         A no-op message, mainly for debugging and testing.
         """
         pass
 
-    async def _RE_class(self, msg):
+    async def _RE_class(self, msg: Msg):
         """
         A no-op message, mainly for debugging and testing.
         """
         return type(self)
 
     @tracer.start_as_current_span(f"{_SPAN_NAME_PREFIX} set")
-    async def _set(self, msg):
+    async def _set(self, msg: Msg):
         """
         Set a device and cache the returned status object.
 
@@ -2245,7 +2248,7 @@ class RunEngine:
 
         return ret
 
-    async def _trigger(self, msg):
+    async def _trigger(self, msg: Msg):
         """
         Trigger a device and cache the returned status object.
 
@@ -2364,7 +2367,7 @@ class RunEngine:
             done = True
         return done
 
-    def _status_object_completed(self, ret, fut: asyncio.Future, pardon_failures):
+    def _status_object_completed(self, ret, fut: asyncio.Future, pardon_failures: asyncio.Event):
         """
         Task to run when a status object is finished.
 
@@ -2393,7 +2396,7 @@ class RunEngine:
         else:
             fut.set_result(None)
 
-    async def _sleep(self, msg):
+    async def _sleep(self, msg: Msg):
         """
         Sleep the event loop.
 
@@ -2405,7 +2408,7 @@ class RunEngine:
         """
         await asyncio.sleep(*msg.args, **self._loop_for_kwargs)
 
-    async def _pause(self, msg):
+    async def _pause(self, msg: Msg):
         """Request the run engine to pause
 
         Expected message object is:
@@ -2417,7 +2420,7 @@ class RunEngine:
         """
         await self._request_pause_coro(*msg.args, **msg.kwargs)
 
-    async def _resume(self, msg):
+    async def _resume(self, msg: Msg):
         """Request the run engine to resume
 
         Expected message object is:
@@ -2435,7 +2438,7 @@ class RunEngine:
             if isinstance(obj, Pausable):
                 await maybe_await(obj.resume())
 
-    async def _checkpoint(self, msg):
+    async def _checkpoint(self, msg: Msg):
         """Instruct the RunEngine to create a checkpoint so that we can rewind
         to this point if necessary
 
@@ -2470,7 +2473,7 @@ class RunEngine:
     async def _reset_checkpoint_state_coro(self):
         self._reset_checkpoint_state()
 
-    async def _clear_checkpoint(self, msg):
+    async def _clear_checkpoint(self, msg: Msg):
         """Clear a set checkpoint
 
         Expected message object is:
@@ -2483,7 +2486,7 @@ class RunEngine:
         for current_run in self._run_bundlers.values():
             await current_run.clear_checkpoint(msg)
 
-    async def _rewindable(self, msg):
+    async def _rewindable(self, msg: Msg):
         """Set rewindable state of RunEngine
 
         Expected message object is:
@@ -2497,7 +2500,7 @@ class RunEngine:
 
         return self.rewindable
 
-    async def _configure(self, msg):
+    async def _configure(self, msg: Msg):
         """Configure an object
 
         Expected message object is:
@@ -2540,7 +2543,7 @@ class RunEngine:
         self._groups[group].add(lambda: fut)
         self._status_objs[group].add(status_object)
 
-    async def _stage(self, msg):
+    async def _stage(self, msg: Msg):
         """Instruct the RunEngine to stage the object
 
         Expected message object is:
@@ -2563,7 +2566,7 @@ class RunEngine:
 
         return ret
 
-    async def _unstage(self, msg):
+    async def _unstage(self, msg: Msg):
         """Instruct the RunEngine to unstage the object
 
         Expected message object is:
@@ -2587,7 +2590,7 @@ class RunEngine:
 
         return ret
 
-    async def _stop(self, msg):
+    async def _stop(self, msg: Msg):
         """
         Stop a device.
 
@@ -2598,7 +2601,7 @@ class RunEngine:
         obj = check_supports(msg.obj, Stoppable)
         return await maybe_await(obj.stop())  # nominally, this returns None
 
-    async def _subscribe(self, msg):
+    async def _subscribe(self, msg: Msg):
         """
         Add a subscription after the run has started.
 
@@ -2630,7 +2633,7 @@ class RunEngine:
         await self._reset_checkpoint_state_coro()
         return token
 
-    async def _unsubscribe(self, msg):
+    async def _unsubscribe(self, msg: Msg):
         """
         Remove a subscription during a call -- useful for a multi-run call
         where subscriptions are wanted for some runs but not others.
@@ -2650,7 +2653,7 @@ class RunEngine:
         self._temp_callback_ids.remove(token)
         await self._reset_checkpoint_state_coro()
 
-    async def _input(self, msg):
+    async def _input(self, msg: Msg):
         """
         Process a 'input' Msg. Expected Msg:
 
@@ -2760,7 +2763,7 @@ class Dispatcher:
         self._token_mapping[public_token] = [private_token]
         return public_token
 
-    def unsubscribe(self, token):
+    def unsubscribe(self, token: int):
         """
         Unregister a callback function using its integer ID.
 
@@ -2895,5 +2898,6 @@ def autoawait_in_bluesky_event_loop(ip=None):
         import IPython
 
         ip = IPython.get_ipython()  # type: ignore
-    assert ip, "Couldn't import IPython"
+    if not ip:
+        raise RuntimeError("Couldn't import Ipython")
     ip.loop_runner = call_in_bluesky_event_loop

--- a/src/bluesky/run_engine.py
+++ b/src/bluesky/run_engine.py
@@ -1550,9 +1550,7 @@ class RunEngine:
                     # continue (resume) or to clean up before exiting.
 
                 if len(self._response_stack) != len(self._plan_stack):
-                    raise RuntimeError(
-                        "The response stack and plan stack are out of sync. "
-                    )
+                    raise RuntimeError("The response stack and plan stack are out of sync. ")
                 # set resp to the sentinel so that if we fail in the sleep
                 # we do not add an extra response
                 resp = sentinel

--- a/src/bluesky/simulators.py
+++ b/src/bluesky/simulators.py
@@ -423,7 +423,8 @@ def assert_message_and_return_remaining(
         return (group is not None and (msg.kwargs and msg.kwargs.get("group") != group)) or not predicate(msg)
 
     matched = list(dropwhile(not_matching, messages))
-    assert matched, f"Nothing matched predicate {predicate}"
+    if not matched:
+        raise AssertionError(f"Nothing matched predicate {predicate}")
     return matched
 
 

--- a/src/bluesky/suspenders.py
+++ b/src/bluesky/suspenders.py
@@ -154,7 +154,8 @@ class SuspenderBase(metaclass=ABCMeta):
 
     def __make_event(self):
         """Make or return the asyncio.Event to use as a bridge."""
-        assert self._lock.locked()
+        if not self._lock.locked():
+            raise RuntimeError("This method should be called with the lock held")
         if self._ev is None and self.RE is not None:
             if threading.get_ident() == getattr(self.RE._loop, "_thread_id", "unknown"):
                 self._ev = asyncio.Event()
@@ -173,7 +174,8 @@ class SuspenderBase(metaclass=ABCMeta):
 
     def __set_event(self, loop):
         """Notify the event that it can resume"""
-        assert self._lock.locked()
+        if not self._lock.locked():
+            raise RuntimeError("This method should be called with the lock held")
         if self._ev:
             ev = self._ev
             sleep = self._sleep

--- a/src/bluesky/tests/test_external_assets_and_paging.py
+++ b/src/bluesky/tests/test_external_assets_and_paging.py
@@ -397,7 +397,7 @@ def test_collect_stream_true_raises(RE):
 
 def test_predeclare_requires_stream_name(RE):
     with pytest.raises(
-        AssertionError,
+        ValueError,
         match=re.escape("A stream name that is not None is required for pre-declare"),
     ):
         RE(collect_plan(OldPvCollectable(name="det"), pre_declare=True))
@@ -405,7 +405,7 @@ def test_predeclare_requires_stream_name(RE):
 
 def test_new_style_with_steam_name_requires_pre_declare(RE):
     with pytest.raises(
-        AssertionError,
+        RuntimeError,
         match=re.escape("If a message stream name is provided declare stream needs to be called first."),
     ):
         RE(collect_plan(StreamDatumReadableCollectable(name="det"), pre_declare=False, stream_name="main"))
@@ -413,7 +413,7 @@ def test_new_style_with_steam_name_requires_pre_declare(RE):
 
 def test_new_style_with_no_stream_name_and_no_pre_declare_does_not_try_and_make_a_stream(RE):
     with pytest.raises(
-        AssertionError,
+        RuntimeError,
         match=re.escape("Single nested data keys should be pre-declared"),
     ):
         RE(collect_plan(StreamDatumReadableCollectable(name="det"), pre_declare=False))
@@ -501,7 +501,7 @@ def test_pv_collectable(RE, cls):
 
 def test_new_collect_needs_predeclare(RE):
     with pytest.raises(
-        AssertionError,
+        RuntimeError,
         match="Single nested data keys should be pre-declared",
     ):
         RE(collect_plan(PvCollectable(name="det"), pre_declare=False))
@@ -539,7 +539,7 @@ def test_many_collectables_fails(RE, cls1, cls2):
     """If there are multiple objects they must all WritesStreamAssests"""
     det1, det2 = cls1(name="det1"), cls2(name="det2")
     with pytest.raises(
-        AssertionError,
+        TypeError,
         match=re.escape("does not implement all WritesStreamAssets methods"),
     ):
         RE(collect_plan(det1, det2, pre_declare=False))

--- a/src/bluesky/utils/__init__.py
+++ b/src/bluesky/utils/__init__.py
@@ -1821,7 +1821,8 @@ class DefaultDuringTask(DuringTask):
                 app = QtWidgets.QApplication.instance()
                 if app is None:
                     _qapp = app = QtWidgets.QApplication(["bluesky"])
-                assert app is not None
+                if app is None:
+                    raise RuntimeError("Failed to create QApplication instance.")
                 event_loop = QtCore.QEventLoop()
 
                 def start_killer_thread():


### PR DESCRIPTION
Assert statements are removed when running with a `-O` flag, and so should not be used in production code except for code quality checks / type narrowing. Replaced all instances outside of tests with explicit check + raise. Also adjusted some type hints, and fixed any tests that had watched for an AssertionError

- **Replace assert statements with explicit checks + raises in non test code. Update type hints in several places**
- **Fix some typing issues**
- **Apply ruff formatter**
