### PR TITLE
WIP: optionally marshal monitor emission onto the event loop (for discussion)

### DIFF
--- a/benchmarks/monitor_marshalling.py
+++ b/benchmarks/monitor_marshalling.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Measure the cost of marshalling monitor emission onto the event loop.
+
+``PlanExecutor.emit`` normally hands a monitored signal's documents to
+subscribers on whichever thread the signal called back on -- for a
+synchronous ophyd v1 signal, that is the device's own thread, not the
+RunEngine's event loop. ``PlanSession(marshal_monitor_emission=True)`` (or
+the ``BLUESKY_MARSHAL_MONITOR_EMISSION`` environment variable) turns that
+around: emission from a foreign thread is marshalled onto the loop with
+``call_soon_threadsafe`` instead, exactly as status callbacks already are.
+
+This script measures what that costs and what it buys, so the question can
+be judged on numbers rather than argument alone. See bluesky#2050, which
+raised the asymmetry and the tradeoffs, and the WIP PR built on top of it.
+
+Self-contained; run with no arguments::
+
+    python benchmarks/monitor_marshalling.py
+
+Needs ophyd on the path (``pip install -e ".[dev]"`` gets it).
+"""
+
+from __future__ import annotations
+
+import platform
+import statistics
+import sys
+import threading
+import time
+
+from bluesky import Msg, RunEngine
+
+try:
+    import ophyd
+except ImportError:  # pragma: no cover
+    print("This benchmark needs ophyd installed: pip install -e '.[dev]'", file=sys.stderr)
+    raise SystemExit(1) from None
+
+
+def _new_RE(marshal: bool) -> RunEngine:
+    """A RunEngine with the guard set directly.
+
+    RunEngine.__init__ does not take marshal_monitor_emission -- it is a
+    PlanSession parameter, and this PR does not touch RunEngine's signature
+    (see the scope fences in the PR body). Setting the session's public
+    attribute after construction has the same effect.
+    """
+    RE = RunEngine({})
+    RE._session.marshal_monitor_emission = marshal
+    return RE
+
+
+def _percentile(data: list[float], pct: float) -> float:
+    data = sorted(data)
+    if len(data) == 1:
+        return data[0]
+    k = (len(data) - 1) * (pct / 100)
+    f, c = int(k), min(int(k) + 1, len(data) - 1)
+    if f == c:
+        return data[f]
+    return data[f] + (data[c] - data[f]) * (k - f)
+
+
+def measure_latency(marshal: bool, n_samples: int = 300) -> tuple[float, float] | None:
+    """Median and p95 latency, in ms, from sig.put() to the subscriber seeing
+    the resulting Event document."""
+    RE = _new_RE(marshal)
+    sig = ophyd.Signal(name="sig", value=0)
+
+    send_times: dict[int, float] = {}
+    latencies_ms: list[float] = []
+    done = threading.Event()
+
+    def collector(name, doc):
+        if name != "event":
+            return
+        value = doc["data"]["sig"]
+        t_send = send_times.get(value)
+        if t_send is not None:
+            latencies_ms.append((time.perf_counter() - t_send) * 1000)
+        if len(latencies_ms) >= n_samples:
+            done.set()
+
+    RE.subscribe(collector)
+
+    monitoring = threading.Event()
+
+    def putter():
+        assert monitoring.wait(timeout=10)
+        for i in range(1, n_samples + 1):
+            send_times[i] = time.perf_counter()
+            sig.put(i)
+            time.sleep(0.002)  # ~500 Hz
+
+    thread = threading.Thread(target=putter, daemon=True)
+    thread.start()
+
+    def plan():
+        yield Msg("open_run")
+        yield Msg("monitor", sig)
+        monitoring.set()
+        # Bounded by both the sample count and a wall-clock ceiling, so a
+        # stuck run cannot hang the benchmark.
+        for _ in range(3000):
+            if done.is_set():
+                break
+            yield Msg("sleep", None, 0.01)
+        yield Msg("unmonitor", sig)
+        yield Msg("close_run")
+
+    RE(plan())
+    thread.join(timeout=5)
+
+    if len(latencies_ms) < n_samples // 2:
+        return None  # too few samples to be meaningful
+    latencies_ms = latencies_ms[:n_samples]
+    return statistics.median(latencies_ms), _percentile(latencies_ms, 95)
+
+
+def measure_throughput(
+    marshal: bool,
+    duration_s: float = 1.0,
+    monitor_hz: float = 500,
+    slow_subscriber_s: float = 0.0,
+) -> float:
+    """Messages/sec the run loop sustains while a monitor fires in the
+    background, optionally with a subscriber slow enough to matter."""
+    RE = _new_RE(marshal)
+    sig = ophyd.Signal(name="sig", value=0)
+
+    if slow_subscriber_s:
+
+        def collector(name, doc):
+            if name == "event":
+                time.sleep(slow_subscriber_s)
+
+        RE.subscribe(collector)
+
+    stop = threading.Event()
+    counted = {"n": 0}
+
+    def putter():
+        period = 1.0 / monitor_hz
+        while not stop.is_set():
+            sig.put(1)
+            time.sleep(period)
+
+    def plan():
+        yield Msg("open_run")
+        yield Msg("monitor", sig)
+        while not stop.is_set():
+            counted["n"] += 1
+            yield Msg("null")
+        yield Msg("unmonitor", sig)
+        yield Msg("close_run")
+
+    thread = threading.Thread(target=putter, daemon=True)
+    thread.start()
+    timer = threading.Timer(duration_s, stop.set)
+    timer.start()
+
+    t0 = time.perf_counter()
+    RE(plan())
+    elapsed = time.perf_counter() - t0
+    thread.join(timeout=10)
+
+    return counted["n"] / elapsed
+
+
+def main() -> None:
+    print(f"Python {platform.python_version()} ({sys.implementation.name}) on {platform.platform()}")
+    print(f"ophyd {ophyd.__version__}")
+    print()
+
+    rows: list[tuple[str, str, str]] = []
+
+    print("Measuring monitor document latency (sig.put() -> subscriber sees the doc)...")
+    for marshal, label in ((False, "off (today)"), (True, "on")):
+        result = measure_latency(marshal)
+        if result is None:
+            rows.append((f"latency, {label}", "n/a", "too noisy to be meaningful"))
+        else:
+            median, p95 = result
+            rows.append((f"latency, {label}", f"{median:.3f} ms median", f"{p95:.3f} ms p95"))
+
+    print("Measuring plan throughput with a monitor firing in the background...")
+    for marshal, label in ((False, "off (today)"), (True, "on")):
+        hz = measure_throughput(marshal)
+        rows.append((f"throughput, {label}", f"{hz:,.0f} msg/s", ""))
+
+    print("Measuring plan throughput with a slow (10 ms) monitor subscriber...")
+    print("(this is the number that decides the 'against' argument from #2050)")
+    stall_rows = []
+    for marshal, label in ((False, "off (today)"), (True, "on")):
+        hz = measure_throughput(marshal, slow_subscriber_s=0.010, monitor_hz=120)
+        stall_rows.append((f"stall case, {label}", f"{hz:,.0f} msg/s", ""))
+
+    print()
+    header = f"{'measurement':<28}{'value':<20}{'detail'}"
+    print(header)
+    print("-" * len(header))
+    for name, value, detail in rows + stall_rows:
+        print(f"{name:<28}{value:<20}{detail}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bluesky/plan_executor.py
+++ b/src/bluesky/plan_executor.py
@@ -9,6 +9,7 @@ import concurrent
 import copy
 import functools
 import json
+import os
 import sys
 import threading
 import typing
@@ -115,6 +116,25 @@ class _NoPlanReturn:
 #: completion, and so never returned one. Distinguishable from a plan that
 #: completed and returned ``None``.
 NO_PLAN_RETURN = _NoPlanReturn()
+
+#: Environment variable that, when set to a truthy value, turns on monitor
+#: emission marshalling (see ``PlanSession``'s ``marshal_monitor_emission``
+#: parameter) without a code change. The keyword argument wins when given
+#: explicitly; this is the rollout knob for when it is not.
+MARSHAL_MONITOR_EMISSION_ENV_VAR = "BLUESKY_MARSHAL_MONITOR_EMISSION"
+
+
+def _env_var_is_truthy(name: str) -> bool:
+    """Return whether the named environment variable is set to a truthy value.
+
+    Unset, empty, or one of ``"0"``, ``"false"``, ``"no"``, ``"off"``
+    (case-insensitive) counts as false; anything else counts as true.
+    """
+    value = os.environ.get(name)
+    if value is None:
+        return False
+    return value.strip().lower() not in ("", "0", "false", "no", "off")
+
 
 #: Commands that must not be replayed when rewinding to a checkpoint, either
 #: because they act on the RunEngine itself or because they are not idempotent.
@@ -364,6 +384,19 @@ class PlanSession:
         What ``Msg('RE_class')`` reports. A `RunEngine` passes its own class;
         without one the executor answers for itself.
 
+    marshal_monitor_emission : bool, optional
+        Whether a monitored signal's documents are handed to subscribers on
+        the event loop rather than on whichever thread the signal fired its
+        callback on. Off by default, matching today's behaviour: a sync
+        ophyd signal's monitor callback reaches ``PlanExecutor.emit`` on the
+        device's own thread, so that is where subscribers currently run --
+        see :meth:`PlanExecutor.emit`. When not given explicitly, the
+        environment variable named by
+        :data:`MARSHAL_MONITOR_EMISSION_ENV_VAR`
+        (``BLUESKY_MARSHAL_MONITOR_EMISSION``) decides, so a deployment can
+        turn this on without a code change. This is a decision aid, not a
+        recommendation either way; see bluesky#2050 for the tradeoffs.
+
     Attributes
     ----------
     state
@@ -391,10 +424,25 @@ class PlanSession:
         on_pause: typing.Callable[[], None] | None = None,
         run_bundler_cls: type[RunBundler] = RunBundler,
         run_engine_cls: type | None = None,
+        marshal_monitor_emission: bool | None = None,
     ):
         if loop is None:
             loop = _default_event_loop()
         self._loop = loop
+
+        # Off by default: today's behaviour is that a sync ophyd signal's
+        # monitor callback reaches PlanExecutor.emit on the device's own
+        # thread, and subscribers are invoked there. See emit()'s docstring.
+        # The keyword wins when given; otherwise the environment variable
+        # allows rollout without a code change. Decided once, here, rather
+        # than read on every emit, so that changing the environment mid-run
+        # cannot change which thread a subscriber is invoked on partway
+        # through a plan.
+        self.marshal_monitor_emission: bool = (
+            marshal_monitor_emission
+            if marshal_monitor_emission is not None
+            else _env_var_is_truthy(MARSHAL_MONITOR_EMISSION_ENV_VAR)
+        )
 
         self.log = log if log is not None else ComposableLogAdapter(logger, {"RE": self})
 
@@ -699,8 +747,29 @@ class PlanExecutor:
 
         May be called from a thread that is not the event loop's: a sync ophyd
         signal fires its monitor callback on the device's own thread, and that
-        path reaches here. Subscribers are therefore invoked on whichever
-        thread emitted, which is not always the loop.
+        path reaches here. By default subscribers are therefore invoked on
+        whichever thread emitted, which is not always the loop -- see
+        bluesky#2050 for the arguments this asymmetry raised.
+
+        When ``self._session.marshal_monitor_emission`` is set, emission from
+        a foreign thread is marshalled onto the loop with
+        ``call_soon_threadsafe`` instead, so every subscriber runs on the
+        loop, like status callbacks already do (:meth:`_add_status_to_group`).
+        Emission from the loop thread itself always stays synchronous: were it
+        marshalled too, it would be reordered relative to whatever the run
+        loop does next, breaking the ordering guarantees plans rely on.
+        """
+        if self._session.marshal_monitor_emission:
+            loop = self._session.loop
+            if threading.get_ident() != getattr(loop, "_thread_id", None):
+                loop.call_soon_threadsafe(self._emit_now, name, doc)
+                return
+        self._emit_now(name, doc)
+
+    def _emit_now(self, name, doc) -> None:
+        """Give a document to the session's subscribers, then to this plan's.
+
+        Runs synchronously on whatever thread calls it. See :meth:`emit`.
         """
         self._session.dispatcher.process(name, doc)
         self.dispatcher.process(name, doc)

