### PR TITLE
MNT: drop the prologue argument from PlanExecutor.run

### DIFF
--- a/src/bluesky/plan_executor.py
+++ b/src/bluesky/plan_executor.py
@@ -807,7 +807,7 @@ class PlanExecutor:
             registry.pop(name, None)
         self.command_registry = registry
 
-    def _load_plan(self, plan, *, metadata=None, prologue=None):
+    def _load_plan(self, plan, *, metadata=None):
         """Put a plan on the stack, ready to be run.
 
         Parameters
@@ -816,9 +816,6 @@ class PlanExecutor:
             The plan to execute. The session's preprocessors are applied to it.
         metadata : dict, optional
             Metadata for every run this plan opens.
-        prologue : iterable of Msg, optional
-            Messages to work off before the plan itself, used to wait for
-            tripped suspenders before starting.
         """
         self._plan = plan  # this ref is just used for metadata introspection
         if metadata:
@@ -830,9 +827,6 @@ class PlanExecutor:
 
         self._plan_stack.append(gen)
         self._response_stack.append(None)
-        if prologue is not None:
-            self._plan_stack.append(prologue)
-            self._response_stack.append(None)
 
     async def prepare_resume(self):
         """Get ready to resume from a pause. Must be called on the loop."""
@@ -845,6 +839,19 @@ class PlanExecutor:
         for obj in self._objs_seen:
             if isinstance(obj, Pausable):
                 await maybe_await(obj.resume())
+
+    def _push_suspend(self, fut, *, pre_plan=None, post_plan=None, justification=None):
+        """Push the ``_start_suspender`` machinery onto the plan stack.
+
+        Shared by :meth:`request_suspend`, for a suspender that trips mid-plan,
+        and by :meth:`run`, for one already tripped before the plan starts.
+        Pushing onto the stack -- so that it is worked off before whatever is
+        beneath it -- is all the two cases have in common. Interrupting
+        whatever is currently running is left to the caller: at plan start
+        there is nothing running yet to interrupt.
+        """
+        self._plan_stack.append(single_gen(Msg("_start_suspender", None, pre_plan, post_plan, justification, fut)))
+        self._response_stack.append(None)
 
     async def request_suspend(self, fut, *, pre_plan=None, post_plan=None, justification=None):
         """Suspend until ``fut`` is finished. Must be called on the loop."""
@@ -860,9 +867,7 @@ class PlanExecutor:
         if justification is not None:
             print(f"Justification for this suspension:\n{justification}")
 
-        # add starting the suspender logic to the stack
-        self._plan_stack.append(single_gen(Msg("_start_suspender", None, pre_plan, post_plan, justification, fut)))
-        self._response_stack.append(None)
+        self._push_suspend(fut, pre_plan=pre_plan, post_plan=post_plan, justification=justification)
 
         # The event loop is still running. The pre_plan will be processed,
         # and then the executor will be hung up on processing the
@@ -871,6 +876,43 @@ class PlanExecutor:
             self.state = "suspending"
             # bump the run task out of what ever it is awaiting
             self._task.cancel()
+
+    def _queue_tripped_suspenders(self):
+        """Wait for any suspender that is already tripped before the plan starts.
+
+        ``RunEngine.__call__`` used to build this as a bespoke 'prologue'
+        generator, pushed directly onto the stack ahead of the plan and
+        containing nothing but a single ``wait_for``. It goes instead through
+        the same ``_start_suspender`` machinery a mid-plan suspension uses --
+        one push per tripped suspender, via :meth:`_push_suspend` -- rather
+        than a second copy of the suspend logic to keep in sync with the
+        first.
+
+        Not :meth:`request_suspend` itself: that also stashes an interrupt
+        exception and cancels the in-progress task, which is right when a
+        suspender trips while a plan is already running. Here there is no
+        task yet -- this runs before `run` reaches the line that sets
+        ``self._task`` -- and nothing to interrupt.
+        """
+        tripped = []
+        for sup in self._session.suspenders:
+            futs, justification = sup.get_futures()
+            if futs:
+                tripped.append((futs[0], justification))
+
+        if not tripped:
+            return
+
+        print(
+            "At least one suspender has tripped. The plan will begin when all suspenders are ready. Justification:"
+        )
+        for i, (_, justification) in enumerate(tripped):
+            print(f"    {i + 1}. {justification}")
+        print()
+        print("Suspending... To get to the prompt, hit Ctrl-C twice to pause.")
+
+        for fut, justification in tripped:
+            self._push_suspend(fut, justification=justification)
 
     async def _stop_movable_objects(self, *, success=True):
         "Call obj.stop() for all objects we have moved. Log any exceptions."
