### PR TITLE
Fix list_scan type annotations

### DIFF
--- a/src/bluesky/plans.py
+++ b/src/bluesky/plans.py
@@ -131,7 +131,7 @@ def count(
 
 def list_scan(
     detectors: Sequence[Readable],
-    *args: tuple[Movable | Any, list[Any]],
+    *args: Movable[Any] | Sequence[Any],
     per_step: PerStep | None = None,
     md: CustomPlanMetadata | None = None,
 ) -> MsgGenerator[str]:


### PR DESCRIPTION
Typing for list scan is wrong. The current typing expects 

```python
def list_scan(
    detectors: Sequence[Readable],
    *args: tuple[Movable | Any, list[Any]],
    per_step: PerStep | None = None,
    md: CustomPlanMetadata | None = None,
) -> MsgGenerator[str]:
```
Meaning the arguments are 

```python
list_scan(dets, (movable1, [p1, p2 ...]), (movable2, [p1, p2 ...]), ...)
```

If I actually try to run this, I get the following error
```python
def test_list_scan(
    run_engine: RunEngine,
    x_axis: SimMotor,
):
    from bluesky import plans as bp

    run_engine(bp.list_scan([], (x_axis, [1, 2, 3])))
```

```
=================================== FAILURES ===================================
____________ test_list_scan _____________
Traceback (most recent call last):
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/_pytest/runner.py", line 353, in from_call
    result: TResult | None = func()
                             ^^^^^^
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/_pytest/runner.py", line 245, in <lambda>
    lambda: runtest_hook(item=item, **kwds),
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 167, in _multicall
    raise exception
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/_pytest/logging.py", line 850, in pytest_runtest_call
    yield
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 53, in run_old_style_hookwrapper
    return result.get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_result.py", line 103, in get_result
    raise exc.with_traceback(tb)
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 38, in run_old_style_hookwrapper
    res = yield
          ^^^^^
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/_pytest/capture.py", line 900, in pytest_runtest_call
    return (yield)
            ^^^^^
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 53, in run_old_style_hookwrapper
    return result.get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_result.py", line 103, in get_result
    raise exc.with_traceback(tb)
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 38, in run_old_style_hookwrapper
    res = yield
          ^^^^^
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/_pytest/skipping.py", line 268, in pytest_runtest_call
    return (yield)
            ^^^^^
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/_pytest/runner.py", line 179, in pytest_runtest_call
    item.runtest()
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/_pytest/python.py", line 1720, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 167, in _multicall
    raise exception
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 53, in run_old_style_hookwrapper
    return result.get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_result.py", line 103, in get_result
    raise exc.with_traceback(tb)
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 38, in run_old_style_hookwrapper
    res = yield
          ^^^^^
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/_pytest/python.py", line 166, in pytest_pyfunc_call
    result = testfunction(**testargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/dodal/tests/plans/scans/test_wrapped.py", line 716, in test_list_scan
    run_engine(bp.list_scan([], (x_axis, [1, 2, 3])))
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/bluesky/run_engine.py", line 982, in __call__
    plan_return = self._resume_task(init_func=_build_task)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/bluesky/run_engine.py", line 1127, in _resume_task
    raise exc
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/bluesky/run_engine.py", line 1762, in _run
    raise err
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/bluesky/run_engine.py", line 1616, in _run
    msg = self._plan_stack[-1].send(resp)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cache/venv-for/scratch/bluesky_development/dodal/lib/python3.11/site-packages/bluesky/plans.py", line 184, in list_scan
    raise ValueError(
ValueError: The list of arguments must contain a list of points for each defined motor
```

If I run

```python
def test_list_scan(
    run_engine: RunEngine,
    x_axis: SimMotor,
):
    from bluesky import plans as bp

    run_engine(bp.list_scan([], x_axis, [1, 2, 3]))  # type: ignore
```

The scan runs successfully! This is because the typing for the *args is wrong.

This change updates the typing to reflect the real expected typing of arguments.