--- a/src/bluesky/tests/test_plan_executor.py
+++ b/src/bluesky/tests/test_plan_executor.py
@@ -12,6 +12,7 @@ import pytest
 
 from bluesky import Msg
 from bluesky.plan_executor import PlanExecutor, PlanSession
+from bluesky.tests import requires_ophyd
 from bluesky.utils import RunEngineInterrupted
 
 THREADING_PRIMITIVES = (
@@ -63,8 +64,14 @@ def test_executor_holds_no_threading_primitives(idle_session):
 
 @pytest.mark.parametrize("cls", [PlanSession, PlanExecutor])
 def test_source_takes_no_locks(cls):
-    """Neither class ever blocks a thread, so neither may lock or join."""
-    source = inspect.getsource(cls)
+    """Neither class ever blocks a thread, so neither may lock or join.
+
+    ``threading.get_ident()`` is allowed: PlanExecutor.emit reads it to
+    decide whether it is already on the loop thread before optionally
+    marshalling onto it. Reading the current thread's id blocks nothing, so
+    it is exempted from the blanket "threading." ban below.
+    """
+    source = inspect.getsource(cls).replace("threading.get_ident(", "")
     for forbidden in ("threading.", "_state_lock", ".acquire(", ".join("):
         assert forbidden not in source, f"{cls.__name__} uses {forbidden}"
 
@@ -222,3 +229,134 @@ def test_request_pause_coro_survives_for_queueserver(RE):
         RE(plan())
     assert RE.state == "paused"
     RE.stop()
+
+
+# --- marshal_monitor_emission -----------------------------------------------
+#
+# A sync ophyd signal fires its monitor callback on whichever thread called
+# .put(), and PlanExecutor.emit's default behaviour is to invoke subscribers
+# on that same thread rather than the loop's. marshal_monitor_emission (a
+# PlanSession kwarg, falling back to the BLUESKY_MARSHAL_MONITOR_EMISSION
+# environment variable) turns that around. See bluesky#2050 for the tradeoffs;
+# this is off by default so today's behaviour is unchanged unless someone
+# opts in.
+
+
+def test_marshal_monitor_emission_defaults_to_off(monkeypatch):
+    """With no kwarg and no environment variable, the guard is off."""
+    monkeypatch.delenv("BLUESKY_MARSHAL_MONITOR_EMISSION", raising=False)
+    assert PlanSession().marshal_monitor_emission is False
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("1", True),
+        ("true", True),
+        ("True", True),
+        ("yes", True),
+        ("on", True),
+        ("0", False),
+        ("false", False),
+        ("False", False),
+        ("no", False),
+        ("off", False),
+        ("", False),
+    ],
+)
+def test_env_var_controls_marshal_monitor_emission(monkeypatch, value, expected):
+    """The environment variable is the rollout knob for when no kwarg is given."""
+    monkeypatch.setenv("BLUESKY_MARSHAL_MONITOR_EMISSION", value)
+    assert PlanSession().marshal_monitor_emission is expected
+
+
+def test_explicit_kwarg_overrides_the_env_var(monkeypatch):
+    """The keyword argument wins over the environment variable either way."""
+    monkeypatch.setenv("BLUESKY_MARSHAL_MONITOR_EMISSION", "1")
+    assert PlanSession(marshal_monitor_emission=False).marshal_monitor_emission is False
+
+    monkeypatch.delenv("BLUESKY_MARSHAL_MONITOR_EMISSION", raising=False)
+    assert PlanSession(marshal_monitor_emission=True).marshal_monitor_emission is True
+
+
+@requires_ophyd
+def test_monitor_subscriber_runs_on_the_device_thread_by_default(RE):
+    """Today's behaviour, pinned: a sync signal's monitor callback is invoked
+    on whichever thread called .put(), not the RunEngine's loop thread."""
+    import ophyd
+
+    sig = ophyd.Signal(name="sig", value=0)
+    seen_thread_ids = []
+    monitoring = threading.Event()
+
+    def collector(*args, **kwargs):
+        seen_thread_ids.append(threading.get_ident())
+
+    RE.subscribe(collector, "event")
+
+    putter_thread_id = {}
+
+    def putter():
+        assert monitoring.wait(timeout=5)
+        putter_thread_id["id"] = threading.get_ident()
+        sig.put(1)
+
+    thread = threading.Thread(target=putter)
+    thread.start()
+
+    def plan():
+        yield Msg("open_run")
+        yield Msg("monitor", sig)
+        monitoring.set()
+        yield Msg("sleep", None, 0.3)
+        yield Msg("unmonitor", sig)
+        yield Msg("close_run")
+
+    RE(plan())
+    thread.join(timeout=5)
+
+    assert seen_thread_ids, "the monitor callback never fired"
+    assert RE._th.ident != putter_thread_id["id"]
+    assert seen_thread_ids == [putter_thread_id["id"]]
+
+
+@requires_ophyd
+def test_monitor_subscriber_runs_on_the_loop_thread_when_marshalled(RE):
+    """With the guard on, the same subscriber runs on the loop thread instead."""
+    import ophyd
+
+    RE._session.marshal_monitor_emission = True
+
+    sig = ophyd.Signal(name="sig", value=0)
+    seen_thread_ids = []
+    monitoring = threading.Event()
+
+    def collector(*args, **kwargs):
+        seen_thread_ids.append(threading.get_ident())
+
+    RE.subscribe(collector, "event")
+
+    putter_thread_id = {}
+
+    def putter():
+        assert monitoring.wait(timeout=5)
+        putter_thread_id["id"] = threading.get_ident()
+        sig.put(1)
+
+    thread = threading.Thread(target=putter)
+    thread.start()
+
+    def plan():
+        yield Msg("open_run")
+        yield Msg("monitor", sig)
+        monitoring.set()
+        yield Msg("sleep", None, 0.3)
+        yield Msg("unmonitor", sig)
+        yield Msg("close_run")
+
+    RE(plan())
+    thread.join(timeout=5)
+
+    assert seen_thread_ids, "the monitor callback never fired"
+    assert putter_thread_id["id"] != RE._th.ident, "the put() itself should still be off the loop thread"
+    assert seen_thread_ids == [RE._th.ident], "the callback should have been marshalled onto the loop thread"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Stacked on #2050. That PR split `RunEngine` and, in doing so, made visible an
asymmetry it deliberately left unchanged:

