### PR TITLE
TST: attempt to fix flaky test

### DIFF
--- a/src/bluesky/tests/test_run_engine.py
+++ b/src/bluesky/tests/test_run_engine.py
@@ -1020,18 +1020,16 @@ def test_single_sigint_no_carry_over(RE):
         os.kill(pid, signal.SIGINT)
 
     def test_plan():
-        first = False
         for _ in range(5):
             yield Msg("null")
-            if first:
-                deferred_pause_done.wait()
-                first = False
 
     # Single SIGINT defers a pause but plan finishes anyway
     sigint_thread = threading.Thread(target=send_sigint, daemon=True)
     sigint_thread.start()
     RE(test_plan())
     sigint_thread.join(timeout=0.1)
+
+    assert deferred_pause_done.wait(timeout=5)
 
     def checkpoint_plan():
         for _ in range(10):

--- a/src/bluesky/tests/test_run_engine.py
+++ b/src/bluesky/tests/test_run_engine.py
@@ -8,6 +8,7 @@ import types
 from collections import defaultdict
 from functools import partial
 from traceback import FrameSummary, extract_tb
+from typing import cast
 
 import pytest
 from event_model import DocumentNames
@@ -996,7 +997,7 @@ def test_single_sigint_no_carry_over(RE):
     pid = os.getpid()
 
     wait_for_reached = threading.Event()
-    deferred_pause_done = _fabricate_asycio_event(RE.loop)
+    deferred_pause_done = cast(asyncio.Event, _fabricate_asycio_event(RE.loop))
 
     def msg_hook(msg):
         if msg.command == "wait_for":

--- a/src/bluesky/tests/test_run_engine.py
+++ b/src/bluesky/tests/test_run_engine.py
@@ -995,12 +995,12 @@ def test_single_sigint_no_carry_over(RE):
     """A single SIGINT does not pause at the next plan's checkpoint"""
     pid = os.getpid()
 
-    running_event = threading.Event()
-    deferred_pause_done = threading.Event()
+    wait_for_reached = threading.Event()
+    deferred_pause_done = _fabricate_asycio_event(RE.loop)
 
     def msg_hook(msg):
-        if msg.command == "null":
-            running_event.set()
+        if msg.command == "wait_for":
+            wait_for_reached.set()
 
     RE.msg_hook = msg_hook
 
@@ -1009,27 +1009,26 @@ def test_single_sigint_no_carry_over(RE):
     def _tracked_request_pause(defer=False):
         result = _orig_request_pause(defer=defer)
         if defer:
-            deferred_pause_done.set()
+            RE.loop.call_soon_threadsafe(deferred_pause_done.set)
         return result
 
     RE.request_pause = _tracked_request_pause
 
     def send_sigint():
-        # Wait for event
-        running_event.wait()
-        os.kill(pid, signal.SIGINT)
+        if wait_for_reached.wait(timeout=5):
+            os.kill(pid, signal.SIGINT)
 
     def test_plan():
-        for _ in range(5):
-            yield Msg("null")
+        yield from wait_for([deferred_pause_done.wait], timeout=5)
 
     # Single SIGINT defers a pause but plan finishes anyway
     sigint_thread = threading.Thread(target=send_sigint, daemon=True)
     sigint_thread.start()
     RE(test_plan())
-    sigint_thread.join(timeout=0.1)
+    sigint_thread.join(timeout=5)
+    assert not sigint_thread.is_alive()
 
-    assert deferred_pause_done.wait(timeout=5)
+    assert deferred_pause_done.is_set()
 
     def checkpoint_plan():
         for _ in range(10):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This is an attempt to fix a flaky test that randomly timeouts in the linux CI.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`test_single_sigint_no_carry_over` was introduced in #1997 

The docstring says:

```python
"""A single SIGINT does not pause at the next plan's checkpoint"""
```

Basically the first SIGINT causing the pause of the first test plan is deferred to a background thread. `_tracked_request_pause` monkey patches `RE.request_pause` to set deferred_pause_done event. Since the first SIGINT is a deferred pause, it sets that event.

This patch removes the `first=False` guard (which was also faulty, since it was always false) and waits for the event to be set after *outside* the plan after the first deferred pause.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This happens only in Linux and randomly on CI. I did not have the chance to test it locally, I'm waiting for the CI to do it's thing.

<!--
## Screenshots (if appropriate):
-->
