### PR TITLE
CI: run workflows on merge_group events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
   pull_request:
+  merge_group:
 
 jobs:
   check:


### PR DESCRIPTION
This is needed if anyone ever turns on the merge queue. Until someone does, this is a no-op.