- **Status callbacks are marshalled.** The callback `PlanExecutor._add_status_to_group`
  hands to `Status.add_callback` does nothing but `loop.call_soon_threadsafe(settle)`, so
  everything touching executor state runs on the loop thread.
- **Monitor emission is not.** `RunBundler.monitor` hands `emit_event_for_subscribe` to
  `obj.subscribe()`. For a synchronous ophyd v1 signal, that callback fires on the
  **device's own thread**, and it calls straight through to `PlanExecutor.emit`, which
  dispatches to every subscriber right there. So today, a subscriber to a monitored
  signal is invoked on the device's thread, not the loop's.

#2050's body lays out the argument both ways:

- *For marshalling*: a subscriber can currently be re-entered concurrently from the
  device thread and the loop. `LiveTable`, `LivePlot` and the tiled writers are not
  written to be thread-safe, so marshalling would give one total order over the document
  stream instead of two interleaving producers.
- *Against*: the device thread currently absorbs slow callbacks. On the loop, a slow
  monitor callback stalls plan execution instead, and monitor documents queue behind a
  busy plan rather than going out promptly.

This PR turns that paragraph into something that can be judged on numbers.

### The guard

`PlanSession.__init__` gains `marshal_monitor_emission: bool | None = None`. Unset, it
falls back to the `BLUESKY_MARSHAL_MONITOR_EMISSION` environment variable (truthy = on),
so it can be rolled out without a code change:

