### PR TITLE
ENH: support per-device stage and unstage groups

### DIFF
--- a/src/bluesky/preprocessors.py
+++ b/src/bluesky/preprocessors.py
@@ -2,7 +2,7 @@ import uuid
 from collections import ChainMap, OrderedDict, deque
 from collections.abc import Hashable, Iterable
 from functools import wraps
-from typing import TypeAlias, TypeVar
+from typing import Any, TypeAlias, TypeVar
 
 from bluesky.protocols import Locatable, Stageable
 
@@ -26,7 +26,6 @@ from .utils import (
     merge_axis,
     normalize_subs_input,
     root_ancestor,
-    separate_devices,
     single_gen,
 )
 from .utils import short_uid as _short_uid
@@ -988,6 +987,28 @@ def lazily_stage_wrapper(plan):
     return (yield from finalize_wrapper(plan_mutator(plan, inner), inner_unstage_all()))
 
 
+def _normalize_stage_devices(devices: StageDevices) -> tuple[bool, list[Any]]:
+    seen_roots: list[Stageable] = []
+    normalized: list[Any] = []
+    is_grouped = False
+
+    for item in devices:
+        if isinstance(item, tuple):
+            is_grouped = True
+            dev, stage_group, unstage_group = item
+            root = root_ancestor(dev)
+            if root not in seen_roots:
+                seen_roots.append(root)
+                normalized.append((root, stage_group, unstage_group))
+        else:
+            root = root_ancestor(item)
+            if root not in seen_roots:
+                seen_roots.append(root)
+                normalized.append(root)
+
+    return is_grouped, normalized
+
+
 def stage_wrapper(
     plan: MsgGenerator[P],
     devices: StageDevices,
@@ -1013,13 +1034,13 @@ def stage_wrapper(
     :func:`bluesky.plans.stage`
     :func:`bluesky.plans.unstage`
     """
-    devices = separate_devices(root_ancestor(device) for device in devices)
+    is_grouped, normalized_devices = _normalize_stage_devices(devices)
 
     def stage_devices():
-        yield from stage_all(*devices)
+        yield from stage_all(*normalized_devices)
 
     def unstage_devices():
-        yield from unstage_all(*reversed(devices))
+        yield from unstage_all(*reversed(normalized_devices))
 
     def inner():
         yield from stage_devices()

--- a/src/bluesky/preprocessors.py
+++ b/src/bluesky/preprocessors.py
@@ -1,9 +1,10 @@
 import uuid
 from collections import ChainMap, OrderedDict, deque
-from collections.abc import Iterable
+from collections.abc import Hashable, Iterable
 from functools import wraps
+from typing import TypeAlias, TypeVar
 
-from bluesky.protocols import Locatable
+from bluesky.protocols import Locatable, Stageable
 
 from .plan_stubs import (
     close_run,
@@ -17,6 +18,7 @@ from .plan_stubs import (
 )
 from .utils import (
     Msg,
+    MsgGenerator,
     RunEngineControlException,
     ensure_generator,
     get_hinted_fields,
@@ -28,6 +30,15 @@ from .utils import (
     single_gen,
 )
 from .utils import short_uid as _short_uid
+
+P = TypeVar("P")
+
+StageGroup: TypeAlias = Hashable | None
+StageDeviceTuple: TypeAlias = tuple[Stageable, StageGroup, StageGroup]
+StageDevices: TypeAlias = (
+    Iterable[Stageable]
+    | Iterable[StageDeviceTuple]
+)
 
 
 def plan_mutator(plan, msg_proc):
@@ -977,7 +988,10 @@ def lazily_stage_wrapper(plan):
     return (yield from finalize_wrapper(plan_mutator(plan, inner), inner_unstage_all()))
 
 
-def stage_wrapper(plan, devices):
+def stage_wrapper(
+    plan: MsgGenerator[P],
+    devices: StageDevices,
+) -> MsgGenerator[P]:
     """
     'Stage' devices (i.e., prepare them for use, 'arm' them) and then unstage.
 

--- a/src/bluesky/preprocessors.py
+++ b/src/bluesky/preprocessors.py
@@ -1015,12 +1015,32 @@ def stage_wrapper(
     """
     'Stage' devices (i.e., prepare them for use, 'arm' them) and then unstage.
 
+    Devices are staged in input order and unstaged in reverse order.
+
+    The ``devices`` argument supports two forms:
+
+    - A collection of devices (legacy form). Devices are staged via
+      :func:`~bluesky.plan_stubs.stage_all` on entrance and unstaged via
+      :func:`~bluesky.plan_stubs.unstage_all` on exit. This generates unique
+      group identifiers and inserts automatic ``wait`` barriers for devices
+      returning asynchronous :class:`~bluesky.protocols.Status` objects.
+    - A collection of three-tuples: ``(device, stage_group, unstage_group)``,
+      where each group is a ``Hashable | None``. Supplying tuples opts into
+      caller-managed synchronization: single-device
+      :func:`~bluesky.plan_stubs.stage` and
+      :func:`~bluesky.plan_stubs.unstage` messages are emitted with the
+      configured groups, and no automatic ``wait`` messages are inserted.
+      The plan (or an enclosing plan, for unstaging) decides where to issue
+      the matching ``wait`` messages.
+
     Parameters
     ----------
     plan : iterable or iterator
         a generator, list, or similar containing `Msg` objects
     devices : collection
-        list of devices to stage immediately on entrance and unstage on exit
+        A collection of devices to stage immediately on entrance and unstage
+        on exit, or a collection of ``(device, stage_group, unstage_group)``
+        tuples where each group is a ``Hashable`` or ``None``.
 
     Yields
     ------
@@ -1032,6 +1052,28 @@ def stage_wrapper(
     :func:`bluesky.plans.lazily_stage_wrapper`
     :func:`bluesky.plans.stage`
     :func:`bluesky.plans.unstage`
+
+    Examples
+    --------
+    Using the tuple form to manage synchronization explicitly:
+
+    >>> import bluesky.plan_stubs as bps
+    >>> from bluesky.preprocessors import stage_wrapper
+
+    >>> def my_plan():
+    ...     # Device staging runs before this plan body starts.
+    ...     # Wait for the stage group when the device is first needed:
+    ...     yield from bps.wait(group="stage_det")
+    ...     yield from bps.trigger_and_read([det])
+
+    >>> def enclosing_plan():
+    ...     yield from stage_wrapper(
+    ...         my_plan(),
+    ...         [(det, "stage_det", "unstage_det")],
+    ...     )
+    ...     # Unstaging occurs during cleanup on exit from stage_wrapper.
+    ...     # The enclosing plan can wait for unstaging completion:
+    ...     yield from bps.wait(group="unstage_det")
     """
     is_grouped, normalized_devices = _normalize_stage_devices(devices)
 

--- a/src/bluesky/preprocessors.py
+++ b/src/bluesky/preprocessors.py
@@ -12,8 +12,10 @@ from .plan_stubs import (
     mv,
     open_run,
     pause,
+    stage,
     stage_all,
     trigger_and_read,
+    unstage,
     unstage_all,
 )
 from .utils import (
@@ -34,10 +36,7 @@ P = TypeVar("P")
 
 StageGroup: TypeAlias = Hashable | None
 StageDeviceTuple: TypeAlias = tuple[Stageable, StageGroup, StageGroup]
-StageDevices: TypeAlias = (
-    Iterable[Stageable]
-    | Iterable[StageDeviceTuple]
-)
+StageDevices: TypeAlias = Iterable[Stageable] | Iterable[StageDeviceTuple]
 
 
 def plan_mutator(plan, msg_proc):
@@ -1036,11 +1035,23 @@ def stage_wrapper(
     """
     is_grouped, normalized_devices = _normalize_stage_devices(devices)
 
-    def stage_devices():
-        yield from stage_all(*normalized_devices)
+    if is_grouped:
 
-    def unstage_devices():
-        yield from unstage_all(*reversed(normalized_devices))
+        def stage_devices():
+            for dev, stage_group, _ in normalized_devices:
+                yield from stage(dev, group=stage_group)
+
+        def unstage_devices():
+            for dev, _, unstage_group in reversed(normalized_devices):
+                yield from unstage(dev, group=unstage_group)
+
+    else:
+
+        def stage_devices():
+            yield from stage_all(*normalized_devices)
+
+        def unstage_devices():
+            yield from unstage_all(*reversed(normalized_devices))
 
     def inner():
         yield from stage_devices()

--- a/src/bluesky/tests/test_preprocessors.py
+++ b/src/bluesky/tests/test_preprocessors.py
@@ -11,23 +11,11 @@ from bluesky.preprocessors import (
     stage_decorator,
     stage_wrapper,
 )
-from bluesky.protocols import HasHints, HasParent, Movable, Stageable
+from bluesky.protocols import HasHints, HasParent, Movable, Stageable, Status
 from bluesky.run_engine import RequestStop, RunEngine
 
 
-class _StageableDevice:
-    def __init__(self, name, parent=None):
-        self.name = name
-        self.parent = parent
-
-    def stage(self):
-        return []
-
-    def unstage(self):
-        return []
-
-
-class _SuccessfulStatus:
+class _SuccessfulStatus(Status):
     def add_callback(self, callback):
         callback(self)
 
@@ -41,6 +29,18 @@ class _SuccessfulStatus:
     @property
     def success(self):
         return True
+
+
+class _StageableDevice(Stageable):
+    def __init__(self, name, parent=None):
+        self.name = name
+        self.parent = parent
+
+    def stage(self) -> Status:
+        return _SuccessfulStatus()
+
+    def unstage(self) -> Status:
+        return _SuccessfulStatus()
 
 
 def _collect_messages(plan, *, asynchronous_stage=False):

--- a/src/bluesky/tests/test_preprocessors.py
+++ b/src/bluesky/tests/test_preprocessors.py
@@ -8,9 +8,54 @@ from bluesky.preprocessors import (
     contingency_wrapper,
     lazily_stage_decorator,
     msg_mutator,
+    stage_decorator,
+    stage_wrapper,
 )
 from bluesky.protocols import HasHints, HasParent, Movable, Stageable
 from bluesky.run_engine import RequestStop, RunEngine
+
+
+class _StageableDevice:
+    def __init__(self, name, parent=None):
+        self.name = name
+        self.parent = parent
+
+    def stage(self):
+        return []
+
+    def unstage(self):
+        return []
+
+
+class _SuccessfulStatus:
+    def add_callback(self, callback):
+        callback(self)
+
+    def exception(self, timeout=0.0):
+        return None
+
+    @property
+    def done(self):
+        return True
+
+    @property
+    def success(self):
+        return True
+
+
+def _collect_messages(plan, *, asynchronous_stage=False):
+    messages = []
+    response = None
+    while True:
+        try:
+            msg = plan.send(response)
+        except StopIteration:
+            return messages
+        messages.append(msg)
+        if asynchronous_stage and msg.command in {"stage", "unstage"}:
+            response = _SuccessfulStatus()
+        else:
+            response = None
 
 
 def test_given_a_plan_that_raises_contigency_will_call_except_plan_with_exception_and_run_engine_errors():
@@ -160,3 +205,133 @@ def test_lazily_stage_decorator_with_nested_devices():
 
     commands = [m.command for m in plan()]
     assert commands == ["stage", "set", "wait", "set", "wait", "set", "wait", "unstage"]
+
+
+def test_stage_wrapper_legacy_devices_waits_for_async_stage_and_unstage():
+    device1 = _StageableDevice("device1")
+    device2 = _StageableDevice("device2")
+
+    messages = _collect_messages(
+        stage_wrapper(bps.null(), [device1, device2]),
+        asynchronous_stage=True,
+    )
+
+    assert [msg.command for msg in messages] == [
+        "stage",
+        "stage",
+        "wait",
+        "null",
+        "unstage",
+        "unstage",
+        "wait",
+    ]
+    assert [msg.obj for msg in messages if msg.command == "stage"] == [device1, device2]
+    assert [msg.obj for msg in messages if msg.command == "unstage"] == [device2, device1]
+
+    stage_messages = messages[:3]
+    unstage_messages = messages[-3:]
+    assert stage_messages[0].kwargs["group"] is not None
+    assert stage_messages[0].kwargs["group"] == stage_messages[1].kwargs["group"]
+    assert stage_messages[1].kwargs["group"] == stage_messages[2].kwargs["group"]
+    assert unstage_messages[0].kwargs["group"] is not None
+    assert unstage_messages[0].kwargs["group"] == unstage_messages[1].kwargs["group"]
+    assert unstage_messages[1].kwargs["group"] == unstage_messages[2].kwargs["group"]
+    assert stage_messages[0].kwargs["group"] != unstage_messages[0].kwargs["group"]
+
+
+def test_grouped_stage_wrapper_preserves_groups_and_explicit_wait_positions():
+    device1 = _StageableDevice("device1")
+    device2 = _StageableDevice("device2")
+    stage_group = ("stage", 1)
+    unstage_group = frozenset({"unstage"})
+
+    def body():
+        yield from bps.wait(group=stage_group)
+        yield from bps.null()
+
+    def enclosing_plan():
+        yield from stage_wrapper(
+            body(),
+            [
+                (device1, stage_group, None),
+                (device2, None, unstage_group),
+            ],
+        )
+        yield from bps.wait(group=unstage_group)
+
+    messages = _collect_messages(enclosing_plan(), asynchronous_stage=True)
+
+    assert [(msg.command, msg.obj, msg.kwargs.get("group")) for msg in messages] == [
+        ("stage", device1, stage_group),
+        ("stage", device2, None),
+        ("wait", None, stage_group),
+        ("null", None, None),
+        ("unstage", device2, unstage_group),
+        ("unstage", device1, None),
+        ("wait", None, unstage_group),
+    ]
+
+
+def test_grouped_stage_decorator():
+    device = _StageableDevice("device")
+
+    @stage_decorator([(device, "stage-group", "unstage-group")])
+    def plan():
+        yield from bps.null()
+
+    messages = _collect_messages(plan())
+
+    assert [(msg.command, msg.kwargs.get("group")) for msg in messages] == [
+        ("stage", "stage-group"),
+        ("null", None),
+        ("unstage", "unstage-group"),
+    ]
+
+
+def test_grouped_stage_wrapper_unstages_when_plan_raises():
+    device = _StageableDevice("device")
+    expected_exception = RuntimeError("failure in wrapped plan")
+
+    def plan():
+        yield from bps.null()
+        raise expected_exception
+
+    messages = []
+    wrapped_plan = stage_wrapper(plan(), [(device, "stage-group", "unstage-group")])
+    with pytest.raises(RuntimeError) as exc_info:
+        while True:
+            messages.append(next(wrapped_plan))
+
+    assert exc_info.value is expected_exception
+    assert [(msg.command, msg.kwargs.get("group")) for msg in messages] == [
+        ("stage", "stage-group"),
+        ("null", None),
+        ("unstage", "unstage-group"),
+    ]
+
+
+def test_grouped_stage_wrapper_normalizes_to_unique_roots_with_first_groups():
+    root = _StageableDevice("root")
+    child = _StageableDevice("child", parent=root)
+
+    messages = _collect_messages(
+        stage_wrapper(
+            bps.null(),
+            [
+                (child, "first-stage", "first-unstage"),
+                (root, "ignored-stage", "ignored-unstage"),
+            ],
+        )
+    )
+
+    stage_message, _, unstage_message = messages
+    assert (stage_message.command, stage_message.obj, stage_message.kwargs["group"]) == (
+        "stage",
+        root,
+        "first-stage",
+    )
+    assert (unstage_message.command, unstage_message.obj, unstage_message.kwargs["group"]) == (
+        "unstage",
+        root,
+        "first-unstage",
+    )

--- a/src/bluesky/tests/test_preprocessors.py
+++ b/src/bluesky/tests/test_preprocessors.py
@@ -14,21 +14,7 @@ from bluesky.preprocessors import (
 from bluesky.protocols import HasHints, HasParent, Movable, Stageable, Status
 from bluesky.run_engine import RequestStop, RunEngine
 
-
-class _SuccessfulStatus(Status):
-    def add_callback(self, callback):
-        callback(self)
-
-    def exception(self, timeout=0.0):
-        return None
-
-    @property
-    def done(self):
-        return True
-
-    @property
-    def success(self):
-        return True
+from .conftest import AlwaysSuccessfulStatus
 
 
 class _StageableDevice(Stageable):
@@ -37,10 +23,10 @@ class _StageableDevice(Stageable):
         self.parent = parent
 
     def stage(self) -> Status:
-        return _SuccessfulStatus()
+        return AlwaysSuccessfulStatus()
 
     def unstage(self) -> Status:
-        return _SuccessfulStatus()
+        return AlwaysSuccessfulStatus()
 
 
 def _collect_messages(plan, *, asynchronous_stage=False):
@@ -53,7 +39,7 @@ def _collect_messages(plan, *, asynchronous_stage=False):
             return messages
         messages.append(msg)
         if asynchronous_stage and msg.command in {"stage", "unstage"}:
-            response = _SuccessfulStatus()
+            response = AlwaysSuccessfulStatus()
         else:
             response = None
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add per-device staging and unstaging groups to `stage_weapper` and `stage_decorator`.

Wrappers now accept collection of three-tuples:
```python3
(device, stage_group, unstage_group)
```
Each group can be any hashable vale or `None`. Devices are staged in input order and unstaged in reverse order. Callers manage the waits explicitly and plain-device API keeps auto. groups and waits. 

Root normalization and first-entry handling are unchanges. Both forms are documented in `stage_wrapper` docstring.

## Motivation and Context
Plans may need to begin work while some devices are still staging, waiting for each device only when it is first needed. Similarly, an enclosing plan may need to control when asynchronous unstaging completes.

closes: https://github.com/bluesky/bluesky/issues/1979

## How Has This Been Tested?
Added focused tests covering:
- existing plain-device behavior with async stage and unstage status
- automatically generated groups and wait messages
- exact propagation of string, non-string, and `None` groups
- input-order strings and reverse order unstaging
- caller positioned waits
- both `stage_wrapper` and `stage_decorator`
- unstaging cleanup when wrapped plan raises
- root-ancenstor normalization, duplicate removal, retention of first entry's groups

<!--
## Screenshots (if appropriate):
-->