@@ -889,7 +931,7 @@ class PlanExecutor:
             _span.set_attribute("exit_status", "aborted")
             _span.end()
 
-    async def run(self, plan, *, metadata=None, prologue=None):
+    async def run(self, plan, *, metadata=None):
         """Execute ``plan``.
 
         Awaiting this is all that is needed to run a plan::
@@ -903,9 +945,6 @@ class PlanExecutor:
             The plan to execute. The session's preprocessors are applied to it.
         metadata : dict, optional
             Metadata for every run the plan opens.
-        prologue : iterable of Msg, optional
-            Messages to work off before the plan itself, used by a `RunEngine`
-            to wait for tripped suspenders before starting.
 
         Returns
         -------
@@ -923,7 +962,8 @@ class PlanExecutor:
         - Try to remove any monitoring subscriptions left on by the plan.
         - If interrupting the middle of a run, try to emit a RunStop document.
         """
-        self._load_plan(plan, metadata=metadata, prologue=prologue)
+        self._load_plan(plan, metadata=metadata)
+        self._queue_tripped_suspenders()
         await self._run_permit.wait()
         # grab the current task.  We need to do this here because the
         # object returned by `run_coroutine_threadsafe` is a future

--- a/src/bluesky/run_engine.py
+++ b/src/bluesky/run_engine.py
@@ -54,7 +54,6 @@ from .utils import (
     RunEngineInterrupted,
     SigintHandler,
     Subscribers,
-    single_gen,
 )
 
 # What this module defines, plus the names it has always passed through from
@@ -783,25 +782,6 @@ class RunEngine:
         if not self._session.state.is_idle:
             raise RuntimeError(f"The RunEngine is in a {self._session.state} state")
 
-        futs = []
-        tripped_justifications = []
-        for sup in self.suspenders:
-            f_lst, justification = sup.get_futures()
-            if f_lst:
-                futs.extend(f_lst)
-                tripped_justifications.append(justification)
-
-        if tripped_justifications:
-            print(
-                "At least one suspender has tripped. The plan will begin "
-                "when all suspenders are ready. Justification:"
-            )
-            for i, justification in enumerate(tripped_justifications):
-                print(f"    {i + 1}. {justification}")
-
-            print()
-            print("Suspending... To get to the prompt, hit Ctrl-C twice to pause.")
-
         self._new_executor(subs)
         self.log.info("Executing plan %r", plan)
 
@@ -810,12 +790,7 @@ class RunEngine:
             self._executor.block_run()
             self._blocking_event.clear()
             self._task_fut = asyncio.run_coroutine_threadsafe(
-                self._executor.run(
-                    plan,
-                    metadata=metadata_kw,
-                    # Wait for any already-tripped suspenders before starting.
-                    prologue=single_gen(Msg("wait_for", None, futs)) if futs else None,
-                ),
+                self._executor.run(plan, metadata=metadata_kw),
                 loop=self.loop,
             )
 

--- a/src/bluesky/tests/test_plan_executor.py
+++ b/src/bluesky/tests/test_plan_executor.py
@@ -222,3 +222,11 @@ def test_request_pause_coro_survives_for_queueserver(RE):
         RE(plan())
     assert RE.state == "paused"
     RE.stop()
+
+
+def test_run_no_longer_takes_a_prologue():
+    """prologue used to be how a RunEngine had run() wait for already-tripped
+    suspenders before starting the plan proper. That is now expressed through
+    the same _start_suspender machinery a mid-plan suspend uses (see
+    test_suspenders.py::test_pretripped), so run() has no more use for it."""
+    assert "prologue" not in inspect.signature(PlanExecutor.run).parameters