```python
# explicit, either way
session = PlanSession(marshal_monitor_emission=True)

# or via the environment, with no code change
# BLUESKY_MARSHAL_MONITOR_EMISSION=1
session = PlanSession()
```

**Default is off** -- today's behaviour, byte-for-byte. `RunEngine.__init__` is untouched
(out of scope for this PR -- see fences below), so a `RunEngine` user reaches the guard
either through the environment variable or by setting `RE._session.marshal_monitor_emission`
directly.

When on, `PlanExecutor.emit` checks `threading.get_ident()` against the loop's own thread
id -- the same test `bluesky.suspenders` already uses to decide whether it needs to hop
threads. Off the loop thread, it dispatches via `loop.call_soon_threadsafe`; on the loop
thread, it always calls straight through, guard or no guard -- marshalling an
already-on-loop emission would queue it behind whatever the run loop does next, reordering
it relative to the plan.

### The measurements

`benchmarks/monitor_marshalling.py` is self-contained and runs with no arguments. Measured
on this sandbox: **Python 3.11.15 (CPython) on Linux-6.18.44-fc-v22-x86_64-with-glibc2.39,
ophyd 1.11.2** (a second run reproduced within noise):

| measurement | guard off (today) | guard on |
|---|---|---|
| monitor doc latency (`sig.put()` → subscriber sees it) | 0.335 ms median / 0.460 ms p95 | 0.440 ms median / 0.595 ms p95 |
| plan throughput, monitor firing in background | 56,924 msg/s | 52,790 msg/s |
| **plan throughput, 10 ms slow monitor subscriber** | **72,885 msg/s** | **16 msg/s** |

