### PR TITLE
ENH: choose the collect verb from what a device produced, not its static type

### DIFF
--- a/docs/api_changes.rst
+++ b/docs/api_changes.rst
@@ -2,6 +2,18 @@
  Release History
 =================
 
+v1.15.2 (yyyy-mm-dd)
+====================
+
+Changed
+-------
+
+- ``collect()`` now chooses whether to ask a device for Events, EventPages or stream
+  assets based on what that device produced, rather than on the protocols it statically
+  obeys, so a single device may obey both ``WritesStreamAssets`` and
+  ``EventPageCollectable`` and decide which of them it uses when it is prepared.
+  Reporting both ways in the same run raises a ``RuntimeError``.
+
 v1.15.1 (2026-05-05)
 ====================
 

--- a/src/bluesky/bundlers.py
+++ b/src/bluesky/bundlers.py
@@ -57,6 +57,11 @@ from .utils import (
 ObjDict = dict[Any, dict[str, T]]
 ExternalAssetDoc: TypeAlias = Datum | Resource | StreamDatum | StreamResource
 
+# The kinds of data a collect object can report, used to choose which collect verb
+# ``RunBundler.collect`` calls, and to reject a device reporting both in one run
+STREAM_ASSETS = "stream assets"
+EVENTS_OR_PAGES = "Events or EventPages"
+
 
 def _describe_collect_dict_is_valid(
     describe_collect_dict: Any | dict[str, Any],
@@ -168,6 +173,10 @@ class RunBundler:
         self._monitor_params: dict[Subscribable, tuple[Callback, dict]] = dict()  # noqa: C408  # cache of {obj: (cb, kwargs)}
         # a cache of stream_resource uid to the data_keys that stream_resource collects for
         self._stream_resource_data_keys: dict[str, Iterable[str]] = dict()  # noqa: C408
+        # what each collect object has reported so far in this run, either STREAM_ASSETS
+        # or EVENTS_OR_PAGES, so that collect() can choose the collect verb from what the
+        # device produced rather than from the protocols it statically satisfies
+        self._reported_data_kinds: dict[HasName, str] = dict()  # noqa: C408
         self.run_is_open = False
         self._uncollected: set[HasName] = set()  # objects after kickoff(), before collect()
         # we expect the RE to take care of the composition
@@ -961,7 +970,8 @@ class RunBundler:
         local_descriptors,
         return_payload: bool,
         message_stream_name: str | None,
-    ):
+    ) -> tuple[list, int]:
+        """Emit an EventPage per set of data keys, returning the payload and how many."""
         payload = []
         pages: dict[frozenset[str], list[Event]] = defaultdict(list)
 
@@ -1002,7 +1012,7 @@ class RunBundler:
                 self._run_start_uid,
                 extra={"doc_name": "event_page", "run_uid": self._run_start_uid},
             )
-        return payload
+        return payload, len(pages)
 
     async def _collect_event_pages(
         self,
@@ -1010,8 +1020,10 @@ class RunBundler:
         local_descriptors,
         return_payload: bool,
         message_stream_name: str | None,
-    ):
+    ) -> tuple[list, int]:
+        """Emit the EventPages the object produces, returning the payload and how many."""
         payload = []
+        emitted = 0
 
         if message_stream_name:
             compose_event_page = self._descriptors[message_stream_name].compose_event_page
@@ -1042,7 +1054,46 @@ class RunBundler:
             )
 
             await self.emit(DocumentNames.event_page, ev_page)