--- a/src/bluesky/tests/test_suspenders.py
+++ b/src/bluesky/tests/test_suspenders.py
@@ -254,8 +254,42 @@ def test_pretripped(RE, hw):
     RE.msg_hook = accum
     RE(scan)
 
-    assert len(msg_lst) == 2
-    assert ["wait_for", "checkpoint"] == [m[0] for m in msg_lst]
+    # Waiting for an already-tripped suspender goes through the same
+    # _start_suspender machinery as a mid-plan suspend (see
+    # test_pre_suspend_plan), rather than a single bespoke 'wait_for', so the
+    # msg_hook sees that machinery's messages ahead of the plan's own.
+    assert [
+        "_start_suspender",
+        "rewindable",
+        "wait_for",
+        "_resume_from_suspender",
+        "rewindable",
+        "checkpoint",
+    ] == [m[0] for m in msg_lst]
+    assert RE.state == "idle"
+
+
+def test_pretripped_plan_runs_to_completion_after_release(RE, hw):
+    """A suspender already tripped when RE(plan) is called holds the plan back
+    until it clears, then the plan's own messages run in order and the
+    RunEngine ends idle -- the behaviour prologue used to provide."""
+    sig = hw.bool_sig
+    scan = [Msg("open_run"), Msg("close_run")]
+    msg_lst = []
+    sig.put(0)
+
+    susp = SuspendBoolLow(sig, sleep=0)
+    RE.install_suspender(susp)
+    RE.msg_hook = lambda msg: msg_lst.append(msg.command)
+    threading.Timer(0.5, sig.put, (1,)).start()
+
+    start = ttime.time()
+    RE(scan)
+    stop = ttime.time()
+
+    assert stop - start > 0.5
+    assert [m for m in msg_lst if m in ("open_run", "close_run")] == ["open_run", "close_run"]
+    assert RE.state == "idle"
 
 
 def test_suspender_wrapper(RE, hw):
@@ -399,9 +433,20 @@ def test_pause_from_suspend(RE, hw):
     RE.msg_hook = accum
     with pytest.raises(RunEngineInterrupted):
         RE(scan)
-    assert [m[0] for m in msg_lst] == ["wait_for"]
+    # Waiting for the already-tripped suspender goes through _start_suspender,
+    # same as a mid-plan suspend (see test_pretripped), so the pause catches
+    # it still inside that machinery rather than at a bare 'wait_for'.
+    assert [m[0] for m in msg_lst] == ["_start_suspender", "rewindable", "wait_for"]
     RE.resume()
-    assert ["wait_for", "wait_for", "checkpoint"] == [m[0] for m in msg_lst]
+    assert [
+        "_start_suspender",
+        "rewindable",
+        "wait_for",
+        "rewindable",
+        "_resume_from_suspender",
+        "rewindable",
+        "checkpoint",
+    ] == [m[0] for m in msg_lst]
 
 
 def test_suspend_when_changed_preserves_falsy_expected_value(hw):
@@ -448,9 +493,26 @@ def test_deferred_pause_from_suspend(RE, hw):
     RE.msg_hook = accum
     with pytest.raises(RunEngineInterrupted):
         RE(scan)
-    assert [m[0] for m in msg_lst] == ["wait_for", "checkpoint"]
+    # See test_pretripped: waiting for the already-tripped suspender goes
+    # through _start_suspender, same as a mid-plan suspend.
+    assert [m[0] for m in msg_lst] == [
+        "_start_suspender",
+        "rewindable",
+        "wait_for",
+        "_resume_from_suspender",
+        "rewindable",
+        "checkpoint",
+    ]
     RE.resume()
-    assert ["wait_for", "checkpoint", "null"] == [m[0] for m in msg_lst]
+    assert [
+        "_start_suspender",
+        "rewindable",
+        "wait_for",
+        "_resume_from_suspender",
+        "rewindable",
+        "checkpoint",
+        "null",
+    ] == [m[0] for m in msg_lst]
 
 
 def test_unresumable_suspend_fail(RE):


### PR DESCRIPTION
## Description