The first two rows are the cost of the hop itself: marshalling adds roughly a tenth of a
millisecond of latency and costs a few percent of throughput when the subscriber is cheap
-- both cheap enough not to decide anything by themselves.

The third row is the number that decides the "against" argument. With a subscriber slow
enough to matter (10 ms -- not unrealistic for a plotting or file-writing callback under
load) firing at 120 Hz, throughput goes from 72,885 msg/s to **16 msg/s** once the guard is
on: the slow callback now runs inline on the run loop and blocks it, exactly as #2050
predicted. With the guard off, the device thread absorbs that cost and plan throughput is
unaffected. This is not a subtle effect -- it is the entire "against" case, reproduced.

### What broke with it on

The full test suite (`pytest -k "not sigint"`, excluding the pre-existing collection
failures noted below) passes identically with the guard off, matching an unmodified
`plan-executor` baseline exactly (1758 → 1775 passed here, the +17 being this PR's own new
tests; 0 failed either way).

Run again with `BLUESKY_MARSHAL_MONITOR_EMISSION=1` for every test: **2 failures, both this
PR's own tests** (`test_monitor_subscriber_runs_on_the_device_thread_by_default`), which
pin the off-by-default behaviour on a `RunEngine` that never sets the kwarg -- failing
under the env var is the correct, expected outcome for that test, not a regression.
**Nothing else in the suite behaved differently** -- `LiveTable`, the tiled writers, and
every other existing monitor/subscriber test passed the same under marshalling as without
it. That is useful information on its own: it did not surface a latent ordering bug in the
current test coverage, but it also does not mean one couldn't exist under real concurrent
load that this suite doesn't reproduce.