-        return payload
+            emitted += 1
+        return payload, emitted
+
+    def _report_data_kind(self, collect_obj: HasName, kind: str):
+        """Record what kind of data a collect object produced in this run.
+
+        Only objects that obey ``WritesStreamAssets`` are recorded, since they are the
+        only ones that can report data two ways: their asset documents advance the
+        stream's sequence counter by the index difference they carry, while Events and
+        EventPages advance it as they are composed, so a device doing both in one run
+        would count every frame twice. Devices that obey the older
+        ``WritesExternalAssets`` protocol have no index of their own, and are expected
+        to report Datums alongside the Events that reference them.
+        """
+        if not isinstance(collect_obj, WritesStreamAssets):
+            return
+        reported = self._reported_data_kinds.setdefault(collect_obj, kind)
+        if reported != kind:
+            raise RuntimeError(
+                f"Collect object {collect_obj.name!r} reported {reported} earlier in this run, "
+                f"but has now reported {kind}. A device must report its data the same way for "
+                "the whole of a run, so that the sequence numbers of the stream are counted "
+                "once: either emit stream assets from `collect_asset_docs()`, or Events or "
+                "EventPages from `collect()` or `collect_pages()`, but do not change which "
+                "part way through a run."
+            )
+
+    def _collects_events_or_pages(self, collect_obj: HasName) -> bool:
+        """Whether ``collect()`` should ask this object for Events or EventPages.
+
+        A device may obey both ``WritesStreamAssets`` and ``EventPageCollectable``,
+        deciding only when it is prepared which of them it will use for a given scan, so
+        the collect verb is chosen from what the device has reported in this run rather
+        than from the protocols it statically obeys. A device that has reported stream
+        assets keeps the sequence counter advanced from those assets, and a device that
+        can only write stream assets is never asked for Events or EventPages.
+        """
+        if not isinstance(collect_obj, (EventCollectable, EventPageCollectable)):
+            return False
+        return self._reported_data_kinds.get(collect_obj) != STREAM_ASSETS
 
     async def collect(self, msg: Msg):
         """
@@ -1085,6 +1136,15 @@ class RunBundler:
         indices: list[Callable[[], SyncOrAsync[int]]] = []
         if len(collect_objects) > 1:
             indices = [check_supports(obj, WritesStreamAssets).get_index for obj in collect_objects]
+            # collect() can only compose Events or EventPages for a single object, so an
+            # object that has reported them in this run would have its data dropped here
+            for obj in collect_objects:
+                if self._reported_data_kinds.get(obj) == EVENTS_OR_PAGES:
+                    raise RuntimeError(
+                        f"Collect object {obj.name!r} reported {EVENTS_OR_PAGES} earlier in this "
+                        "run, so it cannot be collected alongside other objects. Collect it on "
+                        "its own, or make it report stream assets for the whole run."
+                    )
 
         # Warn for page collectable support
         for obj in collect_objects:
@@ -1136,15 +1196,22 @@ class RunBundler:
             # There is only one collect object, so don't pass an index down
             min_index = None
 
-        collected_asset_docs = [
-            x
-            for obj in collect_objects
-            async for x in maybe_collect_asset_docs(
-                msg,
-                obj,
-                index=min_index,
-            )
-        ]
+        collected_asset_docs: list[Asset | StreamAsset] = []
+        for obj in collect_objects:
+            obj_asset_docs = [
+                x
+                async for x in maybe_collect_asset_docs(
+                    msg,
+                    obj,
+                    index=min_index,
+                )
+            ]
+            if any(
+                name in (DocumentNames.stream_resource.value, DocumentNames.stream_datum.value)
+                for name, _ in obj_asset_docs
+            ):
+                self._report_data_kind(obj, STREAM_ASSETS)
+            collected_asset_docs.extend(obj_asset_docs)
 
         indices_difference = await self._pack_external_assets(
             collected_asset_docs, message_stream_name=stream_name
@@ -1152,7 +1219,7 @@ class RunBundler:
 
         # Make event pages for an object which is EventCollectable or EventPageCollectable
         # objects that are EventCollectable will now group the Events and Emit an Event Page
-        if len(collect_objects) == 1 and not isinstance(collect_objects[0], WritesStreamAssets):
+        if len(collect_objects) == 1 and self._collects_events_or_pages(collect_objects[0]):
             local_descriptors: dict[frozenset[str], ComposeDescriptorBundle] = {}
             collect_obj = collect_objects[0]
 
@@ -1170,27 +1237,31 @@ class RunBundler:
             local_descriptors = self._local_descriptors[collect_obj]
 
             if isinstance(collect_obj, EventPageCollectable):
-                payload = await self._collect_event_pages(
+                payload, emitted = await self._collect_event_pages(
                     collect_obj, local_descriptors, return_payload, stream_name
                 )
                 # TODO: check that event pages have same length as indices_difference
-            elif isinstance(collect_obj, EventCollectable):
-                payload = await self._collect_events(collect_obj, local_descriptors, return_payload, stream_name)
-                # TODO: check that events have same length as indices_difference
             else:
-                return_payload = False
-                if not stream_name:
-                    raise RuntimeError(
-                        "A `collect` message on a device that isn't EventCollectable or EventPageCollectable "
-                        "requires a `name=stream_name` argument"
-                    )
-                # Since there are no events or event_pages incrementing the sequence counter, we do it ourselves.
-                self._sequence_counters[stream_name] += indices_difference
+                # `_collects_events_or_pages` has checked it is one or the other
+                payload, emitted = await self._collect_events(
+                    cast(EventCollectable, collect_obj), local_descriptors, return_payload, stream_name
+                )
+                # TODO: check that events have same length as indices_difference
+
+            # Only a device that produced something has reported this way, so a device
+            # with nothing to flush is still free to report stream assets later in the run
+            if emitted:
+                self._report_data_kind(collect_obj, EVENTS_OR_PAGES)
 
             if return_payload:
                 return payload
 
         else:
+            if not stream_name:
+                raise RuntimeError(
+                    "A `collect` message on a device that isn't EventCollectable or EventPageCollectable "
+                    "requires a `name=stream_name` argument"
+                )
             # Since there are no events or event_pages incrementing the sequence counter, we do it ourselves.
             self._sequence_counters[stream_name] += indices_difference
 

--- a/src/bluesky/tests/test_external_assets_and_paging.py
+++ b/src/bluesky/tests/test_external_assets_and_paging.py
@@ -313,6 +313,63 @@ class StreamDatumReadableCollectable(Named, Readable, Collectable, WritesStreamA
     get_index = get_index
 
 
+class StreamAssetsOrPagesCollectable(Named, EventPageCollectable, WritesStreamAssets):
+    """Produces either StreamResources and StreamDatums, or EventPages, or both.
+
+    ``ophyd_async.core.StandardDetector`` is a device of this shape: whether it writes
+    its data to an external file or reports it as EventPages is decided by its data
+    logics when it is prepared, so it satisfies both protocols but only uses one of
+    them in any given run.
+    """
+
+    get_index = get_index
+
+    def __init__(self, name: str, produces: str) -> None:
+        super().__init__(name)
+        # One of "stream_assets", "event_pages", "both" or "nothing"
+        self.produces = produces
+
+    def describe_collect(self) -> dict[str, DataKey]:
+        data_keys: dict[str, DataKey] = {}
+        if self.produces in ("stream_assets", "both"):
+            data_keys.update(describe_stream_datum(self))
+        if self.produces in ("event_pages", "both"):
+            data_keys.update(describe_collect_pv(self))
+        return data_keys
+
+    def collect_asset_docs(self, index: int | None = None) -> Iterator[StreamAsset]:
+        if self.produces in ("stream_assets", "both"):
+            yield from collect_asset_docs_stream_datum(self, index)
+
+    def collect_pages(self) -> Iterator[PartialEventPage]:
+        if self.produces in ("event_pages", "both"):
+            yield from collect_pages_pv(self)
+
+
+class DummyStatus:
+    def add_callback(self, *args, **kwargs): ...
+
+
+class FlyableStreamAssetsOrPagesCollectable(StreamAssetsOrPagesCollectable):
+    """The same device, but flyable, so it can be left uncollected at the end of a run"""
+
+    def kickoff(self) -> DummyStatus:
+        return DummyStatus()
+
+    def complete(self) -> DummyStatus:
+        return DummyStatus()
+
+
+class EmptyStreamDatumCollectable(Named, Collectable, WritesStreamAssets):
+    """Writes stream assets, but has no new frames to flush in this collect"""
+
+    describe_collect = describe_stream_datum
+    get_index = get_index
+
+    def collect_asset_docs(self, index: int | None = None) -> Iterator[StreamAsset]:
+        return iter(())
+
+
 def test_datum_readable_counts(RE):
     """Test that count-ing a datum-producing device results in expected documents."""
     det = DatumReadable(name="det")
@@ -557,6 +614,151 @@ def test_many_stream_datum_collectables(RE):
     assert set(docs["descriptor"][0]["data_keys"]) == set(data_keys)  # This only works in a set
     assert [d["data_key"] for d in docs["stream_resource"]] == data_keys
     assert all(d["descriptor"] == docs["descriptor"][0]["uid"] for d in docs["stream_datum"])
+
+
+def two_collect_plan(det, first, second, stream_name="main"):
+    """Declare a stream, then collect twice, changing what the device reports in between"""
+    yield from bps.open_run()
+    yield from bps.declare_stream(det, name=stream_name, collect=True)
+    det.produces = first
+    yield from bps.collect(det, name=stream_name)
+    det.produces = second
+    yield from bps.collect(det, name=stream_name)
+    yield from bps.close_run()
+
+
+def test_both_protocols_collectable_producing_event_pages(RE):
+    """A device that could write stream assets, but produced pages, emits those pages."""
+    det = StreamAssetsOrPagesCollectable(name="det", produces="event_pages")
+    docs = DocHolder()
+    RE(collect_plan(det, pre_declare=True, stream_name="main"), docs.append)
+    docs.assert_emitted(start=1, descriptor=1, event_page=1, stop=1)
+    assert docs["descriptor"][0]["name"] == "main"
+    assert list(docs["descriptor"][0]["data_keys"]) == ["det-pv1", "det-pv2"]
+    assert docs["event_page"][0]["data"] == {"det-pv1": [0, 1], "det-pv2": [0, 1]}
+    assert docs["event_page"][0]["timestamps"] == {"det-pv1": [100, 101], "det-pv2": [100, 101]}
+    assert docs["event_page"][0]["seq_num"] == [1, 2]
+    assert docs["stop"][0]["num_events"] == {"main": 2}
+
+
+def test_both_protocols_collectable_producing_stream_assets(RE):
+    """A device that could produce pages, but wrote stream assets, emits just those."""
+    det = StreamAssetsOrPagesCollectable(name="det", produces="stream_assets")
+    docs = DocHolder()
+    RE(collect_plan(det, pre_declare=True, stream_name="main"), docs.append)
+    docs.assert_emitted(start=1, descriptor=1, stream_resource=2, stream_datum=2, stop=1)
+    assert docs["descriptor"][0]["name"] == "main"
+    assert list(docs["descriptor"][0]["data_keys"]) == ["det-sd1", "det-sd2"]
+    assert [d["data_key"] for d in docs["stream_resource"]] == ["det-sd1", "det-sd2"]
+    assert docs["stop"][0]["num_events"] == {"main": 1}
+
+
+def test_both_protocols_producing_stream_assets_matches_a_stream_only_device(RE):
+    """Writing stream assets from a both-protocol device is byte for byte the old path."""
+    both, stream_only = DocHolder(), DocHolder()
+    RE(
+        collect_plan(
+            StreamAssetsOrPagesCollectable(name="det", produces="stream_assets"),
+            pre_declare=True,
+            stream_name="main",
+        ),
+        both.append,
+    )
+    RE(
+        collect_plan(StreamDatumReadableCollectable(name="det"), pre_declare=True, stream_name="main"),
+        stream_only.append,
+    )
+    assert {name: len(d) for name, d in both.items()} == {name: len(d) for name, d in stream_only.items()}
+    assert [d["seq_nums"] for d in both["stream_datum"]] == [d["seq_nums"] for d in stream_only["stream_datum"]]
+    assert [d["indices"] for d in both["stream_datum"]] == [d["indices"] for d in stream_only["stream_datum"]]
+    assert both["stop"][0]["num_events"] == stream_only["stop"][0]["num_events"]
+
+
+def test_both_protocols_reporting_both_ways_in_one_run_raises(RE):
+    """Reporting pages and then stream assets in one run would count frames twice."""
+    det = StreamAssetsOrPagesCollectable(name="det", produces="both")
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape(
+            "Collect object 'det' reported Events or EventPages earlier in this run, but has now "
+            "reported stream assets."
+        ),
+    ):
+        RE(two_collect_plan(det, "event_pages", "stream_assets"))
+
+
+def test_both_protocols_reporting_stream_assets_stays_on_the_stream_asset_path(RE):
+    """Once a device has reported stream assets it is not asked for pages again.
+
+    A device with no new frames to flush reports no stream assets, which is not the same
+    as it having changed to producing pages, so the choice is pinned for the run.
+    """
+    det = StreamAssetsOrPagesCollectable(name="det", produces="both")
+    docs = DocHolder()
+    RE(two_collect_plan(det, "stream_assets", "event_pages"), docs.append)
+    docs.assert_emitted(start=1, descriptor=1, stream_resource=2, stream_datum=2, stop=1)
+
+
+def test_both_protocols_with_nothing_to_flush_is_not_pinned_to_pages(RE):
+    """A first collect that produced nothing leaves the device free to stream later."""
+    det = StreamAssetsOrPagesCollectable(name="det", produces="stream_assets")
+    docs = DocHolder()
+    RE(two_collect_plan(det, "nothing", "stream_assets"), docs.append)
+    docs.assert_emitted(start=1, descriptor=1, stream_resource=2, stream_datum=2, stop=1)
+    assert [d["seq_nums"] for d in docs["stream_datum"]] == [{"start": 1, "stop": 2}] * 2
+    assert docs["stop"][0]["num_events"] == {"main": 1}
+
+
+def test_stream_assets_only_device_with_nothing_to_flush(RE):
+    """A device that can only write stream assets never falls into the page branch."""
+    det = EmptyStreamDatumCollectable(name="det")
+    docs = DocHolder()
+    RE(collect_plan(det, pre_declare=True, stream_name="main"), docs.append)
+    docs.assert_emitted(start=1, descriptor=1, stop=1)
+    assert docs["stop"][0]["num_events"] == {"main": 0}
+
+
+def many_collectables_plan(det1, det2):
+    """Collect one device on its own, then collect it alongside another"""
+    yield from bps.open_run()
+    yield from bps.declare_stream(det1, name="main", collect=True)
+    yield from bps.collect(det1, name="main")
+    yield from bps.declare_stream(det1, det2, name="both", collect=True)
+    yield from bps.collect(det1, det2, name="both")
+    yield from bps.close_run()
+
+
+def test_page_collectable_alongside_other_collectables_raises(RE):
+    """collect() can only compose pages for one object, so don't drop the other's data."""
+    det1 = StreamAssetsOrPagesCollectable(name="det1", produces="event_pages")
+    det2 = StreamDatumReadableCollectable(name="det2")
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape(
+            "Collect object 'det1' reported Events or EventPages earlier in this run, so it "
+            "cannot be collected alongside other objects."
+        ),
+    ):
+        RE(many_collectables_plan(det1, det2))
+
+
+def uncollected_plan(det):
+    """Kick off a device, then leave the run open so backstop_collect() has to collect"""
+    yield from bps.open_run()
+    yield from bps.declare_stream(det, name="main", collect=True)
+    yield from bps.kickoff(det)
+
+
+@pytest.mark.parametrize("produces", ["stream_assets", "event_pages"])
+def test_backstop_collect_of_a_both_protocol_device(RE, produces):
+    """backstop_collect() picks the same verb as an explicit collect would."""
+    det = FlyableStreamAssetsOrPagesCollectable(name="det", produces=produces)
+    docs = DocHolder()
+    RE(uncollected_plan(det), docs.append)
+    if produces == "stream_assets":
+        docs.assert_emitted(start=1, descriptor=1, stream_resource=2, stream_datum=2, stop=1)
+    else:
+        docs.assert_emitted(start=1, descriptor=1, event_page=1, stop=1)
 
 
 def tomo_plan(*objs):


### PR DESCRIPTION
## Description

`RunBundler.collect` picks which collect verb to use from the *static* protocol
membership of the collect object. After the asset docs have been packed, in
`src/bluesky/bundlers.py`:

```python
if len(collect_objects) == 1 and not isinstance(collect_objects[0], WritesStreamAssets):
    ...  # the EventPageCollectable / EventCollectable path
else:
    self._sequence_counters[stream_name] += indices_difference
```

So a device that satisfies **both** `WritesStreamAssets` and `EventPageCollectable`
never has `collect_pages()` called, whatever it actually produced. A paged fly scan
over such a device silently emits no data at all — no warning, no error:

```python
det = StreamAssetsOrPagesCollectable(name="det", produces="event_pages")
docs = DocHolder()
RE(collect_plan(det, pre_declare=True, stream_name="main"), docs.append)

# on main:
#   {'start': 1, 'descriptor': 1, 'stop': 1}
#   stop["num_events"] == {'main': 0}
# the descriptor is emitted, and then every frame is dropped
```

This PR replaces the static gate with one based on what the device produced.
The rule: **a single collect object is asked for Events or EventPages when it is
`EventCollectable` or `EventPageCollectable` and it has not reported stream assets
so far in this run; otherwise the sequence counter is advanced from the asset docs
as before.** `RunBundler` keeps a per-run record (`_reported_data_kinds`) of what
each collect object has reported, and a device that reports both ways in one run
raises a `RuntimeError` naming the device, both kinds, and what to do about it.

Reporting both ways has to be an error rather than something the bundler merges,
because the two paths advance the same counter. The stream-asset path advances
`self._sequence_counters[stream_name]` by the `indices_difference` returned from
`_pack_external_assets`, while the Event/EventPage path advances it through
`compose_event`/`compose_event_page`. A device doing both in one run would have
every frame counted twice, and the `seq_nums` written into its `stream_datum`
documents would no longer line up with the events in the stream.

**What is unchanged.** A device that satisfies only one of the two protocols takes
exactly the path it took before:

- The record is only kept for objects that satisfy `WritesStreamAssets`, since they
  are the only ones that can report two ways. Devices on the older
  `WritesExternalAssets` protocol have no index of their own and are expected to
  report Datums alongside the Events that reference them — the devices in
  `test_seq_num_indices_in_sync.py` that are `EventPageCollectable` *and* emit
  `stream_datum` documents keep taking the page path, with their `seq_nums` driven
  by the pages as before.
- A device that can only write stream assets is never asked for pages, whether or
  not it had anything to flush, because the gate also requires page/event
  collectability. Gating purely on "this collect produced no asset docs" would have
  changed that.
- The old-style doubly nested path (`stream_name is None`, `_describe_collect` has
  been called) takes the same branch as before.
- The `RuntimeError` for a `collect` on a device that is neither `EventCollectable`
  nor `EventPageCollectable` and has no `name=stream_name` has moved to the other
  side of the branch, so it is still raised for exactly the same messages.

Every existing test in `test_external_assets_and_paging.py` and
`test_seq_num_indices_in_sync.py` passes unchanged; no existing expectation was
edited.

## Motivation and Context

`ophyd_async.core.StandardDetector` produces stream assets or event pages depending
on what its data logics make for a given scan, which is not known until `prepare()`.
Because the bundler decides from the static type, ophyd-async currently has to bind
`collect_asset_docs` / `collect_pages` as *instance attributes* on every `prepare()`
and delete the other one (`StandardDetector._publish_collect_methods`; see ADR 0023
on the `detector-stack-4-flyable` branch and bluesky/ophyd-async#1408). With this
change those can be two ordinary methods.

ophyd-async will need a released bluesky containing this change before it can drop
that workaround. Nothing in ophyd-async is changed here.

## How Has This Been Tested?

New tests in `src/bluesky/tests/test_external_assets_and_paging.py`, built on the
existing helpers in that file. `StreamAssetsOrPagesCollectable` is
`Named, EventPageCollectable, WritesStreamAssets` and is told which kind of data to
produce:

- producing only stream assets → `stream_resource`/`stream_datum` emitted, no
  `event_page`, and `seq_nums`, `indices` and `stop.num_events` compared document
  for document against an equivalent `StreamDatumReadableCollectable` run;
- producing only event pages → `event_page` with the right data, `seq_num` `[1, 2]`
  and `stop.num_events == {"main": 2}`;
- reporting both ways in one run → raises, message asserted;
- a `WritesStreamAssets`-only device with nothing to flush;
- a both-protocol device with nothing to flush in its first collect, then stream
  assets in the second;
- a both-protocol device that reported pages, then collected alongside another
  object;
- `backstop_collect()` on a both-protocol device, in both modes.

The eight tests that cover new behaviour were confirmed to fail against the
unmodified `bundlers.py`; the twelve that assert unchanged behaviour pass against it.

Edge cases decided deliberately, and worth a reviewer's eye:

- **A device that reports pages and then stream assets raises; the reverse is not
  detected.** Once a device has reported stream assets it stays on the stream-asset
  path for the rest of the run, so if it then starts producing pages they are not
  collected. Detecting that would mean calling `collect_pages()` on a device already
  known to be streaming, which cannot be distinguished from the legitimate case of a
  streaming device with no new frames to flush.
  `test_both_protocols_reporting_stream_assets_stays_on_the_stream_asset_path`
  pins the current behaviour. Happy to change this if you would rather the bundler
  asked and raised.
- **A device is only recorded as having reported when it actually produced
  something.** A collect that flushes nothing and yields no pages leaves the device
  free to report either way later, which is what makes the "nothing to flush on the
  first collect" case work.
- **Multiple collect objects.** `collect()` can only compose pages for one object,
  and a both-protocol device passes the existing `check_supports(obj,
  WritesStreamAssets)` check, so an object that has reported pages earlier in the run
  now raises when it is collected alongside others rather than having its data
  dropped. The residual gap is an object that would produce pages but has never
  reported anything: there is no way to tell it apart from one with nothing to flush
  without calling `collect_pages()` on every object in a multi-object collect.
- **Nothing else was touched.** `protocols.py` is unchanged, and `collect()` was not
  refactored beyond what the rule needs.

The changelog entry in `docs/api_changes.rst` follows the convention of adding a new
version heading with a `yyyy-mm-dd` placeholder; the version number is a guess for
the release manager to correct.

Validation run locally, as CI runs it:

- `pre-commit run --all-files` — passed.
- `mypy src` — passed, no issues in 87 source files.
- `pytest` — 1855 passed, 24 skipped, 2 xfailed.
- `sphinx-build -EW --keep-going -T docs build/html` — could not be run as CI does,
  because this sandbox's network policy blocks `blueskyproject.io`, which
  `docs/conf.py` fetches at import time. With that one call stubbed out, the build
  completed and the only warnings were intersphinx inventories that the same network
  policy blocked; there were no content warnings. The `docs / build` job on CI here
  passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcYkcAefJJUpGgjcLTkJb5

## AI Disclaimer

The code and this description were generated with AI and reviewed/tweaked by the author.