**Draft. Stacked on #2050 (which is stacked on #2052, #1806, #1923), so review those first.**

Removes the `prologue` keyword argument from `PlanExecutor.run` / `PlanExecutor._load_plan`. A `RunEngine` used it for exactly one thing: waiting for any suspender that was already tripped when `RE(plan)` was called, before the plan itself starts. That wait is now expressed through the same `_start_suspender` machinery a mid-plan suspension uses, rather than a bespoke `single_gen(Msg('wait_for', None, futs))` pushed directly onto the stack.

### The design

`PlanExecutor` gets a new private method, `_queue_tripped_suspenders`, called from the top of `run()` right after `_load_plan`. It consults `self._session.suspenders` itself, so `RunEngine.__call__` passes nothing at all -- the collect-futures-and-print-a-message block that used to live there is gone along with the `futs`/`prologue` plumbing.

For each tripped suspender it pushes the same `Msg('_start_suspender', None, pre_plan, post_plan, justification, fut)` a mid-plan suspend pushes, via a new shared helper, `_push_suspend`, factored out of `request_suspend`'s tail. `_push_suspend` is the part of the mechanism the two cases actually have in common -- put this onto the stack so it is worked off before whatever is beneath it. `request_suspend` still does its own checkpoint-abort check and `self._task.cancel()` around the call to it; `_queue_tripped_suspenders` does neither.

### What I rejected, and why

**Calling `request_suspend` itself at the top of `run()`.** This is what "reuse the same mechanism" suggests first, and it does not work:

- It calls `self._task.cancel()` unconditionally (when not already paused), but `self._task` is only assigned a few lines later in `run()`, after `await self._run_permit.wait()`. A naive call hits `AttributeError: 'NoneType' object has no attribute 'cancel'`.
- `_start_suspender` -- which `request_suspend` schedules -- calls `_stop_movable_objects()` and notifies every object in `self._objs_seen` of a pause. Both are no-ops before the plan has touched anything, so harmless here, but they exist to interrupt an in-progress plan, which there isn't one of yet.
- The `if not self.resumable:` abort guard is, as it happens, never true at this point (`_msg_cache` is a fresh empty deque, not `None`, until something rewinds or clears the checkpoint) -- but relying on that is fragile, and the guard's own `self._task.cancel()` branch has the same `None` problem above.

None of this is fatal on its own -- `self._task` could be assigned before the suspender check, the no-ops are genuinely harmless -- but stitching it together this way makes `request_suspend` respond to a "has a task started yet" question it was never written to ask, all to save one small shared method. `_push_suspend` factors out exactly the part that's shared and leaves the parts that aren't (the checkpoint check, the cancel, the state transition) where they already were, each still doing only what it always did.

**A private helper on `RunEngine` that keeps building the `wait_for` prologue, just without the `prologue=` keyword** (e.g. pushing straight onto `_executor._plan_stack`). Rejected because it keeps two independent copies of "how to wait for a suspender" in sync by hand -- the actual goal here -- and because reaching into `_plan_stack`/`_response_stack` from outside the executor is exactly the kind of parent-writes-into-child access #2050 spent its design rules ruling out.

**Making `request_suspend` tolerate `self._task is None`** (guard the cancel, skip the pause-notification side effects when nothing has run yet). Considered, but it teaches one method two different jobs behind one signature, and the mid-plan behaviour it protects (checkpoint-abort, state-machine transitions) has no meaning before a plan exists. Two named entry points -- `request_suspend` for mid-plan, `_queue_tripped_suspenders` for plan start -- read as two different situations because they are.

### Before/after: the tripped-at-call-time command sequence

The task's repro (a `SuspendBoolLow` tripped before `RE([Msg('open_run'), Msg('close_run')])` is called, released 0.5s later):

```
before: ['wait_for', 'open_run', 'close_run']
after:  ['_start_suspender', 'rewindable', 'wait_for', '_resume_from_suspender', 'rewindable', 'open_run', 'close_run']
```