### This is a decision aid, not a merge candidate

@tacaswell -- opened as a draft on top of #2050 so the monitor-marshalling question raised
there can be judged against numbers instead of just the two paragraphs of argument. It
should not be merged as-is: it doesn't touch the `RunEngine` surface (no way to pass
`marshal_monitor_emission` through `RunEngine.__init__`), and whether the default should
ever flip, or whether this belongs on `RunEngine` at all, is exactly the open question.
See #2050's "Two things run off the event loop" section for the original writeup.

## Motivation and Context

Gives a concrete artifact -- code plus measured numbers -- for the monitor-marshalling
decision #2050 deferred, rather than leaving it as an unresolved paragraph in that PR's
description.

## How Has This Been Tested?

- `tox -e pre-commit`, `tox -e type-checking`: both clean.
- `tox -e tests` (`pytest -k "not sigint"`, `test_streams.py` ignored -- pre-existing
  `streamz`/`dask` import failure on the base branch too): 1775 passed, 22 skipped, 2
  xfailed, 0 failed. `test_devices.py` and `test_suspenders.py` were also ignored in this
  sandbox: PyPI's current `ophyd-async` (0.2.0) is missing `soft_signal_rw`, which both
  files import at collection time -- reproduced identically on an unmodified
  `plan-executor` baseline in a separate worktree/venv, so it is not this PR's problem.
- sigint tests run separately (`-k sigint`): all passed, matching the baseline.
- Full suite run again with `BLUESKY_MARSHAL_MONITOR_EMISSION=1`: see "What broke with it
  on" above.
- `benchmarks/monitor_marshalling.py` run twice for reproducibility; numbers above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)