**The leading command changes** -- deliberate, and the reviewable consequence of reusing `_start_suspender`'s machinery rather than a bare `wait_for`. What does not change: the plan's own first message (`open_run`, then `close_run`, same order), and `RE.state == "idle"` once it finishes. Three existing tests in `test_suspenders.py` asserted the exact old leading sequence (`test_pretripped`, `test_pause_from_suspend`, `test_deferred_pause_from_suspend`); all three are updated in this PR to the new sequence, with a comment pointing at this change, and still pass.

One side effect worth naming: a suspender's own `pre_plan`/`post_plan` (constructor arguments to `SuspenderBase`) are still not run for a suspender that is already tripped when `RE(plan)` is called -- `_queue_tripped_suspenders` passes `pre_plan=None, post_plan=None` to `_push_suspend`, matching the old prologue's behaviour of ignoring them in this case too. Wiring them up here is a reasonable follow-up, but it is a behaviour change beyond what this PR sets out to do (drop `prologue`, keep behaviour else unchanged), so it is left alone.

### Tests

- `test_suspenders.py::test_pretripped` (updated): asserts the new leading sequence and that `RE.state == "idle"` at the end.
- `test_suspenders.py::test_pretripped_plan_runs_to_completion_after_release` (new): pins the ordering the task asked for -- a suspender tripped before `RE()`, released 0.5s later, plan runs `open_run` then `close_run`, `RE.state == "idle"`, and the whole thing took longer than the release delay (i.e. it actually waited).
- `test_suspenders.py::test_pause_from_suspend`, `test_deferred_pause_from_suspend` (updated): same leading-sequence change; mid-plan-pause-from-suspend paths still resume and reach the plan's own messages correctly.
- `test_plan_executor.py::test_run_no_longer_takes_a_prologue` (new): `inspect.signature(PlanExecutor.run)` has no `prologue` parameter.

## Motivation and Context

`prologue` was a one-off keyword that existed for exactly one caller (`RunEngine.__call__`) and duplicated, in miniature, the mechanism `request_suspend`/`_start_suspender` already provide for the same underlying situation -- a suspender that needs to be waited on before the plan proceeds. Dropping it removes a second code path to keep in sync and makes `PlanExecutor.run`'s public surface (`plan`, `metadata`) match what it actually needs from a caller that is not a `RunEngine`.

## How Has This Been Tested?

Both runs: clean venv (`python3.11 -m venv`), `pip install -e ".[dev]"`, then `pip install -U ophyd-async` (PyPI resolved 0.2.0 initially, missing `soft_signal_rw` that `test_suspenders.py`/`test_devices.py` import; upgrading to 0.21.2 fixes collection on both trees), `pytest src/bluesky/tests -k "not sigint" --ignore=src/bluesky/tests/test_streams.py` (`streamz` fails to import against the resolved `dask` version identically on both trees).

| | baseline (`plan-executor`, unmodified) | this branch |
|---|---|---|
| passed | 1857 | 1860 (+3 new/changed tests) |
| failed | 0 | 0 |
| skipped / xfailed / deselected | 22 / 2 / 25 | 22 / 2 / 25 |

No regressions. `test_suspenders.py` and `test_plan_executor.py` pass in full, and separately in isolation.

`-k "sigint"` run separately as instructed: pre-existing, timing-dependent flakiness in `test_single_sigint_no_carry_over` (an `os.kill(SIGINT)` race, nothing to do with suspenders) reproduces at a similar rate on **both** this branch and the unmodified baseline across 10 repeated runs of each -- not a regression, not chased further.

Checks:
- `pre-commit run --all-files --show-diff-on-failure` (ruff lint + format): passed.
- `mypy src`: `Success: no issues found in 89 source files`.

### Scope

Touches only `src/bluesky/plan_executor.py`, `src/bluesky/run_engine.py`, and `src/bluesky/tests/test_suspenders.py` / `test_plan_executor.py`. `src/bluesky/suspenders.py` needed no change: `SuspenderBase.get_futures()` already returns exactly what `_push_suspend` needs. Does not touch the `PlanSession`/`PlanExecutor`/`RunEngine` split, forwarding tables, `panicked`, or monitor-emission threading.

Stacks on #2050.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019QdSuZw1MVtMQpTVJv9JbB)_